### PR TITLE
feat: Expose all Rust GameState constructors to Python (Issue #31)

### DIFF
--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -9,6 +9,7 @@ The PyRat Engine is the core game implementation, providing:
 - Python bindings via PyO3
 - PettingZoo-compatible environment interface
 - Support for reinforcement learning research
+- Multiple game creation methods with presets and custom configurations
 
 ## Quick Development Guide
 
@@ -82,3 +83,83 @@ The engine is tested on Python 3.8-3.11 with:
 - `flame`: Enables profiling with flame graphs
 
 Rust tests run without Python features to avoid linking issues.
+
+## Game Creation API
+
+The engine provides multiple ways to create games, supporting various use cases from quick testing to precise control:
+
+### 1. Basic Constructor
+```python
+from pyrat_engine import PyRat
+
+# Default game (21x15, 41 cheese, symmetric)
+game = PyRat()
+
+# Custom parameters
+game = PyRat(width=31, height=21, cheese_count=85, max_turns=500)
+```
+
+### 2. Preset Configurations
+```python
+from pyrat_engine._rust import PyGameState
+
+# Available presets:
+# - "tiny": 11x9 board, 13 cheese, 150 turns
+# - "small": 15x11 board, 21 cheese, 200 turns
+# - "default": 21x15 board, 41 cheese, 300 turns
+# - "large": 31x21 board, 85 cheese, 400 turns
+# - "huge": 41x31 board, 165 cheese, 500 turns
+# - "empty": 21x15, no walls/mud, for testing
+# - "asymmetric": Standard size but asymmetric generation
+
+game_state = PyGameState.create_preset("large", seed=42)
+```
+
+### 3. Custom Maze Layout
+```python
+# Define specific walls, generate random cheese
+walls = [
+    ((0, 0), (0, 1)),  # Wall between (0,0) and (0,1)
+    ((1, 1), (2, 1)),  # Wall between (1,1) and (2,1)
+]
+
+game_state = PyGameState.create_from_maze(
+    width=15,
+    height=11,
+    walls=walls,
+    seed=42,        # For reproducible cheese placement
+    max_turns=200
+)
+```
+
+### 4. Custom Starting Positions
+```python
+# Use preset configuration but with custom player positions
+game_state = PyGameState.create_with_starts(
+    width=21,
+    height=15,
+    player1_start=(5, 5),
+    player2_start=(15, 9),
+    preset="default",
+    seed=42
+)
+```
+
+### 5. Full Custom Configuration
+```python
+# Complete control over all game elements
+walls = [((0, 0), (0, 1)), ((1, 1), (2, 1))]
+mud = [((2, 2), (3, 2), 3)]  # 3 turns to traverse
+cheese = [(5, 5), (10, 10), (15, 7)]
+
+game_state = PyGameState.create_custom(
+    width=21,
+    height=15,
+    walls=walls,
+    mud=mud,
+    cheese=cheese,
+    player1_pos=(0, 0),
+    player2_pos=(20, 14),
+    max_turns=300
+)
+```

--- a/engine/python/pyrat_engine/_rust.pyi
+++ b/engine/python/pyrat_engine/_rust.pyi
@@ -86,6 +86,7 @@ class PyGameState:
         cheese_count: Number of cheese pieces (default: 41)
         symmetric: Whether to generate symmetric mazes (default: True)
         seed: Random seed for reproducible games (default: None)
+        max_turns: Maximum number of turns before game ends (default: 300)
     """
     def __init__(
         self,
@@ -94,7 +95,34 @@ class PyGameState:
         cheese_count: int | None = None,
         symmetric: bool = True,
         seed: int | None = None,
+        max_turns: int | None = None,
     ) -> None: ...
+    @staticmethod
+    def create_preset(
+        preset: str = "default",
+        *,
+        seed: int | None = None,
+    ) -> PyGameState:
+        """Create a game from a preset configuration.
+
+        Available presets:
+        - "tiny": 11x9 board, 13 cheese, 150 turns
+        - "small": 15x11 board, 21 cheese, 200 turns
+        - "default": 21x15 board, 41 cheese, 300 turns (standard)
+        - "large": 31x21 board, 85 cheese, 400 turns
+        - "huge": 41x31 board, 165 cheese, 500 turns
+        - "empty": No walls or mud, good for testing
+        - "asymmetric": Standard size but asymmetric generation
+
+        Args:
+            preset: Name of the preset configuration
+            seed: Random seed for reproducible games
+
+        Returns:
+            A new PyGameState instance with the preset configuration
+        """
+        ...
+
     @staticmethod
     def create_custom(
         width: int,
@@ -120,6 +148,62 @@ class PyGameState:
 
         Returns:
             A new PyGameState instance with the specified configuration
+        """
+        ...
+
+    @staticmethod
+    def create_from_maze(
+        width: int,
+        height: int,
+        walls: list[tuple[tuple[int, int], tuple[int, int]]],
+        *,
+        seed: int | None = None,
+        max_turns: int = 300,
+    ) -> PyGameState:
+        """Create a game with a specific maze layout and random cheese placement.
+
+        This method is useful for creating games with predefined maze structures
+        while still having random cheese placement. Perfect for testing specific maze
+        configurations.
+
+        Args:
+            width: Width of the game board
+            height: Height of the game board
+            walls: List of wall pairs, each defined by two (x,y) positions
+            seed: Random seed for reproducible cheese placement
+            max_turns: Maximum number of turns before game ends
+
+        Returns:
+            A new PyGameState instance with the specified maze and random cheese
+        """
+        ...
+
+    @staticmethod
+    def create_with_starts(
+        width: int,
+        height: int,
+        player1_start: tuple[int, int],
+        player2_start: tuple[int, int],
+        *,
+        preset: str = "default",
+        seed: int | None = None,
+    ) -> PyGameState:
+        """Create a game with custom starting positions.
+
+        This method generates a random maze using the specified preset configuration
+        but places players at custom starting positions. Useful for AI testing
+        with specific positional scenarios.
+
+        Args:
+            width: Width of the game board
+            height: Height of the game board
+            player1_start: Starting (x,y) position for player 1
+            player2_start: Starting (x,y) position for player 2
+            preset: Preset configuration to use for maze generation
+            seed: Random seed for reproducible maze generation
+
+        Returns:
+            A new PyGameState instance with custom starting positions
         """
         ...
 

--- a/engine/python/pyrat_engine/game.py
+++ b/engine/python/pyrat_engine/game.py
@@ -148,6 +148,7 @@ class PyRat:
         cheese_count: Number of cheese pieces to place (default: 41)
         symmetric: If True, generate symmetric mazes (default: True)
         seed: Random seed for reproducible games (default: None)
+        max_turns: Maximum number of turns before game ends (default: 300)
 
     Example:
         >>> game = PyRat(width=15, height=15)
@@ -166,9 +167,12 @@ class PyRat:
         cheese_count: Optional[int] = None,
         symmetric: bool = True,
         seed: Optional[int] = None,
+        max_turns: Optional[int] = None,
     ):
         """Initialize a new PyRat game."""
