### PR TITLE
refactor(engine): consolidate API surface - rename PyGameState to PyR…

### DIFF
--- a/cli/pyrat_runner/ai_process.py
+++ b/cli/pyrat_runner/ai_process.py
@@ -187,12 +187,10 @@ class AIProcess:
         self._write_line("newgame")
 
         # Send maze dimensions
-        self._write_line(
-            f"maze height:{game_state._game.height} width:{game_state._game.width}"
-        )
+        self._write_line(f"maze height:{game_state.height} width:{game_state.width}")
 
         # Send walls
-        walls = game_state._game.wall_entries()
+        walls = game_state.wall_entries()
         if walls:
             walls_str = " ".join(
                 f"({w.pos1.x},{w.pos1.y})-({w.pos2.x},{w.pos2.y})" for w in walls
@@ -200,22 +198,24 @@ class AIProcess:
             self._write_line(f"walls {walls_str}")
 
         # Send mud
-        mud = game_state.mud_positions
-        if mud:
+        mud_entries = game_state.mud_entries()
+        if mud_entries:
             mud_parts = []
-            for (cell1, cell2), turns in mud.items():
-                mud_parts.append(f"({cell1.x},{cell1.y})-({cell2.x},{cell2.y}):{turns}")
+            for m in mud_entries:
+                mud_parts.append(
+                    f"({m.pos1.x},{m.pos1.y})-({m.pos2.x},{m.pos2.y}):{m.value}"
+                )
             self._write_line(f"mud {' '.join(mud_parts)}")
 
         # Send cheese
-        cheese = game_state.cheese_positions
+        cheese = game_state.cheese_positions()
         if cheese:
             cheese_str = " ".join(f"({c.x},{c.y})" for c in cheese)
             self._write_line(f"cheese {cheese_str}")
 
         # Send player positions (protocol-compliant)
-        p1_pos = game_state.player1_pos
-        p2_pos = game_state.player2_pos
+        p1_pos = game_state.player1_position
+        p2_pos = game_state.player2_position
         self._write_line(f"player1 rat ({p1_pos.x},{p1_pos.y})")
         self._write_line(f"player2 python ({p2_pos.x},{p2_pos.y})")
 

--- a/cli/pyrat_runner/display.py
+++ b/cli/pyrat_runner/display.py
@@ -343,20 +343,21 @@ def render_game_state(
         Multi-line string containing the complete game visualization
     """
     # Extract data from game state (read-only operations)
-    rat_pos = (game.player1_pos.x, game.player1_pos.y)
-    python_pos = (game.player2_pos.x, game.player2_pos.y)
-    scores = game.scores
-    cheese_set = set((c.x, c.y) for c in game.cheese_positions)
-    width = game._game.width
-    height = game._game.height
+    rat_pos = (game.player1_position.x, game.player1_position.y)
+    python_pos = (game.player2_position.x, game.player2_position.y)
+    rat_score = game.player1_score
+    python_score = game.player2_score
+    cheese_set = set((c.x, c.y) for c in game.cheese_positions())
+    width = game.width
+    height = game.height
     turn = game.turn
 
     header = render_header(
         rat_pos=rat_pos,
-        rat_score=scores[0],
+        rat_score=rat_score,
         rat_move=rat_move,
         python_pos=python_pos,
-        python_score=scores[1],
+        python_score=python_score,
         python_move=python_move,
         turn=turn,
     )
@@ -451,8 +452,9 @@ class Display:
         self.game = game_state
         self.delay = delay
         # Pre-compute immutable maze structures once
-        walls = game_state._game.wall_entries()
-        mud = game_state.mud_positions
+        walls = game_state.wall_entries()
+        # Convert mud_entries() list to dict format expected by build_maze_structures
+        mud = {(m.pos1, m.pos2): m.value for m in game_state.mud_entries()}
         self.structures = build_maze_structures(walls, mud)
         # Detect non-interactive environments to limit rendering in CI
         # Allow override via PYRAT_DEBUG to force full rendering for troubleshooting
@@ -489,8 +491,8 @@ class Display:
         self, x: int, y: int, cheese_set: Set[Tuple[int, int]]
     ) -> str:
         """Get display content for a cell (delegates to pure function)."""
-        rat_pos = (self.game.player1_pos.x, self.game.player1_pos.y)
-        python_pos = (self.game.player2_pos.x, self.game.player2_pos.y)
+        rat_pos = (self.game.player1_position.x, self.game.player1_position.y)
+        python_pos = (self.game.player2_position.x, self.game.player2_position.y)
         return get_cell_content(x, y, rat_pos, python_pos, cheese_set)
 
     def _get_vertical_separator(self, x: int, y: int) -> str:

--- a/cli/pyrat_runner/game_runner.py
+++ b/cli/pyrat_runner/game_runner.py
@@ -123,9 +123,9 @@ def run_game(
                 display.show_error("rat", error_msg)
             if not should_continue:
                 # Rat AI crashed - determine final state and return
-                scores = game.scores
-                winner = determine_winner_from_scores(scores[0], scores[1])
-                return False, winner, scores[0], scores[1]
+                rat_score, python_score = game.player1_score, game.player2_score
+                winner = determine_winner_from_scores(rat_score, python_score)
+                return False, winner, rat_score, python_score
 
             # Handle python provider errors
             should_continue, python_move_processed, error_msg = classify_ai_move_error(
@@ -135,16 +135,16 @@ def run_game(
                 display.show_error("python", error_msg)
             if not should_continue:
                 # Python AI crashed - determine final state and return
-                scores = game.scores
-                winner = determine_winner_from_scores(scores[0], scores[1])
-                return False, winner, scores[0], scores[1]
+                rat_score, python_score = game.player1_score, game.player2_score
+                winner = determine_winner_from_scores(rat_score, python_score)
+                return False, winner, rat_score, python_score
 
             # Update moves for next iteration
             rat_move = rat_move_processed
             python_move = python_move_processed
 
             # Execute move in game
-            result = game.step(p1_move=rat_move, p2_move=python_move)
+            game_over, _collected = game.step(p1_move=rat_move, p2_move=python_move)
 
             # Update display if provided
             if display:
@@ -152,10 +152,10 @@ def run_game(
                 time.sleep(display_delay)
 
             # Check for game over
-            if result.game_over:
-                scores = game.scores
-                winner = determine_winner_from_scores(scores[0], scores[1])
-                return True, winner, scores[0], scores[1]
+            if game_over:
+                rat_score, python_score = game.player1_score, game.player2_score
+                winner = determine_winner_from_scores(rat_score, python_score)
+                return True, winner, rat_score, python_score
 
 
 class GameRunner:

--- a/cli/tests/test_display.py
+++ b/cli/tests/test_display.py
@@ -2,8 +2,7 @@
 
 import pytest
 
-from pyrat_engine.game import PyRat
-from pyrat_engine.core import GameState as PyGameState
+from pyrat_engine import PyRat
 
 from pyrat_runner.display import (
     Display,
@@ -31,7 +30,7 @@ def empty_game():
     Creates a 5x5 game with players at opposite corners.
     Has one cheese at an out-of-the-way position (engine requires at least one).
     """
-    game_state = PyGameState.create_custom(
+    return PyRat.create_custom(
         width=5,
         height=5,
         walls=[],
@@ -41,9 +40,6 @@ def empty_game():
         player2_pos=(4, 4),
         symmetric=False,
     )
-    wrapper = PyRat.__new__(PyRat)
-    wrapper._game = game_state
-    return wrapper
 
 
 @pytest.fixture
@@ -54,7 +50,7 @@ def game_with_walls():
     - Vertical wall between (1,1) and (2,1)
     - Horizontal wall between (3,2) and (3,3)
     """
-    game_state = PyGameState.create_custom(
+    return PyRat.create_custom(
         width=5,
         height=5,
         walls=[
@@ -67,9 +63,6 @@ def game_with_walls():
         player2_pos=(4, 4),
         symmetric=False,
     )
-    wrapper = PyRat.__new__(PyRat)
-    wrapper._game = game_state
-    return wrapper
 
 
 @pytest.fixture
@@ -80,7 +73,7 @@ def game_with_mud():
     - Vertical mud (3 turns) between (1,2) and (2,2)
     - Horizontal mud (2 turns) between (3,1) and (3,2)
     """
-    game_state = PyGameState.create_custom(
+    return PyRat.create_custom(
         width=5,
         height=5,
         walls=[],
@@ -93,9 +86,6 @@ def game_with_mud():
         player2_pos=(4, 4),
         symmetric=False,
     )
-    wrapper = PyRat.__new__(PyRat)
-    wrapper._game = game_state
-    return wrapper
 
 
 class TestCellContent:
@@ -130,7 +120,7 @@ class TestCellContent:
         # Add a dummy cheese at (0,4) if cheese_set is empty (engine requires at least one)
         cheese_list = list(cheese_set) if cheese_set else [(0, 4)]
 
-        game_state = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=5,
             height=5,
             walls=[],
@@ -140,8 +130,6 @@ class TestCellContent:
             player2_pos=python_pos,
             symmetric=False,
         )
-        game = PyRat.__new__(PyRat)
-        game._game = game_state
 
         display = Display(game, delay=0)
         content = display._get_cell_content(x, y, cheese_set)
@@ -249,7 +237,7 @@ class TestMazeStructureBuilding:
     def test_wall_order_independence(self):
         """Wall parsing should work regardless of coordinate order."""
         # Test that ((x1, y1), (x2, y2)) and ((x2, y2), (x1, y1)) produce same result
-        game_state = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=5,
             height=5,
             walls=[
@@ -261,8 +249,6 @@ class TestMazeStructureBuilding:
             player2_pos=(4, 4),
             symmetric=False,
         )
-        game = PyRat.__new__(PyRat)
-        game._game = game_state
 
         display = Display(game, delay=0)
         # Should still be stored with min x

--- a/cli/tests/test_display_symmetry.py
+++ b/cli/tests/test_display_symmetry.py
@@ -7,8 +7,7 @@ import re
 from typing import Dict, Set, Tuple
 
 
-from pyrat_engine.game import PyRat
-from pyrat_engine.core import GameState as PyGameState
+from pyrat_engine import PyRat
 
 from pyrat_runner.display import (
     MazeStructures,
@@ -482,7 +481,7 @@ class TestGameStateExtractionSymmetry:
     def test_symmetric_game_wall_entries(self):
         """Symmetric game produces symmetric wall entries."""
         # Create a symmetric game with reproducible seed
-        game = PyGameState(width=11, height=9, symmetric=True, seed=42)
+        game = PyRat(width=11, height=9, symmetric=True, seed=42)
 
         walls = game.wall_entries()
 
@@ -518,7 +517,7 @@ class TestGameStateExtractionSymmetry:
             ((4, 3), (4, 4), 3),  # Symmetric pair
         ]
 
-        game_state = PyGameState.create_custom(
+        game_state = PyRat.create_custom(
             width=width,
             height=height,
             walls=[],
@@ -557,7 +556,7 @@ class TestGameStateExtractionSymmetry:
 
     def test_symmetric_game_cheese_positions(self):
         """Symmetric game produces symmetric cheese positions."""
-        game = PyGameState(width=11, height=9, cheese_count=11, symmetric=True, seed=42)
+        game = PyRat(width=11, height=9, cheese_count=11, symmetric=True, seed=42)
 
         cheese_positions = game.cheese_positions()
         width, height = 11, 9
@@ -588,10 +587,7 @@ class TestFullBoardSymmetry:
 
     def test_symmetric_game_renders_symmetrically(self):
         """Symmetric game produces visually symmetric display."""
-        game = PyGameState(width=7, height=7, cheese_count=9, symmetric=True, seed=42)
-
-        wrapper = PyRat.__new__(PyRat)
-        wrapper._game = game
+        game = PyRat(width=7, height=7, cheese_count=9, symmetric=True, seed=42)
 
         # Get game data
         walls = game.wall_entries()
@@ -670,7 +666,7 @@ class TestFullBoardSymmetry:
         assert (sym_x, sym_y) == (center_x, center_y), "Center should be self-symmetric"
 
         # Place cheese at center
-        PyGameState.create_custom(
+        PyRat.create_custom(
             width=width,
             height=height,
             walls=[],
@@ -700,7 +696,7 @@ class TestFullBoardSymmetry:
         # since we can only have one rat and one python
 
         # Test 1: Rat only
-        PyGameState.create_custom(
+        PyRat.create_custom(
             width=width,
             height=height,
             walls=[],
@@ -759,7 +755,7 @@ class TestEdgeCases:
         """Minimum practical board size should work."""
         width, height = 3, 3
 
-        PyGameState.create_custom(
+        PyRat.create_custom(
             width=width,
             height=height,
             walls=[],
@@ -786,7 +782,7 @@ class TestEdgeCases:
         # No single cell is self-symmetric
 
         # Create symmetric game with EVEN cheese count (required for even dimensions)
-        game = PyGameState(
+        game = PyRat(
             width=width, height=height, cheese_count=10, symmetric=True, seed=42
         )
 
@@ -827,7 +823,7 @@ class TestEdgeCases:
         assert (sym_x, sym_y) == (center_x, center_y)
 
         # Create symmetric game with odd cheese count
-        game = PyGameState(
+        game = PyRat(
             width=width, height=height, cheese_count=9, symmetric=True, seed=42
         )
 

--- a/cli/tests/test_move_providers.py
+++ b/cli/tests/test_move_providers.py
@@ -205,18 +205,12 @@ class TestRunGameFunction:
         class FakeGame:
             def __init__(self):
                 self._done = False
-
-            @property
-            def scores(self):
-                return (0.0, 0.0)
+                self.player1_score = 0.0
+                self.player2_score = 0.0
 
             def step(self, p1_move: Direction, p2_move: Direction):
-                class R:
-                    pass
-
-                r = R()
-                r.game_over = True  # end after first step
-                return r
+                # New API returns (game_over: bool, collected: list)
+                return (True, [])
 
         game = FakeGame()
         rat = SpyProvider("Rat", [None], alive=True)
@@ -239,17 +233,13 @@ class TestRunGameFunction:
                 return Direction.STAY
 
         class FakeGame:
-            @property
-            def scores(self):
-                return (0.0, 0.0)
+            def __init__(self):
+                self.player1_score = 0.0
+                self.player2_score = 0.0
 
             def step(self, p1_move: Direction, p2_move: Direction):
-                class R:
-                    pass
-
-                r = R()
-                r.game_over = True
-                return r
+                # New API returns (game_over: bool, collected: list)
+                return (True, [])
 
         # If sequential, ~0.4s; if parallel, ~0.2s (allow generous margin for CI)
         game = FakeGame()

--- a/engine/python/pyrat_engine/__init__.py
+++ b/engine/python/pyrat_engine/__init__.py
@@ -15,26 +15,25 @@ Example:
     >>> from pyrat_engine import PyRat, Direction
     >>> game = PyRat(width=15, height=15)
     >>> # Make moves
-    >>> result = game.step(Direction.RIGHT, Direction.LEFT)
+    >>> game_over, collected = game.step(Direction.RIGHT, Direction.LEFT)
     >>> # Check game state
-    >>> print(f"Player 1 score: {game.scores[0]}")
+    >>> print(f"Player 1 score: {game.player1_score}")
 """
 
-from pyrat_engine.core.game import GameState, MoveUndo
+from pyrat_engine.core import MoveUndo, PyRat
 from pyrat_engine.core.types import (
     Coordinates,
     Direction,
     Mud,
     Wall,
 )
-from pyrat_engine.game import GameResult, PyRat
+from pyrat_engine.game import GameResult
 
 __version__ = "0.1.0"
 __all__ = [
     "Coordinates",
     "Direction",
     "GameResult",
-    "GameState",
     "MoveUndo",
     "Mud",
     "PyRat",

--- a/engine/python/pyrat_engine/core/__init__.py
+++ b/engine/python/pyrat_engine/core/__init__.py
@@ -29,12 +29,12 @@ from pyrat_engine.core.types import Direction  # noqa: E402
 # Conditionally import types for type checking to avoid "not valid as a type" errors
 if TYPE_CHECKING:
     from pyrat_engine.core.builder import PyGameConfigBuilder as GameConfigBuilder
-    from pyrat_engine.core.game import PyGameState as GameState
     from pyrat_engine.core.game import PyMoveUndo as MoveUndo
+    from pyrat_engine.core.game import PyRat
     from pyrat_engine.core.observation import PyGameObservation as GameObservation
     from pyrat_engine.core.observation import PyObservationHandler as ObservationHandler
 else:
-    GameState = _impl.game.PyGameState
+    PyRat = _impl.game.PyRat
     MoveUndo = _impl.game.PyMoveUndo
     GameObservation = _impl.observation.PyGameObservation
     ObservationHandler = _impl.observation.PyObservationHandler
@@ -52,7 +52,7 @@ __all__ = [
     "Wall",
     "Mud",
     # Game
-    "GameState",
+    "PyRat",
     "MoveUndo",
     # Observation
     "GameObservation",

--- a/engine/python/pyrat_engine/core/builder.pyi
+++ b/engine/python/pyrat_engine/core/builder.pyi
@@ -3,7 +3,7 @@
 This module contains the builder pattern for creating custom game configurations.
 """
 
-from pyrat_engine.core.game import GameState
+from pyrat_engine.core.game import PyRat
 from pyrat_engine.core.types import Coordinates, Mud, Wall
 
 class GameConfigBuilder:
@@ -133,11 +133,11 @@ class GameConfigBuilder:
         """
         ...
 
-    def build(self) -> GameState:
+    def build(self) -> PyRat:
         """Construct and return the final game state.
 
         Returns:
-            A new GameState instance with the configured parameters
+            A new PyRat instance with the configured parameters
 
         Raises:
             ValueError: If the configuration is invalid (e.g., invalid positions,

--- a/engine/python/pyrat_engine/core/game.py
+++ b/engine/python/pyrat_engine/core/game.py
@@ -6,12 +6,11 @@ This module re-exports game classes from the compiled Rust module.
 # Import the compiled module directly
 import pyrat_engine._core as _impl
 
-# Re-export game classes with cleaner names
-GameState = _impl.game.PyGameState
+# Re-export game classes
+PyRat = _impl.game.PyRat
 MoveUndo = _impl.game.PyMoveUndo
 
-# Keep original names for backward compatibility if needed
-PyGameState = GameState
+# Alias for backward compatibility
 PyMoveUndo = MoveUndo
 
-__all__ = ["GameState", "MoveUndo", "PyGameState", "PyMoveUndo"]
+__all__ = ["MoveUndo", "PyMoveUndo", "PyRat"]

--- a/engine/python/pyrat_engine/core/game.pyi
+++ b/engine/python/pyrat_engine/core/game.pyi
@@ -1,7 +1,7 @@
 """Core game state and management classes.
 
 This module contains the main game state management:
-- GameState: The core game engine
+- PyRat: The core game engine
 - MoveUndo: Undo information for game tree search
 """
 
@@ -74,19 +74,15 @@ class MoveUndo:
         """Turn number before the move was made."""
         ...
 
-class GameState:
-    """Core game state implementation in Rust.
+class PyRat:
+    """Core PyRat game engine implementation in Rust.
 
-    This class provides the low-level interface to the Rust game engine.
+    This class provides the main interface to the Rust game engine.
     It manages all game state including:
     - Player positions and scores
     - Cheese placement and collection
     - Mud effects and movement delays
     - Turn counting and game termination
-
-    Note:
-        This is an internal class. Users should typically use the PyRat class
-        instead, which provides a more Pythonic interface.
 
     Args:
         width: Board width (default: 21)
@@ -110,7 +106,7 @@ class GameState:
         preset: str = "default",
         *,
         seed: int | None = None,
-    ) -> GameState:
+    ) -> PyRat:
         """Create a game from a preset configuration.
 
         Available presets:
@@ -127,7 +123,7 @@ class GameState:
             seed: Random seed for reproducible games
 
         Returns:
-            A new GameState instance with the preset configuration
+            A new PyRat instance with the preset configuration
         """
         ...
 
@@ -142,7 +138,7 @@ class GameState:
         player2_pos: Coordinates | tuple[int, int] | None = None,
         max_turns: int = 300,
         symmetric: bool = True,
-    ) -> GameState:
+    ) -> PyRat:
         """Create a game with a fully specified maze configuration.
 
         Args:
@@ -158,7 +154,7 @@ class GameState:
                 player positions are 180° rotationally symmetric.
 
         Returns:
-            A new GameState instance with the specified configuration
+            A new PyRat instance with the specified configuration
         """
         ...
 
@@ -171,7 +167,7 @@ class GameState:
         seed: int | None = None,
         max_turns: int = 300,
         symmetric: bool = True,
-    ) -> GameState:
+    ) -> PyRat:
         """Create a game with a specific maze layout and random cheese placement.
 
         This method is useful for creating games with predefined maze structures
@@ -188,7 +184,7 @@ class GameState:
                 generate symmetric cheese/player positions.
 
         Returns:
-            A new GameState instance with the specified maze and random cheese
+            A new PyRat instance with the specified maze and random cheese
         """
         ...
 
@@ -201,7 +197,7 @@ class GameState:
         seed: int | None = None,
         max_turns: int = 300,
         symmetric: bool = True,
-    ) -> GameState:
+    ) -> PyRat:
         """Create a game from a list of validated Wall objects.
 
         Similar to create_from_maze but specifically accepts Wall objects
@@ -217,7 +213,7 @@ class GameState:
                 generate symmetric cheese/player positions.
 
         Returns:
-            A new GameState instance with the specified walls and random cheese
+            A new PyRat instance with the specified walls and random cheese
         """
         ...
 
@@ -230,7 +226,7 @@ class GameState:
         *,
         preset: str = "default",
         seed: int | None = None,
-    ) -> GameState:
+    ) -> PyRat:
         """Create a game with custom starting positions.
 
         This method generates a random maze using the specified preset configuration
@@ -246,7 +242,7 @@ class GameState:
             seed: Random seed for reproducible maze generation
 
         Returns:
-            A new GameState instance with custom starting positions
+            A new PyRat instance with custom starting positions
         """
         ...
 
@@ -380,6 +376,5 @@ class GameState:
         """
         ...
 
-# Rename the classes to match the Rust names
-PyGameState = GameState
+# Alias for the Rust MoveUndo type
 PyMoveUndo = MoveUndo

--- a/engine/python/pyrat_engine/core/observation.pyi
+++ b/engine/python/pyrat_engine/core/observation.pyi
@@ -7,7 +7,7 @@ This module contains classes for observing and tracking game state:
 
 import numpy as np
 
-from pyrat_engine.core.game import GameState
+from pyrat_engine.core.game import PyRat
 from pyrat_engine.core.types import Coordinates
 
 class GameObservation:
@@ -126,7 +126,7 @@ class ObservationHandler:
     and movement constraints, providing efficient updates during gameplay.
     """
 
-    def __init__(self, game: GameState) -> None:
+    def __init__(self, game: PyRat) -> None:
         """Creates a new observation handler for tracking game state.
 
         Args:
@@ -156,7 +156,7 @@ class ObservationHandler:
         """
         ...
 
-    def get_observation(self, game: GameState, is_player_one: bool) -> GameObservation:
+    def get_observation(self, game: PyRat, is_player_one: bool) -> GameObservation:
         """Gets the current game observation from a player's perspective.
 
         Returns a complete observation of the game state, including player positions,

--- a/engine/python/pyrat_engine/env.py
+++ b/engine/python/pyrat_engine/env.py
@@ -7,8 +7,8 @@ from gymnasium.spaces import Box, Discrete
 from gymnasium.spaces import Dict as SpaceDict
 from pettingzoo.utils.env import AgentID, ParallelEnv
 
-from pyrat_engine.core import GameState as PyGameState
 from pyrat_engine.core import ObservationHandler as PyObservationHandler
+from pyrat_engine.core import PyRat
 
 if TYPE_CHECKING:
     from pyrat_engine.core.types import Direction
@@ -62,7 +62,7 @@ class PyRatEnv(ParallelEnv):  # type: ignore[misc]
         self.possible_agents = ["player_1", "player_2"]
 
         # Create game state and observation handler
-        self.game = PyGameState(width, height, cheese_count, symmetric, seed)
+        self.game = PyRat(width, height, cheese_count, symmetric, seed)
         self.obs_handler = PyObservationHandler(self.game)
 
         # Define spaces

--- a/engine/python/tests/test_env.py
+++ b/engine/python/tests/test_env.py
@@ -3,8 +3,7 @@
 import random
 
 import numpy as np
-from pyrat_engine import Direction
-from pyrat_engine.core.game import GameState as PyGameState
+from pyrat_engine import Direction, PyRat
 from pyrat_engine.env import PyRatEnv
 
 TEST_GAME_WIDTH = 5
@@ -132,7 +131,7 @@ def test_custom_maze() -> None:
     """Test environment with custom maze configuration."""
     game_width = 3
     game_height = 3
-    game = PyGameState.create_custom(
+    game = PyRat.create_custom(
         width=game_width,
         height=game_height,
         walls=[

--- a/engine/python/tests/test_import.py
+++ b/engine/python/tests/test_import.py
@@ -4,18 +4,22 @@ from pyrat_engine import Direction, PyRat
 def test_import() -> None:
     # Create game
     game = PyRat(width=15, height=15)
-    print(game.cheese_positions)
+    print(game.cheese_positions())
 
     # Make some moves with undo capability
     undo1 = game.make_move(Direction.RIGHT, Direction.LEFT)
-    print(f"After move 1: P1 at {game.player1_pos}, P2 at {game.player2_pos}")
+    print(f"After move 1: P1 at {game.player1_position}, P2 at {game.player2_position}")
 
     undo2 = game.make_move(Direction.UP, Direction.DOWN)
-    print(f"After move 2: P1 at {game.player1_pos}, P2 at {game.player2_pos}")
+    print(f"After move 2: P1 at {game.player1_position}, P2 at {game.player2_position}")
 
     # Undo moves in reverse order
     game.unmake_move(undo2)
-    print(f"Undid move 2: P1 back to {game.player1_pos}, P2 back to {game.player2_pos}")
+    print(
+        f"Undid move 2: P1 back to {game.player1_position}, P2 back to {game.player2_position}"
+    )
 
     game.unmake_move(undo1)
-    print(f"Undid move 1: P1 back to {game.player1_pos}, P2 back to {game.player2_pos}")
+    print(
+        f"Undid move 1: P1 back to {game.player1_position}, P2 back to {game.player2_position}"
+    )

--- a/engine/python/tests/test_module_structure.py
+++ b/engine/python/tests/test_module_structure.py
@@ -44,9 +44,9 @@ class TestModuleStructure:
 
     def test_game_submodule_imports(self):
         """Test importing from the game submodule."""
-        from pyrat_engine.core.game import GameState, MoveUndo
+        from pyrat_engine.core.game import MoveUndo, PyRat
 
-        assert GameState is not None
+        assert PyRat is not None
         assert MoveUndo is not None
 
     def test_observation_submodule_imports(self):
@@ -69,10 +69,10 @@ class TestModuleStructure:
             Direction,
             GameConfigBuilder,
             GameObservation,
-            GameState,
             MoveUndo,
             Mud,
             ObservationHandler,
+            PyRat,
             Wall,
         )
 
@@ -83,7 +83,7 @@ class TestModuleStructure:
                 Direction,
                 Wall,
                 Mud,
-                GameState,
+                PyRat,
                 MoveUndo,
                 GameObservation,
                 ObservationHandler,
@@ -92,11 +92,9 @@ class TestModuleStructure:
         )
 
     def test_backward_compatibility_names(self):
-        """Test that the Py-prefixed names are still available."""
+        """Test that the Py-prefixed names are still available for some types."""
         from pyrat_engine.core.builder import GameConfigBuilder, PyGameConfigBuilder
-
-        # These should be aliases to the cleaner names
-        from pyrat_engine.core.game import GameState, MoveUndo, PyGameState, PyMoveUndo
+        from pyrat_engine.core.game import MoveUndo, PyMoveUndo, PyRat
         from pyrat_engine.core.observation import (
             GameObservation,
             ObservationHandler,
@@ -104,7 +102,8 @@ class TestModuleStructure:
             PyObservationHandler,
         )
 
-        assert PyGameState is GameState
+        # PyRat is the primary name now (no GameState alias)
+        assert PyRat is not None
         assert PyMoveUndo is MoveUndo
         assert PyGameObservation is GameObservation
         assert PyObservationHandler is ObservationHandler
@@ -167,34 +166,34 @@ class TestTypesFunctionality:
         # For now, just check the type exists
 
 
-class TestGameStateFunctionality:
+class TestPyRatFunctionality:
     """Test that game module classes work correctly."""
 
-    def test_game_state_creation(self):
-        """Test creating GameState objects."""
-        from pyrat_engine.core.game import GameState
+    def test_pyrat_creation(self):
+        """Test creating PyRat objects."""
+        from pyrat_engine import PyRat
 
         # Use odd dimensions to avoid the symmetric maze issue
-        game = GameState(width=11, height=11)
+        game = PyRat(width=11, height=11)
         assert game.width == 11  # noqa: PLR2004
         assert game.height == 11  # noqa: PLR2004
 
-    def test_game_state_preset(self):
-        """Test creating GameState from preset."""
-        from pyrat_engine.core.game import GameState
+    def test_pyrat_preset(self):
+        """Test creating PyRat from preset."""
+        from pyrat_engine import PyRat
 
-        game = GameState.create_preset("tiny", seed=42)
+        game = PyRat.create_preset("tiny", seed=42)
         assert game.width == 11  # noqa: PLR2004
         assert game.height == 9  # noqa: PLR2004
         assert game.max_turns == 150  # noqa: PLR2004
 
     def test_game_state_properties(self):
-        """Test GameState properties return correct types."""
-        from pyrat_engine.core.game import GameState
+        """Test PyRat properties return correct types."""
+        from pyrat_engine import PyRat
         from pyrat_engine.core.types import Coordinates
 
         # Use odd dimensions to avoid the symmetric maze issue
-        game = GameState(width=11, height=11, seed=42)
+        game = PyRat(width=11, height=11, seed=42)
 
         # Position properties should return Coordinates
         pos1 = game.player1_position
@@ -220,9 +219,8 @@ class TestHighLevelAPI:
         from pyrat_engine import PyRat
 
         game = PyRat(width=15, height=15)
-        width, height = game.dimensions
-        assert width == 15  # noqa: PLR2004
-        assert height == 15  # noqa: PLR2004
+        assert game.width == 15  # noqa: PLR2004
+        assert game.height == 15  # noqa: PLR2004
 
     def test_env_import(self):
         """Test that the PettingZoo environment still works."""

--- a/engine/python/tests/test_unified_types.py
+++ b/engine/python/tests/test_unified_types.py
@@ -10,7 +10,7 @@ Tests the new unified type system including:
 # ruff: noqa: PLR2004
 
 import pytest
-from pyrat_engine.core.game import GameState as PyGameState
+from pyrat_engine import PyRat
 from pyrat_engine.core.types import Coordinates, Direction, Mud, Wall
 
 
@@ -235,11 +235,11 @@ class TestTupleInputSupport:
     """Test that tuple input is supported for backward compatibility."""
 
     def test_game_accepts_tuple_walls(self):
-        """Test that PyGameState.create_custom accepts tuple walls."""
+        """Test that PyRat.create_custom accepts tuple walls."""
         # Should be able to pass tuples which get converted to Wall objects
         walls = [((0, 0), (0, 1)), ((1, 1), (2, 1))]
 
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=5,
             height=5,
             walls=walls,
@@ -253,7 +253,7 @@ class TestTupleInputSupport:
         assert game.height == 5
 
     def test_game_accepts_coordinates_walls(self):
-        """Test that PyGameState.create_custom accepts Coordinates-based walls."""
+        """Test that PyRat.create_custom accepts Coordinates-based walls."""
         # Can also pass Wall objects directly
         walls = [
             Wall(Coordinates(0, 0), Coordinates(0, 1)),
@@ -263,7 +263,7 @@ class TestTupleInputSupport:
         # This should fail for now since create_custom expects tuples
         # We'll update this test when we implement the FromPyObject trait
         with pytest.raises(TypeError):
-            PyGameState.create_custom(
+            PyRat.create_custom(
                 width=5, height=5, walls=walls, cheese=[(2, 2)], max_turns=100
             )
 
@@ -271,7 +271,7 @@ class TestTupleInputSupport:
         """Test create_from_maze accepts tuple walls."""
         walls = [((0, 0), (0, 1)), ((1, 1), (2, 1))]
 
-        game = PyGameState.create_from_maze(
+        game = PyRat.create_from_maze(
             width=5, height=5, walls=walls, seed=42, max_turns=100, symmetric=False
         )
 
@@ -299,7 +299,7 @@ class TestIntegrationWithGame:
     def test_game_returns_coordinates(self):
         """Test that game methods return Coordinates objects."""
         # Use even cheese count with even dimensions
-        game = PyGameState(width=10, height=10, cheese_count=6)
+        game = PyRat(width=10, height=10, cheese_count=6)
 
         # Get player positions - should return Coordinates objects
         p1_pos = game.player1_position
@@ -320,7 +320,7 @@ class TestIntegrationWithGame:
     def test_cheese_positions_are_coordinates(self):
         """Test that cheese positions return Coordinates objects."""
         # Use even cheese count with even dimensions
-        game = PyGameState(width=10, height=10, cheese_count=6)
+        game = PyRat(width=10, height=10, cheese_count=6)
 
         cheese_positions = game.cheese_positions()
         assert len(cheese_positions) == 6

--- a/engine/python/tests/test_validation.py
+++ b/engine/python/tests/test_validation.py
@@ -1,7 +1,7 @@
 """Test input validation for PyRat engine."""
 
 import pytest
-from pyrat_engine.core.game import GameState as PyGameState
+from pyrat_engine import PyRat
 
 
 class TestPositionValidation:
@@ -10,7 +10,7 @@ class TestPositionValidation:
     def test_negative_position_cheese(self):
         """Test that negative cheese positions give clear error messages."""
         with pytest.raises(ValueError) as exc_info:
-            PyGameState.create_custom(
+            PyRat.create_custom(
                 width=10,
                 height=10,
                 cheese=[(-1, 0)],
@@ -20,7 +20,7 @@ class TestPositionValidation:
     def test_negative_position_player1(self):
         """Test that negative player1 position gives clear error message."""
         with pytest.raises(ValueError) as exc_info:
-            PyGameState.create_custom(
+            PyRat.create_custom(
                 width=10,
                 height=10,
                 cheese=[(5, 5)],
@@ -31,7 +31,7 @@ class TestPositionValidation:
     def test_negative_position_player2(self):
         """Test that negative player2 position gives clear error message."""
         with pytest.raises(ValueError) as exc_info:
-            PyGameState.create_custom(
+            PyRat.create_custom(
                 width=10,
                 height=10,
                 cheese=[(5, 5)],
@@ -42,7 +42,7 @@ class TestPositionValidation:
     def test_position_too_large(self):
         """Test that positions > 255 give clear error messages."""
         with pytest.raises(ValueError) as exc_info:
-            PyGameState.create_custom(
+            PyRat.create_custom(
                 width=10,
                 height=10,
                 cheese=[(256, 0)],
@@ -54,7 +54,7 @@ class TestPositionValidation:
     def test_position_out_of_bounds(self):
         """Test that out-of-bounds positions give clear error messages."""
         with pytest.raises(ValueError) as exc_info:
-            PyGameState.create_custom(
+            PyRat.create_custom(
                 width=10,
                 height=10,
                 cheese=[(10, 10)],  # Equal to width/height is out of bounds
@@ -70,7 +70,7 @@ class TestWallValidation:
     def test_negative_wall_position(self):
         """Test that negative wall positions give clear error messages."""
         with pytest.raises(ValueError) as exc_info:
-            PyGameState.create_custom(
+            PyRat.create_custom(
                 width=10,
                 height=10,
                 walls=[((-1, 0), (0, 0))],
@@ -81,7 +81,7 @@ class TestWallValidation:
     def test_wall_non_adjacent(self):
         """Test that non-adjacent wall positions give clear error messages."""
         with pytest.raises(ValueError) as exc_info:
-            PyGameState.create_custom(
+            PyRat.create_custom(
                 width=10,
                 height=10,
                 walls=[((0, 0), (2, 0))],  # Not adjacent
@@ -94,7 +94,7 @@ class TestWallValidation:
     def test_duplicate_walls(self):
         """Test that duplicate walls are detected."""
         with pytest.raises(ValueError) as exc_info:
-            PyGameState.create_custom(
+            PyRat.create_custom(
                 width=10,
                 height=10,
                 walls=[
@@ -112,7 +112,7 @@ class TestMudValidation:
     def test_negative_mud_value(self):
         """Test that negative mud values give clear error messages."""
         with pytest.raises(ValueError) as exc_info:
-            PyGameState.create_custom(
+            PyRat.create_custom(
                 width=10,
                 height=10,
                 mud=[((0, 0), (0, 1), -1)],
@@ -123,7 +123,7 @@ class TestMudValidation:
     def test_negative_mud_position(self):
         """Test that negative mud positions give clear error messages."""
         with pytest.raises(ValueError) as exc_info:
-            PyGameState.create_custom(
+            PyRat.create_custom(
                 width=10,
                 height=10,
                 mud=[((-1, 0), (0, 0), 3)],
@@ -134,7 +134,7 @@ class TestMudValidation:
     def test_mud_value_too_small(self):
         """Test that mud value < 2 gives clear error message."""
         with pytest.raises(ValueError) as exc_info:
-            PyGameState.create_custom(
+            PyRat.create_custom(
                 width=10,
                 height=10,
                 mud=[((0, 0), (0, 1), 1)],
@@ -145,7 +145,7 @@ class TestMudValidation:
     def test_mud_value_too_large(self):
         """Test that mud value > 255 gives clear error message."""
         with pytest.raises(ValueError) as exc_info:
-            PyGameState.create_custom(
+            PyRat.create_custom(
                 width=10,
                 height=10,
                 mud=[((0, 0), (0, 1), 256)],
@@ -156,7 +156,7 @@ class TestMudValidation:
     def test_mud_non_adjacent(self):
         """Test that non-adjacent mud positions give clear error messages."""
         with pytest.raises(ValueError) as exc_info:
-            PyGameState.create_custom(
+            PyRat.create_custom(
                 width=10,
                 height=10,
                 mud=[((0, 0), (2, 0), 3)],  # Not adjacent
@@ -170,7 +170,7 @@ class TestMudValidation:
         """Test that walls and mud can coexist (no longer an error)."""
         # This used to be an error, but the semantic fix clarifies that mud exists on passages
         # The maze generator ensures mud only exists on valid connections, not walls
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=10,
             height=10,
             walls=[((0, 0), (0, 1))],
@@ -187,7 +187,7 @@ class TestCheeseValidation:
     def test_empty_cheese_list(self):
         """Test that empty cheese list gives clear error message."""
         with pytest.raises(ValueError) as exc_info:
-            PyGameState.create_custom(
+            PyRat.create_custom(
                 width=10,
                 height=10,
                 cheese=[],
@@ -197,7 +197,7 @@ class TestCheeseValidation:
     def test_duplicate_cheese(self):
         """Test that duplicate cheese positions are detected."""
         with pytest.raises(ValueError) as exc_info:
-            PyGameState.create_custom(
+            PyRat.create_custom(
                 width=10,
                 height=10,
                 cheese=[(5, 5), (5, 5)],
@@ -210,7 +210,7 @@ class TestValidInputs:
 
     def test_valid_game_creation(self):
         """Test that valid game creation works."""
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=10,
             height=10,
             walls=[((0, 0), (0, 1)), ((1, 1), (1, 2))],
@@ -237,7 +237,7 @@ class TestValidInputs:
 
     def test_edge_positions(self):
         """Test that positions at the edges work correctly."""
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=10,
             height=10,
             cheese=[(0, 0), (9, 9), (0, 9), (9, 0)],
@@ -249,7 +249,7 @@ class TestValidInputs:
 
     def test_maximum_mud_value(self):
         """Test that maximum mud value (255) works."""
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=10,
             height=10,
             mud=[((0, 0), (0, 1), 255)],

--- a/engine/python/tests/test_wall_mud_overlap.py
+++ b/engine/python/tests/test_wall_mud_overlap.py
@@ -1,6 +1,6 @@
 """Test that walls and mud never overlap in the game state."""
 
-from pyrat_engine.core.game import GameState as PyGameState
+from pyrat_engine import PyRat
 
 # ruff: noqa: PLR2004
 
@@ -8,7 +8,7 @@ from pyrat_engine.core.game import GameState as PyGameState
 def test_no_wall_mud_overlap_small_maze():
     """Test that walls and mud don't overlap in a small maze."""
     # Test the specific case that was failing: 5x5 with seed=0
-    game = PyGameState(width=5, height=5, cheese_count=5, seed=0)
+    game = PyRat(width=5, height=5, cheese_count=5, seed=0)
 
     walls = game.wall_entries()
     mud = game.mud_entries()
@@ -33,7 +33,7 @@ def test_no_wall_mud_overlap_small_maze():
 
 def test_no_wall_mud_overlap_default_maze():
     """Test that walls and mud don't overlap in a default maze."""
-    game = PyGameState()  # Default 21x15
+    game = PyRat()  # Default 21x15
 
     walls = game.wall_entries()
     mud = game.mud_entries()
@@ -62,7 +62,7 @@ def test_no_wall_mud_overlap_multiple_seeds():
     problematic_seeds = [0, 5, 8, 9, 11, 13, 16, 17, 18]
 
     for seed in problematic_seeds:
-        game = PyGameState(width=5, height=5, cheese_count=5, seed=seed)
+        game = PyRat(width=5, height=5, cheese_count=5, seed=seed)
 
         walls = game.wall_entries()
         mud = game.mud_entries()
@@ -91,13 +91,13 @@ def test_wall_entries_reasonable_count():
     """Test that wall_entries returns a reasonable number of walls."""
     # For a 5x5 maze, there are 40 possible walls (internal connections)
     # A typical maze should have around 10-20 walls
-    game = PyGameState(width=5, height=5, cheese_count=5, seed=0)
+    game = PyRat(width=5, height=5, cheese_count=5, seed=0)
     walls = game.wall_entries()
 
     assert 5 <= len(walls) <= 30, f"Unexpected number of walls: {len(walls)}"
 
     # For default 21x15 maze
-    game = PyGameState()
+    game = PyRat()
     walls = game.wall_entries()
 
     # Maximum possible internal walls: 20*15 + 21*14 = 594
@@ -107,7 +107,7 @@ def test_wall_entries_reasonable_count():
 
 def test_walls_are_between_adjacent_cells():
     """Test that all walls are between adjacent cells."""
-    game = PyGameState(width=5, height=5, cheese_count=5, seed=0)
+    game = PyRat(width=5, height=5, cheese_count=5, seed=0)
     walls = game.wall_entries()
 
     for wall in walls:
@@ -127,7 +127,7 @@ def test_walls_are_between_adjacent_cells():
 
 def test_mud_only_on_passages():
     """Test that mud only exists where there are no walls (i.e., on passages)."""
-    game = PyGameState(width=7, height=7, cheese_count=9, seed=42)
+    game = PyRat(width=7, height=7, cheese_count=9, seed=42)
 
     walls = game.wall_entries()
     mud = game.mud_entries()

--- a/engine/rust/src/bindings/game.rs
+++ b/engine/rust/src/bindings/game.rs
@@ -212,15 +212,15 @@ impl PyMoveUndo {
 }
 
 /// Python-facing PyRat game state
-#[pyclass]
-pub struct PyGameState {
+#[pyclass(name = "PyRat")]
+pub struct PyRat {
     game: GameState,
     observation_handler: ObservationHandler,
     symmetric: bool,
 }
 
 #[pymethods]
-impl PyGameState {
+impl PyRat {
     /// Create a new game state with random generation
     #[new]
     #[pyo3(signature = (
@@ -452,7 +452,7 @@ impl PyGameState {
     // String representation
     fn __repr__(&self) -> String {
         format!(
-            "PyGameState({}x{}, turn={}/{}, p1_score={:.1}, p2_score={:.1})",
+            "PyRat({}x{}, turn={}/{}, p1_score={:.1}, p2_score={:.1})",
             self.game.width(),
             self.game.height(),
             self.game.turns(),
@@ -1021,7 +1021,7 @@ pub struct PyObservationHandler {
 #[pymethods]
 impl PyObservationHandler {
     #[new]
-    fn new(game: &PyGameState) -> Self {
+    fn new(game: &PyRat) -> Self {
         Self {
             inner: ObservationHandler::new(&game.game),
         }
@@ -1035,14 +1035,14 @@ impl PyObservationHandler {
         self.inner.update_collected_cheese(&coords);
     }
 
-    fn refresh_cheese(&mut self, game: &PyGameState) {
+    fn refresh_cheese(&mut self, game: &PyRat) {
         self.inner.refresh_cheese(&game.game);
     }
 
     fn get_observation(
         &self,
         py: Python<'_>,
-        game: &PyGameState,
+        game: &PyRat,
         is_player_one: bool,
     ) -> PyResult<PyGameObservation> {
         let obs = self.inner.get_observation(py, &game.game, is_player_one);
@@ -1270,7 +1270,7 @@ impl PyGameConfigBuilder {
 
     /// Build the game state
     #[pyo3(name = "build")]
-    fn build(&self) -> PyResult<PyGameState> {
+    fn build(&self) -> PyResult<PyRat> {
         // Final validation of the complete configuration
         if self.cheese.is_empty() {
             return Err(PyValueError::new_err("Game must have at least one cheese"));
@@ -1311,7 +1311,7 @@ impl PyGameConfigBuilder {
 
         let observation_handler = ObservationHandler::new(&game);
 
-        Ok(PyGameState {
+        Ok(PyRat {
             game,
             observation_handler,
             symmetric: self.symmetric,
@@ -1330,7 +1330,7 @@ pub(crate) fn register_types(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
 /// Register game submodule
 pub(crate) fn register_game(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_class::<PyGameState>()?;
+    m.add_class::<PyRat>()?;
     m.add_class::<PyMoveUndo>()?;
     Ok(())
 }

--- a/protocol/pyrat_base/CLAUDE.md
+++ b/protocol/pyrat_base/CLAUDE.md
@@ -163,7 +163,7 @@ The protocol package has comprehensive test coverage with 177 tests covering:
 
 - **Threading**: IOHandler uses a background thread for continuous stdin reading
 - **Interruption**: Move calculations can be interrupted by 'stop' command
-- **State Management**: ProtocolState is a thin wrapper around PyGameState
+- **State Management**: ProtocolState is a thin wrapper around PyRat
 - **Coordinate System**: (0,0) is bottom-left, UP increases y
 - **Wall Format**: Walls are tuples of adjacent cells
 - **Mud Mechanics**: Mud value N means N turns to traverse

--- a/protocol/pyrat_base/pyrat_base/base_ai.py
+++ b/protocol/pyrat_base/pyrat_base/base_ai.py
@@ -23,7 +23,7 @@ import sys
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
-from pyrat_engine.core.game import GameState as PyGameState
+from pyrat_engine import PyRat
 from pyrat_engine.core.types import Direction
 
 from pyrat_base.enums import CommandType, GameResult, Player, ResponseType
@@ -68,7 +68,7 @@ class PyRatAI:
         self._io = IOHandler(debug=self.debug)
         self._protocol = Protocol()
         self._state = "INITIAL"
-        self._game_state: Optional[PyGameState] = None
+        self._game_state: Optional[PyRat] = None
         self._player: Optional[Player] = None
         self._options: Dict[str, Any] = {}
         self._time_limits: Dict[str, int] = {
@@ -509,7 +509,7 @@ class PyRatAI:
         if required.issubset(self._game_config.keys()) and self._player:
             # Create the game state
             # Note: symmetric=False because protocol data may not be symmetric
-            self._game_state = PyGameState.create_custom(
+            self._game_state = PyRat.create_custom(
                 width=self._game_config["width"],
                 height=self._game_config["height"],
                 walls=self._game_config["walls"],

--- a/protocol/pyrat_base/pyrat_base/protocol_state.py
+++ b/protocol/pyrat_base/pyrat_base/protocol_state.py
@@ -1,6 +1,6 @@
-"""Protocol-oriented wrapper for PyGameState.
+"""Protocol-oriented wrapper for PyRat game state.
 
-This module provides a thin wrapper around PyGameState that adds player identity
+This module provides a thin wrapper around PyRat that adds player identity
 awareness, allowing AI developers to access game state from their perspective
 (my_position vs opponent_position) while delegating all game logic to the
 underlying Rust implementation.
@@ -9,7 +9,7 @@ underlying Rust implementation.
 
 from typing import TYPE_CHECKING, List, Optional
 
-from pyrat_engine.core.game import GameState as PyGameState
+from pyrat_engine import PyRat
 from pyrat_engine.core.observation import GameObservation as PyGameObservation
 from pyrat_engine.core.types import Coordinates, Direction
 
@@ -22,7 +22,7 @@ from pyrat_base.enums import Player
 class ProtocolState:
     """Ultra-thin wrapper providing protocol-oriented view of game state.
 
-    This class adds player identity awareness to PyGameState, providing
+    This class adds player identity awareness to PyRat, providing
     convenient my/opponent properties while delegating everything else
     to the underlying Rust implementation.
 
@@ -30,23 +30,23 @@ class ProtocolState:
     when accessing multiple player-perspective properties.
 
     Args:
-        game_state: The underlying PyGameState from the Rust engine
+        game_state: The underlying PyRat game instance from the Rust engine
         i_am: Which player this AI is (RAT or PYTHON)
 
     Example:
-        >>> from pyrat_engine import PyGameState
+        >>> from pyrat_engine import PyRat
         >>> from pyrat_base.enums import Player
-        >>> game = PyGameState(width=15, height=15)
+        >>> game = PyRat(width=15, height=15)
         >>> state = ProtocolState(game, Player.RAT)
         >>> print(f"My position: {state.my_position}")
         >>> print(f"Opponent position: {state.opponent_position}")
     """
 
-    def __init__(self, game_state: PyGameState, i_am: Player):
+    def __init__(self, game_state: PyRat, i_am: Player):
         """Initialize the protocol state wrapper.
 
         Args:
-            game_state: The underlying PyGameState instance
+            game_state: The underlying PyRat instance
             i_am: The player identity (RAT or PYTHON)
         """
         self._game = game_state

--- a/protocol/pyrat_base/pyrat_base/replay.py
+++ b/protocol/pyrat_base/pyrat_base/replay.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, TextIO, Tuple, Union
 
-from pyrat_engine.core.game import GameState as PyGameState
+from pyrat_engine import PyRat
 from pyrat_engine.core.types import Coordinates as Position
 from pyrat_engine.core.types import Direction
 from pyrat_engine.game import GameResult
@@ -535,11 +535,11 @@ class ReplayPlayer:
         self.current_turn = 0
         self._move_index = 0
 
-    def _create_game(self) -> PyGameState:
-        """Create game from initial state using PyGameState.create_custom()."""
+    def _create_game(self) -> PyRat:
+        """Create game from initial state using PyRat.create_custom()."""
         state = self.replay.initial_state
 
-        # Convert walls and mud to the format expected by PyGameState
+        # Convert walls and mud to the format expected by PyRat
         walls = state.walls
         mud = [(cells[0], cells[1], value) for cells, value in state.mud]
 
@@ -548,7 +548,7 @@ class ReplayPlayer:
             state.cheese if state.cheese else [(state.width // 2, state.height // 2)]
         )
 
-        return PyGameState.create_custom(
+        return PyRat.create_custom(
             width=state.width,
             height=state.height,
             walls=walls,
@@ -604,7 +604,7 @@ class ReplayPlayer:
                 break
             self.step_forward()
 
-    def get_state(self) -> PyGameState:
+    def get_state(self) -> PyRat:
         """Get current game state."""
         return self.game
 

--- a/protocol/pyrat_base/tests/integration/test_base_ai_large_commands.py
+++ b/protocol/pyrat_base/tests/integration/test_base_ai_large_commands.py
@@ -155,7 +155,7 @@ class TestLargeCommandIntegration:
 
     def test_create_game_with_many_walls(self):
         """Test creating a game state with many walls."""
-        from pyrat_engine.core.game import GameState as PyGameState
+        from pyrat_engine import PyRat
 
         # Create walls (but not too many to avoid performance issues)
         walls = []
@@ -163,7 +163,7 @@ class TestLargeCommandIntegration:
             walls.append(((i, 0), (i, 1)))
 
         # Create game state
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=50,
             height=50,
             walls=walls,

--- a/protocol/pyrat_base/tests/integration/test_dijkstra_puzzles.py
+++ b/protocol/pyrat_base/tests/integration/test_dijkstra_puzzles.py
@@ -6,8 +6,8 @@ makes optimal decisions considering walls, mud, and actual travel time.
 # ruff: noqa: PLR2004
 
 import pytest
+from pyrat_engine import PyRat
 from pyrat_engine.core import Direction
-from pyrat_engine.core.game import GameState as PyGameState
 from pyrat_engine.core.types import Coordinates
 
 from pyrat_base.enums import Player
@@ -28,7 +28,7 @@ def create_game_state():
         player1_pos=(0, 0),
         player2_pos=(4, 4),
     ):
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=width,
             height=height,
             walls=walls or [],
@@ -233,9 +233,9 @@ class TestRandomGames:
     def test_pathfinding_on_random_game(self, seed, width, height, cheese_count):
         """Test pathfinding works correctly on random games."""
         if cheese_count is None:
-            game = PyGameState(width=width, height=height, seed=seed)
+            game = PyRat(width=width, height=height, seed=seed)
         else:
-            game = PyGameState(
+            game = PyRat(
                 width=width, height=height, seed=seed, cheese_count=cheese_count
             )
         state = ProtocolState(game, Player.RAT)

--- a/protocol/pyrat_base/tests/integration/test_direct_validation.py
+++ b/protocol/pyrat_base/tests/integration/test_direct_validation.py
@@ -1,6 +1,6 @@
-"""Test validation directly with PyGameState."""
+"""Test validation directly with PyRat."""
 
-from pyrat_engine.core.game import GameState as PyGameState
+from pyrat_engine import PyRat
 from pyrat_engine.core.types import Coordinates
 
 
@@ -8,7 +8,7 @@ def test_negative_positions():
     """Test that negative positions give clear error messages."""
     # Test negative cheese position
     try:
-        PyGameState.create_custom(
+        PyRat.create_custom(
             width=10,
             height=10,
             cheese=[(-1, 0)],
@@ -20,7 +20,7 @@ def test_negative_positions():
 
     # Test negative player position
     try:
-        PyGameState.create_custom(
+        PyRat.create_custom(
             width=10,
             height=10,
             cheese=[(5, 5)],
@@ -35,7 +35,7 @@ def test_negative_positions():
 def test_negative_mud():
     """Test that negative mud values give clear error messages."""
     try:
-        PyGameState.create_custom(
+        PyRat.create_custom(
             width=10,
             height=10,
             cheese=[(5, 5)],
@@ -50,7 +50,7 @@ def test_negative_mud():
 def test_out_of_bounds():
     """Test that out of bounds positions give clear error messages."""
     try:
-        PyGameState.create_custom(
+        PyRat.create_custom(
             width=10,
             height=10,
             cheese=[(10, 10)],  # Equal to width/height is out of bounds
@@ -63,7 +63,7 @@ def test_out_of_bounds():
 
 def test_valid_creation():
     """Test that valid game creation still works."""
-    game = PyGameState.create_custom(
+    game = PyRat.create_custom(
         width=10,
         height=10,
         walls=[((0, 0), (0, 1)), ((1, 1), (1, 2))],

--- a/protocol/pyrat_base/tests/integration/test_greedy_ai_end_to_end.py
+++ b/protocol/pyrat_base/tests/integration/test_greedy_ai_end_to_end.py
@@ -9,7 +9,7 @@ This test verifies that the greedy AI:
 # ruff: noqa: PLR2004
 
 import pytest
-from pyrat_engine.core.game import GameState as PyGameState
+from pyrat_engine import PyRat
 from pyrat_engine.core.types import Coordinates, Direction
 
 from pyrat_base import ProtocolState
@@ -25,7 +25,7 @@ class DirectAIRunner:
         self.ai = ai_class()
         self.player = player
 
-    def get_move(self, game_state: PyGameState) -> Direction:
+    def get_move(self, game_state: PyRat) -> Direction:
         """Get the AI's move for the current game state."""
         state = ProtocolState(game_state, self.player)
         return self.ai.get_move(state)
@@ -37,7 +37,7 @@ class TestGreedyAIEndToEnd:
     def test_greedy_finds_nearest_cheese_simple_maze(self):
         """Test greedy AI finds and collects the nearest cheese in a simple maze."""
         # Create a simple 5x5 game with cheese at different distances
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=5,
             height=5,
             walls=[],
@@ -80,7 +80,7 @@ class TestGreedyAIEndToEnd:
             ((2, y), (3, y)) for y in range(4)
         ]  # Vertical wall at x=2-3 boundary, gap at y=4
 
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=6,
             height=5,
             walls=walls,
@@ -127,7 +127,7 @@ class TestGreedyAIEndToEnd:
         """Test greedy AI considers mud costs when choosing paths."""
         # Create scenario where direct path has heavy mud
         # and longer path is faster
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=6,
             height=3,
             walls=[],
@@ -150,7 +150,7 @@ class TestGreedyAIEndToEnd:
     def test_greedy_vs_dummy_full_game(self):
         """Test greedy AI beats dummy AI in a full game."""
         # Create a standard game
-        game = PyGameState(width=11, height=9, seed=12345, cheese_count=5)
+        game = PyRat(width=11, height=9, seed=12345, cheese_count=5)
 
         greedy = DirectAIRunner(GreedyAI, Player.RAT)
         dummy = DirectAIRunner(DummyAI, Player.PYTHON)
@@ -185,7 +185,7 @@ class TestGreedyAIEndToEnd:
         This is a regression test for the command-dropping bug where
         game state would desync.
         """
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=7,
             height=7,
             walls=[],
@@ -234,7 +234,7 @@ class TestGreedyAIEndToEnd:
     @pytest.mark.parametrize("seed", [12345, 54321, 99999, 11111])
     def test_greedy_on_random_mazes(self, seed):
         """Test greedy AI performs well on various random mazes."""
-        game = PyGameState(width=15, height=11, seed=seed, cheese_count=10)
+        game = PyRat(width=15, height=11, seed=seed, cheese_count=10)
 
         greedy = DirectAIRunner(GreedyAI, Player.RAT)
 
@@ -256,7 +256,7 @@ class TestGreedyAIEndToEnd:
 
     def test_greedy_recalculates_when_cheese_collected(self):
         """Test greedy AI updates its target when cheese is collected."""
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=5,
             height=5,
             walls=[],
@@ -299,7 +299,7 @@ class TestGreedyAIEndToEnd:
 
     def test_greedy_handles_simultaneous_collection(self):
         """Test greedy AI handles simultaneous cheese collection correctly."""
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=3,
             height=1,
             walls=[],
@@ -345,7 +345,7 @@ class TestGreedyVsGreedy:
         - Turn 2: Both reach (2,0) simultaneously
         - Final: Rat=1.5, Python=1.5
         """
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=5,
             height=1,
             walls=[],
@@ -407,7 +407,7 @@ class TestGreedyVsGreedy:
         - Turn 2: Rat collects (2,0), Python still moving
         - Final: Rat=2.0, Python=0.0
         """
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=7,
             height=1,
             walls=[],
@@ -467,7 +467,7 @@ class TestGreedyVsGreedy:
         - Python goes direct LEFT (2 moves)
         - Python wins
         """
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=5,
             height=3,
             walls=[],
@@ -532,7 +532,7 @@ class TestGreedyVsGreedy:
         - Both AIs see same cheese list
         - Total cheese collected equals initial count
         """
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=7,
             height=7,
             walls=[],
@@ -622,7 +622,7 @@ class TestGreedyVsGreedy:
         # Create vertical wall blocking middle, with gap at top
         walls = [((3, y), (4, y)) for y in range(4)]  # Wall from y=0 to y=3
 
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=7,
             height=5,
             walls=walls,

--- a/protocol/pyrat_base/tests/integration/test_integration_ai_examples.py
+++ b/protocol/pyrat_base/tests/integration/test_integration_ai_examples.py
@@ -156,10 +156,10 @@ async def test_ai_with_small_maze():
 @pytest.mark.asyncio
 async def test_ai_with_large_maze():
     """Test AIs can handle a large maze with many walls."""
-    from pyrat_engine.core.game import GameState as PyGameState
+    from pyrat_engine import PyRat
 
     # Create a real game to get realistic wall data
-    game = PyGameState(width=21, height=15)
+    game = PyRat(width=21, height=15)
     walls = game.wall_entries()
 
     # Format walls for protocol (Wall objects have pos1, pos2 attributes)

--- a/protocol/pyrat_base/tests/integration/test_protocol_state.py
+++ b/protocol/pyrat_base/tests/integration/test_protocol_state.py
@@ -3,16 +3,16 @@
 
 import numpy as np
 import pytest
+from pyrat_engine import PyRat
 from pyrat_engine.core import Direction
 from pyrat_engine.core.builder import GameConfigBuilder as PyGameConfigBuilder
-from pyrat_engine.core.game import GameState as PyGameState
 from pyrat_engine.core.types import Coordinates
 
 from pyrat_base import Player, ProtocolState
 
 
 @pytest.fixture
-def simple_game() -> PyGameState:
+def simple_game() -> PyRat:
     """Create a simple 5x5 game for testing."""
     return (
         PyGameConfigBuilder(5, 5)
@@ -44,7 +44,7 @@ class TestProtocolState:
         assert state_python._observation is None
 
     def test_direct_passthrough_properties(self, simple_game):
-        """Test properties that pass through directly to PyGameState."""
+        """Test properties that pass through directly to PyRat."""
         game = simple_game
         state = ProtocolState(game, Player.RAT)
 

--- a/protocol/pyrat_base/tests/unit/test_base_ai_protocol_bugs.py
+++ b/protocol/pyrat_base/tests/unit/test_base_ai_protocol_bugs.py
@@ -139,7 +139,7 @@ class TestProtocolBugFixes:
         Fix: MOVES commands are re-queued and processed after calculation.
         """
         # This test demonstrates the impact of the bug using a simple example
-        # We don't need full PyGameState for this - just show the concept
+        # We don't need full PyRat for this - just show the concept
 
         # Simulate game state update
         class SimpleGameState:

--- a/protocol/pyrat_base/tests/unit/test_utils.py
+++ b/protocol/pyrat_base/tests/unit/test_utils.py
@@ -1,7 +1,7 @@
 """Tests for utility functions in pyrat_base.utils."""
 
+from pyrat_engine import PyRat
 from pyrat_engine.core import Direction
-from pyrat_engine.core.game import GameState as PyGameState
 from pyrat_engine.core.types import Coordinates
 
 from pyrat_base import Player, ProtocolState, utils
@@ -40,7 +40,7 @@ class TestPathfinding:
     def test_dijkstra_simple_path(self):
         """Test Dijkstra on a simple maze without mud."""
         # Create a 5x5 maze with no walls or mud
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=5,
             height=5,
             walls=[],
@@ -71,7 +71,7 @@ class TestPathfinding:
         """Test Dijkstra finding path around walls."""
         # Create a maze with walls blocking the direct horizontal path
         # We'll create a partial barrier that forces going around
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=5,
             height=3,
             walls=[
@@ -112,7 +112,7 @@ class TestPathfinding:
     def test_dijkstra_with_mud(self):
         """Test Dijkstra choosing longer path to avoid mud."""
         # Create a maze where direct path has mud
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=5,
             height=5,
             walls=[],
@@ -153,7 +153,7 @@ class TestPathfinding:
         """Test Dijkstra when no path exists."""
         # Create a maze with complete wall barrier
         # To create a vertical barrier at x=2, we need walls between x=1 and x=2
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=5,
             height=5,
             walls=[
@@ -180,7 +180,7 @@ class TestPathfinding:
 
     def test_dijkstra_same_position(self):
         """Test Dijkstra when start equals goal."""
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=5, height=5, walls=[], mud=[], cheese=[(2, 2)], symmetric=False
         )
         state = ProtocolState(game, Player.RAT)
@@ -193,7 +193,7 @@ class TestPathfinding:
     def test_find_nearest_cheese_by_time_simple(self):
         """Test finding nearest cheese by time in simple maze."""
         # Place multiple cheese at different distances
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=5,
             height=5,
             walls=[],
@@ -217,7 +217,7 @@ class TestPathfinding:
     def test_find_nearest_cheese_by_time_with_mud(self):
         """Test finding nearest cheese considering mud delays."""
         # Create scenario where closer cheese has mud
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=7,
             height=3,
             walls=[],
@@ -247,7 +247,7 @@ class TestPathfinding:
     def test_find_nearest_cheese_by_time_complex(self):
         """Test finding nearest cheese in complex maze."""
         # Create a maze where direct paths are blocked
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=5,
             height=5,
             walls=[
@@ -287,9 +287,9 @@ class TestPathfinding:
 
     def test_find_nearest_cheese_no_cheese(self):
         """Test finding cheese when none exist."""
-        # PyGameState requires at least one cheese, so we'll place one
+        # PyRat requires at least one cheese, so we'll place one
         # but then manually clear it to test the no-cheese case
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=5,
             height=5,
             walls=[],
@@ -316,7 +316,7 @@ class TestPathfinding:
     def test_find_nearest_cheese_unreachable(self):
         """Test finding cheese when all are unreachable."""
         # Create maze with cheese behind walls
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=5,
             height=5,
             walls=[
@@ -339,7 +339,7 @@ class TestPathfinding:
 
     def test_get_direction_toward_target(self):
         """Test getting direction toward target using pathfinding."""
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=5,
             height=5,
             walls=[
@@ -361,7 +361,7 @@ class TestPathfinding:
     def test_mud_cost_calculation(self):
         """Test that mud costs are calculated correctly."""
         # Create a path that must go through mud
-        game = PyGameState.create_custom(
+        game = PyRat.create_custom(
             width=3,
             height=1,
             walls=[],


### PR DESCRIPTION
…at (E-003)

Remove the Python PyRat wrapper class and expose the Rust binding directly as the primary interface named PyRat. This eliminates the redundant dual API surface (PyRat wrapper vs GameState Rust binding).

Breaking changes:
- Remove GameState alias - use PyRat directly
- player1_pos/player2_pos → player1_position/player2_position
- scores tuple → player1_score/player2_score (separate properties)
- dimensions tuple → width/height (separate properties)
- cheese_positions property → cheese_positions() method
- mud_positions dict → mud_entries() method
- step() returns tuple[bool, list[Coordinates]] instead of GameResult

🤖 Generated with [Claude Code](https://claude.com/claude-code)

