### PR TITLE
fix(engine): reset() now respects symmetric flag (E-001)

### DIFF
--- a/cli/tests/test_display_symmetry.py
+++ b/cli/tests/test_display_symmetry.py
@@ -526,6 +526,7 @@ class TestGameStateExtractionSymmetry:
             cheese=[(3, 3)],  # Center cheese
             player1_pos=(0, 0),
             player2_pos=(6, 6),
+            symmetric=False,
         )
 
         mud_entries = game_state.mud_entries()
@@ -677,6 +678,7 @@ class TestFullBoardSymmetry:
             cheese=[(center_x, center_y)],
             player1_pos=(0, 0),
             player2_pos=(4, 4),
+            symmetric=False,
         )
 
         structures = build_maze_structures([], {})
@@ -706,6 +708,7 @@ class TestFullBoardSymmetry:
             cheese=[(5, 5)],  # Dummy cheese far away
             player1_pos=(1, 1),  # Rat here
             player2_pos=(6, 6),  # Python elsewhere
+            symmetric=False,
         )
 
         structures = build_maze_structures([], {})
@@ -764,6 +767,7 @@ class TestEdgeCases:
             cheese=[(1, 1)],
             player1_pos=(0, 0),
             player2_pos=(2, 2),
+            symmetric=False,
         )
 
         structures = build_maze_structures([], {})

--- a/engine/python/pyrat_engine/core/game.pyi
+++ b/engine/python/pyrat_engine/core/game.pyi
@@ -141,6 +141,7 @@ class GameState:
         player1_pos: Coordinates | tuple[int, int] | None = None,
         player2_pos: Coordinates | tuple[int, int] | None = None,
         max_turns: int = 300,
+        symmetric: bool = True,
     ) -> GameState:
         """Create a game with a fully specified maze configuration.
 
@@ -153,6 +154,8 @@ class GameState:
             player1_pos: Starting position for player 1 (default: (0,0))
             player2_pos: Starting position for player 2 (default: (width-1, height-1))
             max_turns: Maximum number of turns before game ends
+            symmetric: If True (default), validate that walls, mud, cheese, and
+                player positions are 180° rotationally symmetric.
 
         Returns:
             A new GameState instance with the specified configuration
@@ -167,6 +170,7 @@ class GameState:
         *,
         seed: int | None = None,
         max_turns: int = 300,
+        symmetric: bool = True,
     ) -> GameState:
         """Create a game with a specific maze layout and random cheese placement.
 
@@ -180,6 +184,8 @@ class GameState:
             walls: List of wall pairs, each defined by two (x,y) positions
             seed: Random seed for reproducible cheese placement
             max_turns: Maximum number of turns before game ends
+            symmetric: If True (default), validate walls are symmetric and
+                generate symmetric cheese/player positions.
 
         Returns:
             A new GameState instance with the specified maze and random cheese
@@ -194,6 +200,7 @@ class GameState:
         *,
         seed: int | None = None,
         max_turns: int = 300,
