### PR TITLE
feat(engine): add effective_actions API for MCTS action equivalence

### DIFF
--- a/engine/rust/src/bindings/game.rs
+++ b/engine/rust/src/bindings/game.rs
@@ -364,6 +364,49 @@ impl PyRat {
         Ok(valid)
     }
 
+    /// Get effective actions for a position (ignores mud state).
+    ///
+    /// Returns a list of 5 integers where result[action] = effective_action.
+    /// Blocked actions (walls, boundaries) map to STAY (4).
+    /// Valid actions map to themselves.
+    ///
+    /// Direction values: UP=0, RIGHT=1, DOWN=2, LEFT=3, STAY=4
+    ///
+    /// Example: at corner (0,0) with no walls
+    ///   [0, 1, 4, 4, 4]  # UP=valid, RIGHT=valid, DOWN→STAY, LEFT→STAY, STAY→STAY
+    fn effective_actions(&self, pos: CoordinatesInput) -> PyResult<[u8; 5]> {
+        let coords: Coordinates = PyResult::<Coordinates>::from(pos)?;
+
+        // Bounds check
+        if coords.x >= self.game.width() || coords.y >= self.game.height() {
+            return Err(PyValueError::new_err(format!(
+                "Position ({}, {}) is outside board bounds ({}x{})",
+                coords.x,
+                coords.y,
+                self.game.width(),
+                self.game.height()
+            )));
+        }
+
+        Ok(self.game.effective_actions_at(coords))
+    }
+
+    /// Get effective actions for player 1, accounting for mud state.
+    ///
+    /// If player 1 is in mud, all actions map to STAY [4, 4, 4, 4, 4].
+    /// Otherwise, returns effective actions based on player 1's position.
+    fn effective_actions_p1(&self) -> [u8; 5] {
+        self.game.effective_actions_p1()
+    }
+
+    /// Get effective actions for player 2, accounting for mud state.
+    ///
+    /// If player 2 is in mud, all actions map to STAY [4, 4, 4, 4, 4].
+    /// Otherwise, returns effective actions based on player 2's position.
+    fn effective_actions_p2(&self) -> [u8; 5] {
+        self.game.effective_actions_p2()
+    }
+
     fn mud_entries(&self) -> Vec<crate::Mud> {
         self.game
             .mud_positions()


### PR DESCRIPTION
## Summary

- Add `effective_actions(pos)` method that maps each of 5 actions to their effective outcome
- Add `effective_actions_p1()` and `effective_actions_p2()` methods that account for mud state
- Blocked actions (walls, boundaries) map to STAY, enabling MCTS to identify equivalent actions

## API

```python
from pyrat_engine import PyRat, Direction

game = PyRat.create_preset("empty", seed=42)

# Position-based (ignores mud)
result = game.effective_actions((0, 0))
# [0, 1, 4, 4, 4] = UP valid, RIGHT valid, DOWN→STAY, LEFT→STAY

# Player methods (account for mud)
game.effective_actions_p1()  # Based on player 1 position + mud state
game.effective_actions_p2()  # Based on player 2 position + mud state

# When player is in mud, all actions map to STAY
# [4, 4, 4, 4, 4]
```

## Test plan

- [x] Rust unit tests for corner, center, wall, and mud cases
- [x] Python tests for all edge cases including mud state
- [x] Consistency test with existing `get_valid_moves()` API

Closes #101