-        self._game = _RustGameState(width, height, cheese_count, symmetric, seed)
+        self._game = _RustGameState(
+            width, height, cheese_count, symmetric, seed, max_turns
+        )
 
     @property
     def dimensions(self) -> Tuple[int, int]:

--- a/engine/python/tests/test_game.py
+++ b/engine/python/tests/test_game.py
@@ -1,14 +1,213 @@
+"""Tests for PyGameState from the Rust bindings.
+
+This tests the low-level game state implementation including:
+- Basic game creation
+- Constructor parameters
+- Preset configurations
+- Custom game creation methods
+"""
+# ruff: noqa: PLR2004
+
+import pytest
 from pyrat_engine._rust import PyGameState
-
-TEST_GAME_WIDTH = 5
-TEST_GAME_HEIGHT = 5
-TEST_CHEESE_COUNT = 3
+from pyrat_engine.game import PyRat
 
 
-def test_game_creation() -> None:
-    game = PyGameState(
-        width=TEST_GAME_WIDTH, height=TEST_GAME_HEIGHT, cheese_count=TEST_CHEESE_COUNT
-    )
-    assert game.width == TEST_GAME_WIDTH
-    assert game.height == TEST_GAME_HEIGHT
-    assert len(game.cheese_positions()) == TEST_CHEESE_COUNT
+class TestBasicGameCreation:
+    """Test basic game creation."""
+
+    def test_game_creation(self) -> None:
+        """Test basic game creation with minimal parameters."""
+        game = PyGameState(width=5, height=5, cheese_count=3)
+        assert game.width == 5
+        assert game.height == 5
+        assert len(game.cheese_positions()) == 3
+
+    def test_default_values(self) -> None:
+        """Test game creation with default values."""
+        game = PyGameState()
+        assert game.width == 21
+        assert game.height == 15
+        assert game.max_turns == 300
+        # Default cheese count is 41
+        assert len(game.cheese_positions()) == 41
+
+
+class TestEnhancedConstructor:
+    """Test the enhanced main constructor with new parameters."""
+
+    def test_max_turns_parameter(self):
+        """Test that max_turns can be set in main constructor."""
+        game = PyGameState(max_turns=500)
+        assert game.max_turns == 500
+
+    def test_default_max_turns(self):
+        """Test that default max_turns is still 300."""
+        game = PyGameState()
+        assert game.max_turns == 300
+
+    def test_all_parameters(self):
+        """Test all parameters work together."""
+        game = PyGameState(
+            width=15, height=11, cheese_count=21, symmetric=True, seed=42, max_turns=200
+        )
+        assert game.width == 15
+        assert game.height == 11
+        assert game.max_turns == 200
+        assert len(game.cheese_positions()) == 21
+
+
+class TestPresets:
+    """Test the preset system."""
+
+    def test_all_presets_exist(self):
+        """Test that all presets can be created."""
+        presets = ["tiny", "small", "default", "large", "huge", "empty", "asymmetric"]
+
+        for preset in presets:
+            game = PyGameState.create_preset(preset)
+            assert game is not None
+
+    def test_preset_dimensions(self):
+        """Test that presets have correct dimensions."""
+        expected = {
+            "tiny": (11, 9, 13, 150),
+            "small": (15, 11, 21, 200),
+            "default": (21, 15, 41, 300),
+            "large": (31, 21, 85, 400),
+            "huge": (41, 31, 165, 500),
+            "empty": (21, 15, 41, 300),
+            "asymmetric": (21, 15, 41, 300),
+        }
+
+        for preset, (width, height, cheese, turns) in expected.items():
+            game = PyGameState.create_preset(preset)
+            assert game.width == width
+            assert game.height == height
+            assert game.max_turns == turns
+            # Cheese count might vary slightly due to generation
+            assert abs(len(game.cheese_positions()) - cheese) <= 2
+
+    def test_preset_with_seed(self):
+        """Test that presets with same seed are reproducible."""
+        game1 = PyGameState.create_preset("default", seed=42)
+        game2 = PyGameState.create_preset("default", seed=42)
+
+        # Check that cheese positions are the same
+        cheese1 = set(game1.cheese_positions())
+        cheese2 = set(game2.cheese_positions())
+        assert cheese1 == cheese2
+
+    def test_empty_preset_has_no_walls(self):
+        """Test that empty preset has no walls or mud."""
+        game = PyGameState.create_preset("empty")
+
+        # Check walls by seeing if all moves are valid
+        # In a maze with no walls, you can move in all 4 directions
+        # from any non-edge position
+        obs = game.get_observation(True)  # True for player 1
+        movement_matrix = obs.movement_matrix
+
+        # Check a center position (should have all 4 moves valid)
+        center_x, center_y = game.width // 2, game.height // 2
+        # Movement matrix: [x, y, direction]
+        # Directions: 0=UP, 1=RIGHT, 2=DOWN, 3=LEFT
+        # Values: -1=wall/invalid, 0=free movement, >0=mud
+        for direction in range(4):
+            assert movement_matrix[center_x][center_y][direction] == 0
+
+    def test_invalid_preset_name(self):
+        """Test that invalid preset names raise an error."""
+        with pytest.raises(ValueError, match="Unknown preset"):
+            PyGameState.create_preset("invalid_preset")
+
+
+class TestCustomCreationMethods:
+    """Test the new custom creation methods."""
+
+    def test_create_from_maze(self):
+        """Test creating a game from a specific maze layout."""
+        walls = [
+            ((0, 0), (0, 1)),  # Wall between (0,0) and (0,1)
+            ((1, 1), (2, 1)),  # Wall between (1,1) and (2,1)
+        ]
+
+        game = PyGameState.create_from_maze(
+            width=5, height=5, walls=walls, seed=42, max_turns=100
+        )
+
+        assert game.width == 5
+        assert game.height == 5
+        assert game.max_turns == 100
+        # Should have cheese (13% of 25 = ~3 pieces)
+        assert 2 <= len(game.cheese_positions()) <= 4
+
+    def test_create_with_starts(self):
+        """Test creating a game with custom starting positions."""
+        game = PyGameState.create_with_starts(
+            width=15,
+            height=11,
+            player1_start=(3, 3),
+            player2_start=(11, 7),
+            preset="small",
+            seed=42,
+        )
+
+        assert game.width == 15
+        assert game.height == 11
+        assert game.player1_position == (3, 3)
+        assert game.player2_position == (11, 7)
+        # Should use the preset's max_turns
+        assert game.max_turns == 200
+
+
+class TestPyRatIntegration:
+    """Test that the new API works with the high-level PyRat class."""
+
+    def test_pyrat_with_max_turns(self):
+        """Test that PyRat class accepts max_turns parameter."""
+        game = PyRat(max_turns=500)
+        assert game.max_turns == 500
+
+    def test_pyrat_defaults(self):
+        """Test that PyRat defaults still work."""
+        game = PyRat()
+        assert game.max_turns == 300
+        assert game.dimensions == (21, 15)
+
+    def test_pyrat_all_parameters(self):
+        """Test PyRat with all parameters."""
+        game = PyRat(
+            width=25,
+            height=17,
+            cheese_count=50,
+            symmetric=False,
+            seed=123,
+            max_turns=400,
+        )
+        assert game.dimensions == (25, 17)
+        assert game.max_turns == 400
+        # Cheese count might vary slightly
+        assert 48 <= len(game.cheese_positions) <= 52
+
+
+class TestBackwardCompatibility:
+    """Test that the new API maintains backward compatibility."""
+
+    def test_old_constructor_still_works(self):
+        """Test that the old constructor signature still works."""
+        # Old way without max_turns
+        game = PyGameState(
+            width=10, height=10, cheese_count=10, symmetric=True, seed=42
+        )
+        assert game.width == 10
+        assert game.height == 10
+        assert game.max_turns == 300  # Default value
+
+    def test_positional_arguments_work(self):
+        """Test that positional arguments still work for backward compatibility."""
+        # This is how some old code might call it
+        game = PyGameState(15, 15, 20, True, 42)
+        assert game.width == 15
+        assert game.height == 15
+        assert len(game.cheese_positions()) == 20


