### PR TITLE
feat(engine): add wall_density and mud_density params to PyRat

### DIFF
--- a/engine/python/tests/test_game.py
+++ b/engine/python/tests/test_game.py
@@ -56,6 +56,92 @@ class TestEnhancedConstructor:
         assert len(game.cheese_positions()) == 21
 
 
+class TestDensityParameters:
+    """Test wall_density and mud_density parameters."""
+
+    def test_zero_wall_density_creates_open_maze(self):
+        """wall_density=0.0 should create a maze with no walls."""
+        game = PyRat(width=11, height=11, cheese_count=10, wall_density=0.0, seed=42)
+        walls = game.wall_entries()
+        assert len(walls) == 0
+
+    def test_zero_mud_density_creates_no_mud(self):
+        """mud_density=0.0 should create a maze with no mud."""
+        game = PyRat(width=11, height=11, cheese_count=10, mud_density=0.0, seed=42)
+        mud = game.mud_entries()
+        assert len(mud) == 0
+
+    def test_open_maze_with_random_cheese(self):
+        """The main use case: open maze with random symmetric cheese."""
+        game = PyRat(
+            width=5,
+            height=5,
+            cheese_count=5,
+            wall_density=0.0,
+            mud_density=0.0,
+            seed=42,
+        )
+        assert len(game.wall_entries()) == 0
+        assert len(game.mud_entries()) == 0
+        assert len(game.cheese_positions()) == 5
+
+    def test_high_wall_density_creates_more_walls(self):
+        """Higher wall_density should create more walls."""
+        game_low = PyRat(
+            width=15, height=15, cheese_count=10, wall_density=0.3, seed=42
+        )
+        game_high = PyRat(
+            width=15, height=15, cheese_count=10, wall_density=0.9, seed=42
+        )
+
+        walls_low = len(game_low.wall_entries())
+        walls_high = len(game_high.wall_entries())
+
+        assert walls_high > walls_low
+
+    def test_high_mud_density_creates_more_mud(self):
+        """Higher mud_density should create more mud passages."""
+        game_low = PyRat(width=15, height=15, cheese_count=10, mud_density=0.1, seed=42)
+        game_high = PyRat(
+            width=15, height=15, cheese_count=10, mud_density=0.8, seed=42
+        )
+
+        mud_low = len(game_low.mud_entries())
+        mud_high = len(game_high.mud_entries())
+
+        assert mud_high > mud_low
+
+    def test_default_density_unchanged(self):
+        """Games without density params should use defaults (0.7 walls, 0.1 mud)."""
+        game_default = PyRat(width=15, height=15, cheese_count=10, seed=42)
+        game_explicit = PyRat(
+            width=15,
+            height=15,
+            cheese_count=10,
+            wall_density=0.7,
+            mud_density=0.1,
+            seed=42,
+        )
+
+        # Same seed + same density = same maze
+        assert len(game_default.wall_entries()) == len(game_explicit.wall_entries())
+        assert len(game_default.mud_entries()) == len(game_explicit.mud_entries())
+
+    def test_density_with_asymmetric(self):
+        """Density parameters should work with asymmetric games."""
+        game = PyRat(
+            width=11,
+            height=11,
+            cheese_count=10,
+            symmetric=False,
+            wall_density=0.0,
+            mud_density=0.0,
+            seed=42,
+        )
+        assert len(game.wall_entries()) == 0
+        assert len(game.mud_entries()) == 0
+
+
 class TestPresets:
     """Test the preset system."""
 

--- a/engine/rust/benches/bin/profile.rs
+++ b/engine/rust/benches/bin/profile.rs
@@ -35,6 +35,8 @@ fn main() {
         Some(15),
         Some(41),
         Some(42), // Fixed seed for reproducibility
+        None,
+        None,
     );
 
     // Pre-generate random moves

--- a/engine/rust/benches/bin/profile_process_turn.rs
+++ b/engine/rust/benches/bin/profile_process_turn.rs
@@ -19,6 +19,8 @@ fn main() {
             Some(16),
             Some(40), // Realistic cheese count
             Some(42), // Same seed each time
+            None,
+            None,
         );
 
         let mut move_idx = 0;

