### PR TITLE
feat(engine): expose PyRat accessors for cross-crate bindings

### DIFF
--- a/engine/rust/src/bindings/game.rs
+++ b/engine/rust/src/bindings/game.rs
@@ -1064,6 +1064,26 @@ impl PyRat {
     }
 }
 
+/// Rust-only accessors for cross-crate use (not exposed to Python)
+impl PyRat {
+    /// Borrow the inner `GameState`.
+    pub fn game_state(&self) -> &GameState {
+        &self.game
+    }
+
+    /// Wrap an existing `GameState` into a `PyRat`.
+    ///
+    /// `symmetric` controls how `reset()` regenerates the maze.
+    pub fn from_game_state(game: GameState, symmetric: bool) -> Self {
+        let observation_handler = ObservationHandler::new(&game);
+        Self {
+            game,
+            observation_handler,
+            symmetric,
+        }
+    }
+}
+
 #[pyclass]
 pub struct PyGameObservation {
     player_position: Coordinates,
@@ -1437,7 +1457,7 @@ impl PyGameConfigBuilder {
 }
 
 /// Register types submodule
-pub(crate) fn register_types(m: &Bound<'_, PyModule>) -> PyResult<()> {
+pub fn register_types(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Coordinates>()?;
     // Direction is now a Python IntEnum defined in types.py, not exposed from Rust
     m.add_class::<crate::Wall>()?;
@@ -1446,21 +1466,21 @@ pub(crate) fn register_types(m: &Bound<'_, PyModule>) -> PyResult<()> {
 }
 
 /// Register game submodule
-pub(crate) fn register_game(m: &Bound<'_, PyModule>) -> PyResult<()> {
+pub fn register_game(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyRat>()?;
     m.add_class::<PyMoveUndo>()?;
     Ok(())
 }
 
 /// Register observation submodule
-pub(crate) fn register_observation(m: &Bound<'_, PyModule>) -> PyResult<()> {
+pub fn register_observation(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyGameObservation>()?;
     m.add_class::<PyObservationHandler>()?;
     Ok(())
 }
 
 /// Register builder submodule
-pub(crate) fn register_builder(m: &Bound<'_, PyModule>) -> PyResult<()> {
+pub fn register_builder(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyGameConfigBuilder>()?;
     Ok(())
 }

--- a/engine/rust/src/bindings/mod.rs
+++ b/engine/rust/src/bindings/mod.rs
@@ -1,27 +1,27 @@
 //! Python bindings for the `PyRat` engine
 #![allow(clippy::missing_const_for_fn)] // Disable const fn warnings globally for bindings
-mod game;
+pub mod game;
 mod validation;
 
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
 
-pub(crate) fn register_types_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
+pub fn register_types_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     game::register_types(m)?;
     Ok(())
 }
 
-pub(crate) fn register_game_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
+pub fn register_game_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     game::register_game(m)?;
     Ok(())
 }
 
-pub(crate) fn register_observation_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
+pub fn register_observation_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     game::register_observation(m)?;
     Ok(())
 }
 
-pub(crate) fn register_builder_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
+pub fn register_builder_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     game::register_builder(m)?;
     Ok(())
 }

--- a/engine/rust/src/lib.rs
+++ b/engine/rust/src/lib.rs
@@ -10,10 +10,12 @@
 
 pub mod bench_scenarios;
 #[cfg(feature = "python")]
-mod bindings;
+pub mod bindings;
 pub mod game;
 
 // Re-export commonly used items for Rust users
+#[cfg(feature = "python")]
+pub use bindings::game::PyRat;
 pub use game::{
     board::MoveTable,
     cheese_board::CheeseBoard,


### PR DESCRIPTION
## Summary

- Make `bindings` module and its `game` submodule public so downstream crates can access `PyRat`
- Add Rust-only `game_state()` and `from_game_state()` on `PyRat` (not exposed to Python)
- Widen `pub(crate)` → `pub` on register functions and module-level fns to match new visibility

Enables alpharat-mcts (and other Rust consumers) to extract `&GameState` from a `PyRat` and wrap leaf `GameState` objects back into `PyRat`.

## Test plan

- [x] `cargo test --lib --no-default-features` — 66 tests pass
- [x] `cargo clippy --all-targets --all-features` — clean
- [x] `cargo clippy --all-targets --no-default-features` — clean
- [x] `pytest python/tests -v` — 185 tests pass
- [x] Pre-commit and pre-push hooks pass