### PR DESCRIPTION
## Summary
This PR completes the implementation of issue #31 by exposing all Rust GameState constructors to Python with a unified API design.

### New Methods Added:
- `create_from_maze()`: Create games with specific wall layouts and random cheese placement
- `create_with_starts()`: Create games with custom starting positions using preset configurations

### Additional Improvements:
- Enhanced main constructor with `max_turns` parameter
- Updated `engine/CLAUDE.md` with comprehensive API documentation
- Reorganized tests to mirror module structure
- Fixed test for empty preset (corrected matrix indexing)

## Changes
- Added two new static methods to `PyGameState` in Rust bindings
- Updated Python type stubs (`.pyi` files) 
- Enhanced `PyRat` class to accept `max_turns` parameter
- Merged and reorganized test files for better structure
- Added comprehensive test coverage for all new methods

## Test Plan
All tests pass:
- [x] Rust tests (`cargo test`)
- [x] Python tests (`pytest`)
- [x] Pre-commit hooks (formatting, linting, type checking)
- [x] Backward compatibility tests included

## API Examples
```python
# Create game with specific maze layout
walls = [((0, 0), (0, 1)), ((1, 1), (2, 1))]
game = PyGameState.create_from_maze(
    width=15, height=11, walls=walls, seed=42, max_turns=200
)

# Create game with custom starting positions
game = PyGameState.create_with_starts(
    width=21, height=15,
    player1_start=(5, 5),
    player2_start=(15, 9),
    preset="default",
    seed=42
)
```

Fixes #31

🤖 Generated with [Claude Code](https://claude.ai/code)