### PR TITLE
fix(ci): remove duplicate workflow triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,6 @@
 name: Build
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
   workflow_call:
     outputs:
       artifact-name:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,7 @@
 name: Lint
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-  workflow_call:  # Allow being called by other workflows
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,11 +1,7 @@
 name: Rust
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-  workflow_call:  # Allow being called by other workflows
+  workflow_call:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,7 @@
 name: Test
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-  workflow_call:  # Allow being called by other workflows
+  workflow_call:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Child workflows (build, lint, rust, test) now only trigger via workflow_call from integration.yml, eliminating duplicate runs. Reduces job count from ~34 to 16 per PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