+        symmetric: bool = True,
     ) -> GameState:
         """Create a game from a list of validated Wall objects.
 
@@ -206,6 +213,8 @@ class GameState:
             walls: List of Wall objects defining the maze structure
             seed: Random seed for reproducible cheese placement
             max_turns: Maximum number of turns before game ends
+            symmetric: If True (default), validate walls are symmetric and
+                generate symmetric cheese/player positions.
 
         Returns:
             A new GameState instance with the specified walls and random cheese

--- a/engine/python/tests/test_env.py
+++ b/engine/python/tests/test_env.py
@@ -145,6 +145,7 @@ def test_custom_maze() -> None:
         cheese=[(1, 1)],  # One cheese in the middle
         player1_pos=(0, 0),
         player2_pos=(2, 2),
+        symmetric=False,
     )
 
     # Verify maze configuration

--- a/engine/python/tests/test_unified_types.py
+++ b/engine/python/tests/test_unified_types.py
@@ -240,7 +240,12 @@ class TestTupleInputSupport:
         walls = [((0, 0), (0, 1)), ((1, 1), (2, 1))]
 
         game = PyGameState.create_custom(
-            width=5, height=5, walls=walls, cheese=[(2, 2)], max_turns=100
+            width=5,
+            height=5,
+            walls=walls,
+            cheese=[(2, 2)],
+            max_turns=100,
+            symmetric=False,
         )
 
         assert game is not None
@@ -267,7 +272,7 @@ class TestTupleInputSupport:
         walls = [((0, 0), (0, 1)), ((1, 1), (2, 1))]
 
         game = PyGameState.create_from_maze(
-            width=5, height=5, walls=walls, seed=42, max_turns=100
+            width=5, height=5, walls=walls, seed=42, max_turns=100, symmetric=False
         )
 
         assert game is not None

--- a/engine/python/tests/test_validation.py
+++ b/engine/python/tests/test_validation.py
@@ -176,6 +176,7 @@ class TestMudValidation:
             walls=[((0, 0), (0, 1))],
             mud=[((0, 0), (0, 1), 3)],
             cheese=[(5, 5)],
+            symmetric=False,
         )
         assert game is not None  # Should create successfully
 
@@ -218,6 +219,7 @@ class TestValidInputs:
             player1_pos=(0, 0),
             player2_pos=(9, 9),
             max_turns=100,
+            symmetric=False,
         )
         expected_width = 10
         expected_height = 10
@@ -252,6 +254,7 @@ class TestValidInputs:
             height=10,
             mud=[((0, 0), (0, 1), 255)],
             cheese=[(5, 5)],
+            symmetric=False,
         )
         mud_entries = game.mud_entries()
         max_mud_value = 255

--- a/protocol/pyrat_base/pyrat_base/base_ai.py
+++ b/protocol/pyrat_base/pyrat_base/base_ai.py
@@ -509,6 +509,7 @@ class PyRatAI:
         }
         if required.issubset(self._game_config.keys()) and self._player:
             # Create the game state
+            # Note: symmetric=False because protocol data may not be symmetric
             self._game_state = PyGameState.create_custom(
                 width=self._game_config["width"],
                 height=self._game_config["height"],
@@ -517,6 +518,7 @@ class PyRatAI:
                 cheese=self._game_config["cheese"],
                 player1_pos=self._game_config["player1_pos"],
                 player2_pos=self._game_config["player2_pos"],
+                symmetric=False,
             )
             self._state = "READY"
 

--- a/protocol/pyrat_base/pyrat_base/replay.py
+++ b/protocol/pyrat_base/pyrat_base/replay.py
@@ -557,6 +557,7 @@ class ReplayPlayer:
             player1_pos=state.rat_position,
             player2_pos=state.python_position,
             max_turns=state.max_turns,
+            symmetric=False,  # Replay data may not be symmetric
         )
 
     def step_forward(self) -> Optional[GameResult]:

--- a/protocol/pyrat_base/tests/integration/test_base_ai_large_commands.py
+++ b/protocol/pyrat_base/tests/integration/test_base_ai_large_commands.py
@@ -171,6 +171,7 @@ class TestLargeCommandIntegration:
             cheese=[(25, 25)],
             player1_pos=(0, 0),
             player2_pos=(49, 49),
+            symmetric=False,
         )
 
         # Verify it was created successfully

--- a/protocol/pyrat_base/tests/integration/test_dijkstra_puzzles.py
+++ b/protocol/pyrat_base/tests/integration/test_dijkstra_puzzles.py
@@ -36,6 +36,7 @@ def create_game_state():
             cheese=cheese or [],
             player1_pos=player1_pos,
             player2_pos=player2_pos,
+            symmetric=False,
         )
         return ProtocolState(game, Player.RAT)
 

--- a/protocol/pyrat_base/tests/integration/test_direct_validation.py
+++ b/protocol/pyrat_base/tests/integration/test_direct_validation.py
@@ -12,6 +12,7 @@ def test_negative_positions():
             width=10,
             height=10,
             cheese=[(-1, 0)],
+            symmetric=False,
         )
         raise AssertionError("Should have raised ValueError")
     except ValueError as e:
@@ -24,6 +25,7 @@ def test_negative_positions():
             height=10,
             cheese=[(5, 5)],
             player1_pos=(-1, 0),
+            symmetric=False,
         )
         raise AssertionError("Should have raised ValueError")
     except ValueError as e:
@@ -38,6 +40,7 @@ def test_negative_mud():
             height=10,
             cheese=[(5, 5)],
             mud=[((0, 0), (0, 1), -1)],
+            symmetric=False,
         )
         raise AssertionError("Should have raised ValueError")
     except ValueError as e:
@@ -51,6 +54,7 @@ def test_out_of_bounds():
             width=10,
             height=10,
             cheese=[(10, 10)],  # Equal to width/height is out of bounds
+            symmetric=False,
         )
         raise AssertionError("Should have raised ValueError")
     except ValueError as e:
@@ -67,6 +71,7 @@ def test_valid_creation():
         cheese=[(5, 5), (7, 7)],
         player1_pos=(0, 0),
         player2_pos=(9, 9),
+        symmetric=False,
     )
     expected_width = 10
     expected_height = 10

--- a/protocol/pyrat_base/tests/integration/test_greedy_ai_end_to_end.py
+++ b/protocol/pyrat_base/tests/integration/test_greedy_ai_end_to_end.py
@@ -45,6 +45,7 @@ class TestGreedyAIEndToEnd:
             cheese=[(1, 0), (4, 4)],  # Close cheese and far cheese
             player1_pos=(0, 0),  # Rat starts at bottom-left
             player2_pos=(0, 4),  # Python starts at top-left (away from cheese)
+            symmetric=False,
         )
 
         greedy = DirectAIRunner(GreedyAI, Player.RAT)
@@ -87,6 +88,7 @@ class TestGreedyAIEndToEnd:
             cheese=[(4, 0)],  # Cheese on other side of wall
             player1_pos=(0, 0),  # Rat starts bottom-left
             player2_pos=(5, 4),  # Python starts top-right
+            symmetric=False,
         )
 
         greedy = DirectAIRunner(GreedyAI, Player.RAT)
@@ -136,6 +138,7 @@ class TestGreedyAIEndToEnd:
             cheese=[(2, 0), (0, 2)],  # One through mud, one around
             player1_pos=(0, 0),
             player2_pos=(5, 2),
+            symmetric=False,
         )
 
         greedy = DirectAIRunner(GreedyAI, Player.RAT)
@@ -190,6 +193,7 @@ class TestGreedyAIEndToEnd:
             cheese=[(3, 3), (6, 6), (1, 1)],
             player1_pos=(0, 0),
             player2_pos=(6, 0),
+            symmetric=False,
         )
 
         greedy = DirectAIRunner(GreedyAI, Player.RAT)
@@ -260,6 +264,7 @@ class TestGreedyAIEndToEnd:
             cheese=[(1, 0), (2, 0), (3, 0)],
             player1_pos=(0, 0),
             player2_pos=(4, 4),
+            symmetric=False,
         )
 
         greedy = DirectAIRunner(GreedyAI, Player.RAT)
@@ -302,6 +307,7 @@ class TestGreedyAIEndToEnd:
             cheese=[(1, 0)],  # One cheese in the middle
             player1_pos=(0, 0),  # Rat on left
             player2_pos=(2, 0),  # Python on right
+            symmetric=False,
         )
 
         greedy = DirectAIRunner(GreedyAI, Player.RAT)
@@ -347,6 +353,7 @@ class TestGreedyVsGreedy:
             cheese=[(1, 0), (2, 0), (3, 0)],
             player1_pos=(0, 0),  # Rat starts left
             player2_pos=(4, 0),  # Python starts right
+            symmetric=False,
         )
 
         greedy_rat = DirectAIRunner(GreedyAI, Player.RAT)
@@ -408,6 +415,7 @@ class TestGreedyVsGreedy:
             cheese=[(1, 0), (2, 0)],
             player1_pos=(0, 0),  # Rat starts left
             player2_pos=(6, 0),  # Python starts far right
+            symmetric=False,
         )
 
         greedy_rat = DirectAIRunner(GreedyAI, Player.RAT)
@@ -469,6 +477,7 @@ class TestGreedyVsGreedy:
             cheese=[(2, 1)],  # Center cheese
             player1_pos=(0, 1),  # Rat starts left middle
             player2_pos=(4, 1),  # Python starts right middle
+            symmetric=False,
         )
 
         greedy_rat = DirectAIRunner(GreedyAI, Player.RAT)
@@ -537,6 +546,7 @@ class TestGreedyVsGreedy:
             ],  # 5 cheese distributed
             player1_pos=(0, 0),  # Rat bottom-left
             player2_pos=(6, 0),  # Python bottom-right
+            symmetric=False,
         )
 
         greedy_rat = DirectAIRunner(GreedyAI, Player.RAT)
@@ -620,6 +630,7 @@ class TestGreedyVsGreedy:
             cheese=[(1, 2), (5, 2)],  # One cheese on each side of wall
             player1_pos=(0, 0),  # Rat on left side
             player2_pos=(6, 0),  # Python on right side
+            symmetric=False,
         )
 
         greedy_rat = DirectAIRunner(GreedyAI, Player.RAT)

--- a/protocol/pyrat_base/tests/unit/test_utils.py
+++ b/protocol/pyrat_base/tests/unit/test_utils.py
@@ -48,6 +48,7 @@ class TestPathfinding:
             cheese=[(4, 4)],
             player1_pos=(0, 0),
             player2_pos=(4, 0),
+            symmetric=False,
         )
         state = ProtocolState(game, Player.RAT)
 
@@ -84,6 +85,7 @@ class TestPathfinding:
             cheese=[(4, 1)],
             player1_pos=(0, 1),
             player2_pos=(4, 1),
+            symmetric=False,
         )
         state = ProtocolState(game, Player.RAT)
 
@@ -120,6 +122,7 @@ class TestPathfinding:
             cheese=[(4, 2)],
             player1_pos=(0, 2),
             player2_pos=(4, 4),
+            symmetric=False,
         )
         state = ProtocolState(game, Player.RAT)
 
@@ -165,6 +168,7 @@ class TestPathfinding:
             cheese=[(4, 2)],
             player1_pos=(0, 2),
             player2_pos=(4, 2),
+            symmetric=False,
         )
         state = ProtocolState(game, Player.RAT)
 
@@ -177,7 +181,7 @@ class TestPathfinding:
     def test_dijkstra_same_position(self):
         """Test Dijkstra when start equals goal."""
         game = PyGameState.create_custom(
-            width=5, height=5, walls=[], mud=[], cheese=[(2, 2)]
+            width=5, height=5, walls=[], mud=[], cheese=[(2, 2)], symmetric=False
         )
         state = ProtocolState(game, Player.RAT)
 
@@ -197,6 +201,7 @@ class TestPathfinding:
             cheese=[(1, 0), (4, 0), (2, 2)],  # Different distances
             player1_pos=(0, 0),
             player2_pos=(4, 4),
+            symmetric=False,
         )
         state = ProtocolState(game, Player.RAT)
 
@@ -222,6 +227,7 @@ class TestPathfinding:
             cheese=[(1, 0), (4, 0)],  # Two cheese at different distances
             player1_pos=(0, 0),
             player2_pos=(6, 2),
+            symmetric=False,
         )
         state = ProtocolState(game, Player.RAT)
 
@@ -257,6 +263,7 @@ class TestPathfinding:
             cheese=[(1, 4), (4, 0), (4, 4)],
             player1_pos=(0, 0),
             player2_pos=(2, 2),
+            symmetric=False,
         )
         state = ProtocolState(game, Player.RAT)
 
@@ -290,6 +297,7 @@ class TestPathfinding:
             cheese=[(2, 2)],  # Need at least one for creation
             player1_pos=(0, 0),
             player2_pos=(4, 4),
+            symmetric=False,
         )
 
         # Collect the cheese to empty the board
@@ -322,6 +330,7 @@ class TestPathfinding:
             cheese=[(4, 4)],  # Trapped cheese
             player1_pos=(0, 0),
             player2_pos=(2, 2),
+            symmetric=False,
         )
         state = ProtocolState(game, Player.RAT)
 
@@ -340,6 +349,7 @@ class TestPathfinding:
             cheese=[(4, 2)],
             player1_pos=(0, 2),
             player2_pos=(4, 4),
+            symmetric=False,
         )
         state = ProtocolState(game, Player.RAT)
 
@@ -362,6 +372,7 @@ class TestPathfinding:
             cheese=[(2, 0)],
             player1_pos=(0, 0),
             player2_pos=(2, 0),
+            symmetric=False,
         )
         state = ProtocolState(game, Player.RAT)
 


### PR DESCRIPTION
Previously, reset() always created symmetric games regardless of how the game was originally created. Now it preserves the symmetric/asymmetric setting.

Changes:
- Add symmetric field to PyGameState struct
- Add symmetry validation utilities (walls, mud, cheese, players)
- Add symmetric parameter to create_custom(), create_from_maze(), create_from_walls() (default: true)
- Update reset() to use stored symmetric flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Pull Request

## Summary
<!-- What does this change do and why? -->

## Type of Change
- [ ] Bug fix (game logic, Python bindings, or API correctness)
- [ ] New feature (game mechanics, API extensions, or tooling)
- [ ] Performance improvement (hot path optimization, memory usage, or benchmark improvements)
- [ ] Test coverage (edge cases, property testing, or benchmark scenarios)
- [ ] Documentation (game rules, API usage, or development workflows)
- [ ] Breaking change (API modifications that affect existing usage)

## Changes Made
<!-- Specific technical changes -->

## Testing
- [ ] Rust unit tests pass: `cd rust && cargo test --lib`
- [ ] Python integration tests pass: `pytest python/tests`
- [ ] Added tests for edge cases or new functionality
- [ ] Verified critical game invariants (if applicable)

## Performance Impact
<!-- Required for changes to hot paths, data structures, or Python bindings -->
- [ ] Benchmarked before/after with `cargo bench`
- [ ] Performance impact: <!-- Quantify: e.g., "15% faster", "same", "2% slower but fixes critical bug" -->

### Benchmark Results
```
Before: [relevant benchmark results]
After:  [relevant benchmark results]
```

## Code Quality
- [ ] Rust clippy warnings resolved: `cargo clippy`
- [ ] Python linting passes: `ruff check python/`
- [ ] Uses appropriate error handling (Result types vs unwrap)
- [ ] Follows existing patterns for data structures and performance

## API Consistency
<!-- For changes affecting Python interface or public APIs -->
- [ ] Maintains PettingZoo Parallel environment interface compatibility
- [ ] Observation space format unchanged (or documented if changed)
- [ ] Direction/action mappings work correctly between Rust and Python

## Breaking Changes
<!-- Describe impact on existing PyRat users and migration path -->

## Additional Notes
<!-- Technical details, design decisions, or specific areas for reviewer focus -->