--- a/engine/rust/benches/game_benchmarks.rs
+++ b/engine/rust/benches/game_benchmarks.rs
@@ -181,6 +181,8 @@ fn bench_full_game(c: &mut Criterion) {
                         Some(size),
                         Some(((size as u16 * size as u16) as f32 * CHEESE_DENSITY) as u16), // Use 25% of cells for cheese
                         Some(random::<u64>()), // New random seed each time
+                        None,
+                        None,
                     )
                 },
                 |mut game| {

--- a/engine/rust/benches/profile_lib.rs
+++ b/engine/rust/benches/profile_lib.rs
@@ -66,6 +66,8 @@ pub fn run_profiling(config: ProfilingConfig) -> ProfilingStats {
                 Some(config.height),
                 Some(config.cheese_count),
                 Some(seed),
+                None,
+                None,
             )
         } else {
             GameState::new_asymmetric(
@@ -73,6 +75,8 @@ pub fn run_profiling(config: ProfilingConfig) -> ProfilingStats {
                 Some(config.height),
                 Some(config.cheese_count),
                 Some(seed),
+                None,
+                None,
             )
         };
 

--- a/engine/rust/src/bindings/game.rs
+++ b/engine/rust/src/bindings/game.rs
@@ -229,8 +229,11 @@ impl PyRat {
         cheese_count=None,
         symmetric=true,
         seed=None,
-        max_turns=None
+        max_turns=None,
+        wall_density=None,
+        mud_density=None
     ))]
+    #[allow(clippy::too_many_arguments)]
     fn new(
         width: Option<u8>,
         height: Option<u8>,
@@ -238,11 +241,13 @@ impl PyRat {
         symmetric: bool,
         seed: Option<u64>,
         max_turns: Option<u16>,
+        wall_density: Option<f32>,
+        mud_density: Option<f32>,
     ) -> Self {
         let mut game = if symmetric {
-            GameState::new_symmetric(width, height, cheese_count, seed)
+            GameState::new_symmetric(width, height, cheese_count, seed, wall_density, mud_density)
         } else {
-            GameState::new_asymmetric(width, height, cheese_count, seed)
+            GameState::new_asymmetric(width, height, cheese_count, seed, wall_density, mud_density)
         };
 
         // Override max_turns if provided
@@ -477,6 +482,8 @@ impl PyRat {
                 Some(self.game.height()),
                 Some(self.game.total_cheese()),
                 seed,
+                None,
+                None,
             )
         } else {
             GameState::new_asymmetric(
@@ -484,6 +491,8 @@ impl PyRat {
                 Some(self.game.height()),
                 Some(self.game.total_cheese()),
                 seed,
+                None,
+                None,
             )
         };
         // Need full refresh after reset

--- a/engine/rust/src/game/observations.rs
+++ b/engine/rust/src/game/observations.rs
@@ -226,7 +226,7 @@ mod tests {
 
     #[test]
     fn test_observation_refresh() {
-        let game = GameState::new_symmetric(Some(4), Some(4), Some(2), Some(42));
+        let game = GameState::new_symmetric(Some(4), Some(4), Some(2), Some(42), None, None);
         let mut handler = ObservationHandler::new(&game);
 
         // Clear all cheese


### PR DESCRIPTION
## Summary

- Add `wall_density` (0.0-1.0) and `mud_density` (0.0-1.0) parameters to the `PyRat()` constructor
- Enables control over maze complexity while keeping random symmetric cheese placement
- Defaults unchanged (0.7 wall density, 0.1 mud density)

**Example usage:**
```python
# Open maze with random cheese placement
PyRat(width=5, height=5, cheese_count=5, wall_density=0.0, mud_density=0.0, seed=42)
```

## Test plan

- [x] Rust unit tests for density parameters (2 new tests)
- [x] Python integration tests for density parameters (7 new tests)
- [x] Verify default behavior unchanged
- [x] Verify works with `symmetric=False`

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)