### PR TITLE
fix(host,headless): review followups — docs, shutdown drain, test assertions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 PyRat is a monorepo containing the complete PyRat ecosystem for a competitive maze game. The repository is organized into multiple components:
 
 - **engine/**: Rust game engine with PyO3 bindings - core game logic and Python API
+- **host/**: Match hosting library — setup, turn loop, event streaming (Rust, `pyrat-host` crate)
+- **headless/**: Headless match runner binary — launches bots, runs a match, outputs JSON (`pyrat-headless` crate)
 - **protocol/**: AI communication protocol — text-based Python SDK (`pyrat_base`) and FlatBuffers wire protocol (`pyrat_protocol`)
 - **cli/**: Command-line game runner tool (`pyrat-game` command)
 
@@ -124,15 +126,19 @@ cd engine && uv run pytest python/tests -v
 ### Building and Testing
 ```bash
 # From repository root
-make test        # Run all tests
-make test-engine # Run engine tests only
+make test          # Run all tests
+make test-engine   # Run engine tests only
+make test-host     # Run host library tests
+make test-headless # Run headless runner tests
 make test-protocol # Run protocol tests only
-make test-cli    # Run CLI tests only
-make bench       # Run benchmarks
+make test-cli      # Run CLI tests only
+make bench         # Run benchmarks
 
 # Rust commands (from repo root — Cargo workspace is at root)
 cargo build -p pyrat-rust --release
 cargo test -p pyrat-rust --lib --no-default-features
+cargo test -p pyrat-host
+cargo test -p pyrat-headless
 cargo bench -p pyrat-rust --bench game_benchmarks
 
 # Build Python package with maturin
@@ -252,6 +258,21 @@ Each player receives:
 - Or use `make test-engine` from the repository root for both
 
 ## Component Details
+
+### Host Library (`host/`)
+Match hosting library. Manages bot connections, setup handshake, and the turn loop:
+- `game_loop/` — Setup phases (connect → identify → configure → preprocess), playing loop, event streaming
+- `session/` — Per-connection state machine, FlatBuffers wire codec
+- `wire/` — FlatBuffers schema types re-exported for consumers
+- `MatchEvent` — Event stream consumed by headless runner, GUI, or tournament systems
+
+**Key pattern:** The host is a pipe — it streams `MatchEvent`s through a channel. Consumers decide what to record or display.
+
+### Headless Runner (`headless/`)
+CLI binary that launches bot subprocesses, runs a match via the host library, and optionally writes a JSON game record:
+- `main.rs` — CLI parsing, bot launch, match orchestration, JSON output
+
+Command: `cargo run -p pyrat-headless -- bot1_cmd bot2_cmd`
 
 ### Protocol (`protocol/`)
 Text-based stdin/stdout protocol for AI communication. The `pyrat_base` package provides:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # PyRat Monorepo Makefile
 
-.PHONY: all engine gui protocol examples cli test bench clean help sync lint lint-engine lint-protocol lint-cli test-cli test-integration generate-protocol
+.PHONY: all engine gui protocol examples cli test bench clean help sync lint lint-engine lint-protocol lint-cli test-cli test-host test-headless test-integration generate-protocol
 
 # Default target
 all: sync engine
@@ -40,12 +40,20 @@ dev-setup:
 	uv run pre-commit install && uv run pre-commit install --hook-type pre-push
 
 # Testing
-test: test-engine test-protocol test-cli
+test: test-engine test-host test-headless test-protocol test-cli
 
 test-engine:
 	@echo "Running engine tests..."
 	cargo test -p pyrat-rust --lib --no-default-features
 	cd engine && uv run pytest python/tests -v
+
+test-host:
+	@echo "Running host library tests..."
+	cargo test -p pyrat-host
+
+test-headless:
+	@echo "Running headless runner tests..."
+	cargo test -p pyrat-headless
 
 test-protocol:
 	@echo "Running protocol tests..."
@@ -129,6 +137,8 @@ help:
 	@echo "Testing:"
 	@echo "  test             - Run all tests (engine, protocol, CLI)"
 	@echo "  test-engine      - Run engine tests only"
+	@echo "  test-host        - Run host library tests"
+	@echo "  test-headless    - Run headless runner tests"
 	@echo "  test-protocol    - Run protocol tests only"
 	@echo "  test-cli         - Run CLI tests only"
 	@echo "  test-integration - Run integration tests"

--- a/headless/src/main.rs
+++ b/headless/src/main.rs
@@ -9,7 +9,6 @@ use tokio::sync::mpsc;
 use tracing::{info, warn};
 
 use pyrat::game::builder::GameConfig;
-use pyrat::game::game_logic::GameState;
 
 use pyrat_host::game_loop::{
     accept_connections, build_owned_match_config, launch_bots, run_playing, run_setup, BotConfig,
@@ -116,16 +115,23 @@ fn result_label(result: GameResult) -> &'static str {
 }
 
 fn build_game_record(
-    game: &GameState,
     seed: Option<u64>,
     events: Vec<MatchEvent>,
     match_result: &MatchResult,
 ) -> GameRecord {
     let mut players = Vec::new();
     let mut turns = Vec::new();
+    let mut width: u8 = 0;
+    let mut height: u8 = 0;
+    let mut max_turns: u16 = 0;
 
     for event in events {
         match event {
+            MatchEvent::MatchStarted { config } => {
+                width = config.width;
+                height = config.height;
+                max_turns = config.max_turns;
+            },
             MatchEvent::BotIdentified {
                 player,
                 name,
@@ -163,9 +169,9 @@ fn build_game_record(
     }
 
     GameRecord {
-        width: game.width(),
-        height: game.height(),
-        max_turns: game.max_turns(),
+        width,
+        height,
+        max_turns,
         seed,
         players,
         turns,
@@ -293,14 +299,35 @@ async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
 
-    // 11. Shutdown sessions
+    // 11. Shutdown sessions and drain disconnect messages
+    let session_count = setup_result.sessions.len();
     for s in &setup_result.sessions {
         let _ = s
             .cmd_tx
             .send(pyrat_host::session::messages::HostCommand::Shutdown)
             .await;
     }
-    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let mut disconnected = 0usize;
+    let drain_deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    while disconnected < session_count {
+        tokio::select! {
+            msg = game_rx.recv() => {
+                match msg {
+                    Some(SessionMsg::Disconnected { .. }) => { disconnected += 1; }
+                    Some(_) => {}
+                    None => break,
+                }
+            }
+            _ = tokio::time::sleep_until(drain_deadline) => {
+                warn!(
+                    remaining = session_count - disconnected,
+                    "shutdown drain timed out"
+                );
+                break;
+            }
+        }
+    }
 
     // 12. Collect events
     drop(event_tx);
@@ -311,7 +338,7 @@ async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
 
     // 14. Write game record
     if let Some(ref output_path) = cli.output {
-        let record = build_game_record(&game, cli.seed, events, &match_result);
+        let record = build_game_record(cli.seed, events, &match_result);
         let json = serde_json::to_string_pretty(&record).expect("JSON serialization failed");
         std::fs::write(output_path, json)?;
         info!(path = %output_path.display(), "game record written");

--- a/host/src/game_loop/config.rs
+++ b/host/src/game_loop/config.rs
@@ -138,6 +138,7 @@ pub fn build_owned_match_config(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pyrat::game::builder::GameConfig;
     use pyrat::{Coordinates, GameBuilder};
 
     #[test]
@@ -166,5 +167,22 @@ mod tests {
         assert_eq!(cfg.timing, TimingMode::Wait);
         assert_eq!(cfg.move_timeout_ms, 500);
         assert_eq!(cfg.preprocessing_timeout_ms, 3000);
+    }
+
+    #[test]
+    fn build_owned_match_config_extracts_walls_and_mud() {
+        let game = GameConfig::classic(7, 5, 3).create(Some(42)).unwrap();
+
+        let cfg = build_owned_match_config(&game, TimingMode::Wait, 500, 3000);
+
+        assert_eq!(cfg.width, 7);
+        assert_eq!(cfg.height, 5);
+        assert!(!cfg.walls.is_empty(), "classic 7×5 maze should have walls");
+
+        // Mud entries should be normalized: pos1 <= pos2.
+        for &(p1, p2, value) in &cfg.mud {
+            assert!(p1 <= p2, "mud entry not normalized: {p1:?} > {p2:?}");
+            assert!(value >= 2, "mud value should be >= 2, got {value}");
+        }
     }
 }

--- a/host/src/game_loop/playing.rs
+++ b/host/src/game_loop/playing.rs
@@ -254,6 +254,9 @@ async fn collect_actions(
                     }
                     SessionMsg::Info { session_id, info } => {
                         if let Some(players) = session_players.get(&session_id) {
+                            // Hivemind sessions control multiple players — emit one
+                            // BotInfo per controlled player so consumers see info
+                            // attributed to each.
                             for &p in players {
                                 emit(event_tx, MatchEvent::BotInfo {
                                     player: p,

--- a/host/tests/orchestration_integration.rs
+++ b/host/tests/orchestration_integration.rs
@@ -189,11 +189,20 @@ async fn full_flow_with_events() {
     assert_eq!(match_over.result, GameResult::Draw);
     assert_eq!(match_over.turns_played, 3);
 
-    // Verify event ordering: SetupComplete before all TurnPlayed, MatchOver last.
+    // Verify event ordering:
+    // BotIdentified < SetupComplete < MatchStarted < TurnPlayed < MatchOver (last)
+    let last_identified_pos = events
+        .iter()
+        .rposition(|e| matches!(e, MatchEvent::BotIdentified { .. }))
+        .expect("expected BotIdentified events");
     let setup_pos = events
         .iter()
         .position(|e| matches!(e, MatchEvent::SetupComplete))
         .unwrap();
+    let match_started_pos = events
+        .iter()
+        .position(|e| matches!(e, MatchEvent::MatchStarted { .. }))
+        .expect("expected MatchStarted event");
     let first_turn_pos = events
         .iter()
         .position(|e| matches!(e, MatchEvent::TurnPlayed { .. }))
@@ -203,8 +212,17 @@ async fn full_flow_with_events() {
         .position(|e| matches!(e, MatchEvent::MatchOver { .. }))
         .unwrap();
     assert!(
-        setup_pos < first_turn_pos,
-        "SetupComplete should precede first TurnPlayed"
+        last_identified_pos < setup_pos,
+        "all BotIdentified events should precede SetupComplete"
+    );
+    assert_eq!(
+        match_started_pos,
+        setup_pos + 1,
+        "MatchStarted should immediately follow SetupComplete"
+    );
+    assert!(
+        match_started_pos < first_turn_pos,
+        "MatchStarted should precede first TurnPlayed"
     );
     assert_eq!(
         match_over_pos,
@@ -425,10 +443,10 @@ async fn timeout_emits_event() {
         events.push(event);
     }
 
-    let timeout_player = events
+    let (timeout_player, timeout_turn) = events
         .iter()
         .find_map(|e| match e {
-            MatchEvent::BotTimeout { player, .. } => Some(*player),
+            MatchEvent::BotTimeout { player, turn } => Some((*player, *turn)),
             _ => None,
         })
         .expect("expected at least one BotTimeout event");
@@ -437,6 +455,7 @@ async fn timeout_emits_event() {
         Player::Player2,
         "Player2 was silent and should have timed out"
     );
+    assert_eq!(timeout_turn, 0, "timeout should occur on first turn");
 
     drop(w1);
     drop(r1);
@@ -547,12 +566,14 @@ async fn disconnect_emits_event() {
             _ => None,
         })
         .collect();
-    assert!(
-        !disconnect_players.is_empty(),
-        "expected at least one BotDisconnected event"
+    assert_eq!(
+        disconnect_players.len(),
+        1,
+        "expected exactly one BotDisconnected event, got {disconnect_players:?}"
     );
-    assert!(
-        disconnect_players.contains(&Player::Player2),
+    assert_eq!(
+        disconnect_players[0],
+        Player::Player2,
         "expected Player2 disconnect, got {disconnect_players:?}"
     );
 


### PR DESCRIPTION
## Summary
- Add `host/` and `headless/` to CLAUDE.md project overview, component details, and Makefile test targets
- Headless `build_game_record` now extracts config from `MatchStarted` event instead of taking `&GameState`; shutdown uses `select!` drain loop instead of 100ms sleep
- Add `build_owned_match_config` wall/mud extraction test, hivemind `BotInfo` comment, tighter orchestration test assertions (exact disconnect count, timeout turn number, `MatchStarted` ordering)

## Test plan
- [x] `cargo test -p pyrat-host` — all 99 tests pass
- [x] `cargo test -p pyrat-headless` — e2e test passes
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean