### PR TITLE
fix: update stale path references in comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,7 +265,7 @@ Each player receives:
 Match hosting library. Manages bot connections, setup handshake, and the turn loop:
 - `game_loop/` — Setup phases (connect → identify → configure → preprocess), playing loop, event streaming
 - `session/` — Per-connection state machine, FlatBuffers wire codec
-- `wire/` — FlatBuffers schema types re-exported for consumers
+- `pub use pyrat_wire as wire` — Re-exports FlatBuffers schema types from `server/wire/` for consumers
 - `MatchEvent` — Event stream consumed by headless runner, GUI, or tournament systems
 
 **Key pattern:** The host is a pipe — it streams `MatchEvent`s through a channel. Consumers decide what to record or display.

--- a/sdk/python/pyrat_sdk/_wire/connection.py
+++ b/sdk/python/pyrat_sdk/_wire/connection.py
@@ -1,6 +1,6 @@
 """Synchronous TCP socket with 4-byte BE length-prefix framing.
 
-Mirrors the wire format from ``wire/src/framing.rs``:
+Mirrors the wire format from ``server/wire/src/framing.rs``:
 ``[u32 BE payload length][payload bytes]``
 """
 

--- a/sdk/rust/src/wire.rs
+++ b/sdk/rust/src/wire.rs
@@ -1,6 +1,6 @@
 //! Wire codec: extract HostPackets to owned types, build BotPackets.
 //!
-//! Mirror of `host/src/session/codec.rs` but in the opposite direction —
+//! Mirror of `server/host/src/session/codec.rs` but in the opposite direction —
 //! we extract `HostPacket`s and build `BotPacket`s.
 
 use flatbuffers::FlatBufferBuilder;


### PR DESCRIPTION
## Summary
- Three comment/docstring references still pointed to pre-restructure paths after #156
- `sdk/rust/src/wire.rs`: `host/src/...` → `server/host/src/...`
- `sdk/python/.../connection.py`: `wire/src/...` → `server/wire/src/...`
- `CLAUDE.md`: clarify host `wire/` bullet as re-export from `server/wire/`

## Test plan
- [x] No code changes — comments only
- [x] Pre-commit hooks pass