### PR TITLE
feat(engine): make `check_game_over` public on `GameState`

### DIFF
--- a/engine/rust/src/game/game_logic.rs
+++ b/engine/rust/src/game/game_logic.rs
@@ -577,7 +577,14 @@ impl GameState {
         collected
     }
 
-    fn check_game_over(&self) -> bool {
+    /// Check if the game is over.
+    ///
+    /// Returns `true` when any terminal condition is met:
+    /// 1. A player scored more than half the total cheese
+    /// 2. All cheese has been collected
+    /// 3. Maximum turns reached
+    #[must_use]
+    pub fn check_game_over(&self) -> bool {
         // Check win conditions:
         // 1. Player scored more than half the total cheese (not remaining)
         let total_cheese = f32::from(self.cheese.total_cheese());


### PR DESCRIPTION
## Summary

- Makes `GameState::check_game_over` public so external code (e.g. MCTS search) can check terminal conditions without reimplementing game-over logic

Closes #123

## Test plan

- [x] `cargo test --lib --no-default-features` — all 66 tests pass
- [x] `cargo clippy --no-default-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Pre-commit hooks pass (fmt, clippy, pytest)