### PR TITLE
chore(engine): upgrade ndarray from 0.15 to 0.16

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -389,14 +389,16 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.15.6"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
 dependencies = [
  "matrixmultiply",
  "num-complex",
  "num-integer",
  "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
  "rawpointer",
 ]
 
@@ -498,6 +500,15 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "pretty_assertions"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ rand = "0.10"
 pyo3 = { version = "0.25", features = ["extension-module"], optional = true }
 numpy = { version = "0.25", optional = true }
 serde = { version = "1.0.214", features = ["derive"] }
-ndarray = { version = "0.15", optional = true }
+ndarray = { version = "0.16", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }


### PR DESCRIPTION
## Summary
- Bumps `ndarray` dependency from 0.15 to 0.16
- No code changes needed — the API surface we use (`Array2`, `Array3`, `zeros`, `fill`, index access) is stable across versions
- `numpy` 0.25 accepts `ndarray >= 0.15, < 0.17`, so 0.16 is within range

## Test plan
- [x] `cargo check` with and without `python` feature
- [x] `cargo test --lib --no-default-features` — 66 tests pass
- [x] `cargo clippy` clean in both modes
- [x] Pre-push hooks pass (pytest engine, protocol, CLI)