### PR TITLE
docs(engine): fix Python API documentation gaps

### DIFF
--- a/engine/python/pyrat_engine/core/game.pyi
+++ b/engine/python/pyrat_engine/core/game.pyi
@@ -91,6 +91,8 @@ class PyRat:
         symmetric: Whether to generate symmetric mazes (default: True)
         seed: Random seed for reproducible games (default: None)
         max_turns: Maximum number of turns before game ends (default: 300)
+        wall_density: Proportion of walls in the maze, 0.0 to 1.0 (default: 0.7)
+        mud_density: Proportion of passages with mud, 0.0 to 1.0 (default: 0.1)
     """
     def __init__(
         self,
@@ -100,6 +102,8 @@ class PyRat:
         symmetric: bool = True,
         seed: int | None = None,
         max_turns: int | None = None,
+        wall_density: float | None = None,
+        mud_density: float | None = None,
     ) -> None: ...
     @staticmethod
     def create_preset(


### PR DESCRIPTION
## Summary

- **Restructure README Usage section** — lead with `PyRat` (the primary API), move `PyRatEnv` to a dedicated "Reinforcement Learning" subsection with correct import path. Removes stale TODO comment. Closes #103.
- **Document `movement_matrix` format** — add shape `(width, height, 4)`, direction ordering, and value encoding (`-1` wall, `0` valid, `N>0` mud). Closes #106.
- **Add `wall_density` and `mud_density`** — include both params in the `.pyi` stub (`__init__` signature + docstring) and the README constructor example. Closes #111.

## Test plan

- [x] `from pyrat_engine import PyRat, Direction` works
- [x] `from pyrat_engine.env import PyRatEnv` works
- [x] `PyRat(wall_density=0.5, mud_density=0.2)` works
- [x] All pre-commit hooks and tests pass