### PR TITLE
refactor(engine): remove Deref<HashMap> impl from MudMap

### DIFF
--- a/engine/rust/benches/game_benchmarks.rs
+++ b/engine/rust/benches/game_benchmarks.rs
@@ -1,4 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use pyrat::game::types::MudMap;
 use pyrat::{Coordinates, Direction, GameState};
 use rand::{random, Rng};
 use std::collections::HashMap;
@@ -398,9 +399,9 @@ fn bench_process_moves_mud_movement(c: &mut Criterion) {
         for &direction in &directions {
             for &mud_timer in &MUD_TIMER_RANGE {
                 // Create mud in the direction of movement
-                let mut mud = std::collections::HashMap::new();
+                let mut mud = MudMap::new();
                 let mud_pos = direction.apply_to(start_pos);
-                mud.insert((start_pos, mud_pos), mud_timer);
+                mud.insert(start_pos, mud_pos, mud_timer);
 
                 let game_state = GameState::new_with_config(
                     size,

--- a/engine/rust/src/bindings/game.rs
+++ b/engine/rust/src/bindings/game.rs
@@ -2,6 +2,7 @@
 use crate::game::game_logic::MoveUndo;
 use crate::game::observations::ObservationHandler;
 use crate::game::types::CoordinatesInput;
+use crate::game::types::MudMap;
 use crate::{Coordinates, Direction, GameState, Wall};
 use numpy::{PyArray2, PyArray3};
 use pyo3::exceptions::PyValueError;
@@ -860,7 +861,7 @@ impl PyRat {
             width,
             height,
             walls_map,
-            HashMap::new(), // No mud
+            MudMap::new(), // No mud
             &cheese_positions,
             Coordinates { x: 0, y: 0 }, // Default player 1 position
             Coordinates {
@@ -954,7 +955,7 @@ impl PyRat {
             width,
             height,
             walls_map,
-            HashMap::new(),
+            MudMap::new(),
             &cheese_positions,
             p1_pos,
             p2_pos,
@@ -1041,7 +1042,7 @@ impl PyRat {
             width,
             height,
             walls,
-            (*mud).clone(),
+            mud,
             &cheese_positions,
             Coordinates {
                 x: p1_pos.0,
@@ -1406,11 +1407,10 @@ impl PyGameConfigBuilder {
                 .push(wall.pos1);
         }
 
-        // Convert mud to HashMap
-        let mut mud_map = HashMap::new();
+        // Convert mud to MudMap
+        let mut mud_map = MudMap::new();
         for m in &self.mud {
-            mud_map.insert((m.pos1, m.pos2), m.value);
-            mud_map.insert((m.pos2, m.pos1), m.value); // Make mud symmetric
+            mud_map.insert(m.pos1, m.pos2, m.value);
         }
 
         // Create game state

--- a/engine/rust/src/game/game_logic.rs
+++ b/engine/rust/src/game/game_logic.rs
@@ -158,7 +158,7 @@ impl GameState {
         width: u8,
         height: u8,
         walls: HashMap<Coordinates, Vec<Coordinates>>,
-        mud: HashMap<(Coordinates, Coordinates), u8>,
+        mud: MudMap,
         cheese_positions: &[Coordinates],
         player1_pos: Coordinates,
         player2_pos: Coordinates,
@@ -167,10 +167,7 @@ impl GameState {
         let mut game =
             Self::new_with_positions(width, height, walls, max_turns, player1_pos, player2_pos);
 
-        // Add mud - convert from HashMap to MudMap
-        for ((pos1, pos2), value) in mud {
-            game.mud.insert(pos1, pos2, value);
-        }
+        game.mud = mud;
 
         // Add cheese
         for &pos in cheese_positions {
@@ -804,8 +801,8 @@ mod tests {
         let mut walls = HashMap::new();
         walls.insert(Coordinates::new(0, 0), vec![Coordinates::new(1, 0)]);
 
-        let mut mud = HashMap::new();
-        mud.insert((Coordinates::new(1, 1), Coordinates::new(1, 2)), 2);
+        let mut mud = MudMap::new();
+        mud.insert(Coordinates::new(1, 1), Coordinates::new(1, 2), 2);
 
         let cheese_positions = vec![Coordinates::new(1, 1), Coordinates::new(2, 2)];
 
@@ -826,7 +823,7 @@ mod tests {
         assert_eq!(game.cheese.total_cheese(), 2);
         assert!(game
             .mud
-            .contains_key(&(Coordinates::new(1, 1), Coordinates::new(1, 2))));
+            .contains(Coordinates::new(1, 1), Coordinates::new(1, 2)));
         assert_eq!(game.mud.len(), 1);
     }
     #[test]

--- a/engine/rust/src/game/types.rs
+++ b/engine/rust/src/game/types.rs
@@ -252,13 +252,10 @@ impl MudMap {
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
-}
 
-impl std::ops::Deref for MudMap {
-    type Target = HashMap<(Coordinates, Coordinates), u8>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
+    /// Check if mud exists between two positions (order doesn't matter)
+    pub fn contains(&self, pos1: Coordinates, pos2: Coordinates) -> bool {
+        self.inner.contains_key(&(pos1, pos2)) || self.inner.contains_key(&(pos2, pos1))
     }
 }
 


### PR DESCRIPTION
## Summary
- Remove `Deref<Target=HashMap>` from `MudMap` — callers can no longer bypass the bidirectional-insert API via raw HashMap methods
- Add `MudMap::contains(pos1, pos2)` method to replace `.contains_key()` usage that went through Deref
- Change `new_with_config` to accept `MudMap` directly instead of `HashMap`, removing the conversion loop
- Update all call sites in bindings (`create_with_starts`, `create_from_maze`, `create_from_walls`, `PyGameConfigBuilder::build`) and benchmarks

## Test plan
- [x] `cargo test --lib --no-default-features` — 66 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] All pre-commit and pre-push hooks pass (including pytest)
- [x] `cargo bench --no-default-features -- mud` — no regression