### PR TITLE
Add pyrat-protocol crate with shared protocol types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3053,11 +3053,20 @@ version = "0.1.0"
 dependencies = [
  "fastrand",
  "flatbuffers",
+ "pyrat-protocol",
  "pyrat-rust",
  "pyrat-wire",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "pyrat-protocol"
+version = "0.1.0"
+dependencies = [
+ "pyrat-rust",
+ "pyrat-wire",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["engine", "engine/extension", "server/headless", "server/host", "server/wire", "interface", "sdk/python", "sdk/rust", "sdk/rust/derive", "gui/src-tauri", "tools/bot-check", "eval/store"]
+members = ["engine", "engine/extension", "server/headless", "server/host", "server/protocol", "server/wire", "interface", "sdk/python", "sdk/rust", "sdk/rust/derive", "gui/src-tauri", "tools/bot-check", "eval/store"]
 resolver = "2"
 
 [workspace.lints.clippy]

--- a/engine/rust/src/game/types.rs
+++ b/engine/rust/src/game/types.rs
@@ -150,7 +150,7 @@ impl Coordinates {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 #[repr(u8)]
 pub enum Direction {
     Up = 0,

--- a/gui/src-tauri/src/commands.rs
+++ b/gui/src-tauri/src/commands.rs
@@ -8,7 +8,7 @@ use tokio::sync::{mpsc, oneshot};
 
 use crate::bot_probe::MatchBotOptions;
 use crate::events::{Direction as SpectaDirection, MatchErrorEvent, MatchStartedEvent};
-use crate::match_runner::{run_match, specta_to_wire, wire_to_specta, PlayerSetup};
+use crate::match_runner::{engine_to_specta, run_match, specta_to_engine, PlayerSetup};
 use crate::state::{AnalysisCmd, AnalysisResp, AnalysisTx, AppState, MatchPhase};
 
 /// Pair of player actions for `advance_analysis`. Both must be provided together.
@@ -182,8 +182,8 @@ pub struct MazeState {
 
 /// Convert engine GameState to our serializable MazeState.
 pub fn build_maze_state(game: &GameState) -> MazeState {
+    use pyrat::{Coordinates, Direction as EngineDirection};
     use pyrat_host::game_loop::{HashedTurnState, OwnedTurnState};
-    use pyrat_host::wire::Direction as WireDirection;
 
     let walls = game
         .wall_entries()
@@ -213,15 +213,15 @@ pub fn build_maze_state(game: &GameState) -> MazeState {
     // Compute state_hash for the initial position (last moves are Stay/Stay).
     let hts = HashedTurnState::new(OwnedTurnState {
         turn: game.turns(),
-        player1_position: (game.player1_position().x, game.player1_position().y),
-        player2_position: (game.player2_position().x, game.player2_position().y),
+        player1_position: game.player1_position(),
+        player2_position: game.player2_position(),
         player1_score: game.player1_score(),
         player2_score: game.player2_score(),
         player1_mud_turns: game.player1_mud_turns(),
         player2_mud_turns: game.player2_mud_turns(),
-        cheese: cheese.iter().map(|c| (c.x, c.y)).collect(),
-        player1_last_move: WireDirection::Stay,
-        player2_last_move: WireDirection::Stay,
+        cheese: cheese.iter().map(|c| Coordinates::new(c.x, c.y)).collect(),
+        player1_last_move: EngineDirection::Stay,
+        player2_last_move: EngineDirection::Stay,
     });
 
     MazeState {
@@ -472,8 +472,8 @@ pub async fn stop_analysis_turn(
     let resp = send_analysis_cmd(&tx, AnalysisCmd::StopTurn).await?;
     match resp {
         AnalysisResp::Actions { p1, p2 } => Ok(StopAnalysisTurnResult {
-            player1_action: wire_to_specta(p1),
-            player2_action: wire_to_specta(p2),
+            player1_action: engine_to_specta(p1),
+            player2_action: engine_to_specta(p2),
         }),
         _ => Err("unexpected response".into()),
     }
@@ -486,12 +486,12 @@ pub async fn advance_analysis(
     actions: Option<AnalysisActions>,
 ) -> Result<AdvanceAnalysisResult, String> {
     let tx = get_cmd_tx(&state.match_phase).await?;
-    let actions = actions.map(|a| [specta_to_wire(a.player1), specta_to_wire(a.player2)]);
+    let actions = actions.map(|a| [specta_to_engine(a.player1), specta_to_engine(a.player2)]);
     let resp = send_analysis_cmd(&tx, AnalysisCmd::Advance { actions }).await?;
     match resp {
         AnalysisResp::Advanced { p1, p2, game_over } => Ok(AdvanceAnalysisResult {
-            player1_action: wire_to_specta(p1),
-            player2_action: wire_to_specta(p2),
+            player1_action: engine_to_specta(p1),
+            player2_action: engine_to_specta(p2),
             game_over,
         }),
         _ => Err("unexpected response".into()),

--- a/gui/src-tauri/src/match_runner.rs
+++ b/gui/src-tauri/src/match_runner.rs
@@ -9,9 +9,8 @@ use tracing::{debug, info, warn};
 use pyrat::game::game_logic::GameState;
 use pyrat::{Coordinates, Direction as EngineDirection};
 use pyrat_host::game_loop::{
-    build_owned_match_config, determine_result, run_playing, run_setup, wire_to_engine,
-    HashedTurnState, MatchEvent, MatchSetup, OwnedTurnState, PlayerEntry, PlayingConfig,
-    PlayingState, SetupTiming,
+    build_owned_match_config, determine_result, run_playing, run_setup, HashedTurnState,
+    MatchEvent, MatchSetup, OwnedTurnState, PlayerEntry, PlayingConfig, PlayingState, SetupTiming,
 };
 use pyrat_host::session::messages::{HostCommand, OwnedInfo, SessionId, SessionMsg};
 use pyrat_host::stub::spawn_stub_bot;
@@ -525,7 +524,7 @@ async fn finish_collecting(
                 let Some(msg) = msg else { break; };
                 match msg {
                     SessionMsg::Action { player, direction, .. } => {
-                        fill_action(player, wire_to_engine(direction), &mut p1, &mut p2);
+                        fill_action(player, direction, &mut p1, &mut p2);
                     }
                     SessionMsg::Info { session_id, info } => {
                         if let Some(players) = playing.session_players().get(&session_id) {
@@ -593,7 +592,7 @@ fn handle_bot_msg(
                 debug!(turn, current_turn, "stale action ignored in analysis");
                 return;
             }
-            fill_action(player, wire_to_engine(direction), p1_action, p2_action);
+            fill_action(player, direction, p1_action, p2_action);
         },
         SessionMsg::Info { session_id, info } => {
             if let Some(players) = playing.session_players().get(&session_id) {

--- a/gui/src-tauri/src/match_runner.rs
+++ b/gui/src-tauri/src/match_runner.rs
@@ -7,6 +7,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use pyrat::game::game_logic::GameState;
+use pyrat::{Coordinates, Direction as EngineDirection};
 use pyrat_host::game_loop::{
     build_owned_match_config, determine_result, run_playing, run_setup, wire_to_engine,
     HashedTurnState, MatchEvent, MatchSetup, OwnedTurnState, PlayerEntry, PlayingConfig,
@@ -14,7 +15,7 @@ use pyrat_host::game_loop::{
 };
 use pyrat_host::session::messages::{HostCommand, OwnedInfo, SessionId, SessionMsg};
 use pyrat_host::stub::spawn_stub_bot;
-use pyrat_host::wire::{Direction as WireDirection, GameResult, Player, TimingMode};
+use pyrat_host::wire::{GameResult, Player, TimingMode};
 
 use tauri_specta::Event;
 
@@ -25,23 +26,23 @@ use crate::events::{
 };
 use crate::state::AnalysisRx;
 
-pub fn wire_to_specta(d: WireDirection) -> SpectaDirection {
+pub fn engine_to_specta(d: EngineDirection) -> SpectaDirection {
     match d {
-        WireDirection::Up => SpectaDirection::Up,
-        WireDirection::Right => SpectaDirection::Right,
-        WireDirection::Down => SpectaDirection::Down,
-        WireDirection::Left => SpectaDirection::Left,
-        _ => SpectaDirection::Stay,
+        EngineDirection::Up => SpectaDirection::Up,
+        EngineDirection::Right => SpectaDirection::Right,
+        EngineDirection::Down => SpectaDirection::Down,
+        EngineDirection::Left => SpectaDirection::Left,
+        EngineDirection::Stay => SpectaDirection::Stay,
     }
 }
 
-pub fn specta_to_wire(d: SpectaDirection) -> WireDirection {
+pub fn specta_to_engine(d: SpectaDirection) -> EngineDirection {
     match d {
-        SpectaDirection::Up => WireDirection::Up,
-        SpectaDirection::Right => WireDirection::Right,
-        SpectaDirection::Down => WireDirection::Down,
-        SpectaDirection::Left => WireDirection::Left,
-        SpectaDirection::Stay => WireDirection::Stay,
+        SpectaDirection::Up => EngineDirection::Up,
+        SpectaDirection::Right => EngineDirection::Right,
+        SpectaDirection::Down => EngineDirection::Down,
+        SpectaDirection::Left => EngineDirection::Left,
+        SpectaDirection::Stay => EngineDirection::Stay,
     }
 }
 
@@ -260,8 +261,8 @@ enum AnalysisPhase {
     Idle,
     Collecting {
         turn: u16,
-        p1_action: Option<WireDirection>,
-        p2_action: Option<WireDirection>,
+        p1_action: Option<EngineDirection>,
+        p2_action: Option<EngineDirection>,
         deadline: Option<tokio::time::Instant>,
     },
 }
@@ -334,7 +335,7 @@ async fn run_analysis_inner(
                                 sessions, &mut playing, game_rx, &mut phase, event_tx,
                             ).await
                         } else {
-                            (WireDirection::Stay, WireDirection::Stay)
+                            (EngineDirection::Stay, EngineDirection::Stay)
                         };
 
                         // Provided actions override collected ones
@@ -345,7 +346,7 @@ async fn run_analysis_inner(
                         };
 
                         // Step the engine
-                        let result = game.process_turn(wire_to_engine(p1), wire_to_engine(p2));
+                        let result = game.process_turn(p1, p2);
                         playing.record_actions(p1, p2);
 
                         // Emit TurnPlayed
@@ -401,15 +402,19 @@ async fn run_analysis_inner(
 fn build_turn_state_from_position(pos: AnalysisPosition) -> HashedTurnState {
     HashedTurnState::new(OwnedTurnState {
         turn: pos.turn,
-        player1_position: (pos.player1.position.x, pos.player1.position.y),
-        player2_position: (pos.player2.position.x, pos.player2.position.y),
+        player1_position: Coordinates::new(pos.player1.position.x, pos.player1.position.y),
+        player2_position: Coordinates::new(pos.player2.position.x, pos.player2.position.y),
         player1_score: pos.player1.score,
         player2_score: pos.player2.score,
         player1_mud_turns: pos.player1.mud_turns,
         player2_mud_turns: pos.player2.mud_turns,
-        cheese: pos.cheese.iter().map(|c| (c.x, c.y)).collect(),
-        player1_last_move: specta_to_wire(pos.player1_last_move),
-        player2_last_move: specta_to_wire(pos.player2_last_move),
+        cheese: pos
+            .cheese
+            .iter()
+            .map(|c| Coordinates::new(c.x, c.y))
+            .collect(),
+        player1_last_move: specta_to_engine(pos.player1_last_move),
+        player2_last_move: specta_to_engine(pos.player2_last_move),
     })
 }
 
@@ -476,7 +481,7 @@ async fn finish_collecting(
     game_rx: &mut mpsc::Receiver<SessionMsg>,
     phase: &mut AnalysisPhase,
     event_tx: &mpsc::UnboundedSender<MatchEvent>,
-) -> (WireDirection, WireDirection) {
+) -> (EngineDirection, EngineDirection) {
     // Extract current action slots
     let (mut p1, mut p2) = match phase {
         AnalysisPhase::Collecting {
@@ -485,7 +490,7 @@ async fn finish_collecting(
             ..
         } => (*p1_action, *p2_action),
         AnalysisPhase::Idle => {
-            return (WireDirection::Stay, WireDirection::Stay);
+            return (EngineDirection::Stay, EngineDirection::Stay);
         },
     };
 
@@ -493,7 +498,7 @@ async fn finish_collecting(
     for sid in playing.disconnected().clone() {
         if let Some(players) = playing.session_players().get(&sid) {
             for &player in players {
-                fill_action(player, WireDirection::Stay, &mut p1, &mut p2);
+                fill_action(player, EngineDirection::Stay, &mut p1, &mut p2);
             }
         }
     }
@@ -520,7 +525,7 @@ async fn finish_collecting(
                 let Some(msg) = msg else { break; };
                 match msg {
                     SessionMsg::Action { player, direction, .. } => {
-                        fill_action(player, direction, &mut p1, &mut p2);
+                        fill_action(player, wire_to_engine(direction), &mut p1, &mut p2);
                     }
                     SessionMsg::Info { session_id, info } => {
                         if let Some(players) = playing.session_players().get(&session_id) {
@@ -538,7 +543,7 @@ async fn finish_collecting(
                         playing.disconnected_mut().insert(session_id);
                         if let Some(players) = playing.session_players().get(&session_id) {
                             for &player in players {
-                                fill_action(player, WireDirection::Stay, &mut p1, &mut p2);
+                                fill_action(player, EngineDirection::Stay, &mut p1, &mut p2);
                                 emit_event(event_tx, MatchEvent::BotDisconnected { player, reason });
                             }
                         }
@@ -555,8 +560,8 @@ async fn finish_collecting(
 
     *phase = AnalysisPhase::Idle;
     (
-        p1.unwrap_or(WireDirection::Stay),
-        p2.unwrap_or(WireDirection::Stay),
+        p1.unwrap_or(EngineDirection::Stay),
+        p2.unwrap_or(EngineDirection::Stay),
     )
 }
 
@@ -588,7 +593,7 @@ fn handle_bot_msg(
                 debug!(turn, current_turn, "stale action ignored in analysis");
                 return;
             }
-            fill_action(player, direction, p1_action, p2_action);
+            fill_action(player, wire_to_engine(direction), p1_action, p2_action);
         },
         SessionMsg::Info { session_id, info } => {
             if let Some(players) = playing.session_players().get(&session_id) {
@@ -616,7 +621,7 @@ fn handle_bot_msg(
             playing.disconnected_mut().insert(session_id);
             if let Some(players) = playing.session_players().get(&session_id) {
                 for &player in players {
-                    fill_action(player, WireDirection::Stay, p1_action, p2_action);
+                    fill_action(player, EngineDirection::Stay, p1_action, p2_action);
                     emit_event(event_tx, MatchEvent::BotDisconnected { player, reason });
                 }
             }
@@ -628,9 +633,9 @@ fn handle_bot_msg(
 /// Insert a direction for the given player, first-wins.
 fn fill_action(
     player: Player,
-    direction: WireDirection,
-    p1: &mut Option<WireDirection>,
-    p2: &mut Option<WireDirection>,
+    direction: EngineDirection,
+    p1: &mut Option<EngineDirection>,
+    p2: &mut Option<EngineDirection>,
 ) {
     match player {
         Player::Player1 => {
@@ -705,7 +710,7 @@ fn build_bot_info_event(
         depth: info.depth,
         nodes: info.nodes,
         score: info.score,
-        pv: info.pv.iter().map(|&d| wire_to_specta(d)).collect(),
+        pv: info.pv.iter().map(|&d| engine_to_specta(d)).collect(),
         message: info.message.clone(),
     }
 }
@@ -742,8 +747,8 @@ async fn forward_events(
                         mud_turns: state.player2_mud_turns,
                     },
                     cheese: state.cheese.iter().copied().map(Coord::from).collect(),
-                    player1_action: wire_to_specta(p1_action),
-                    player2_action: wire_to_specta(p2_action),
+                    player1_action: engine_to_specta(p1_action),
+                    player2_action: engine_to_specta(p2_action),
                 };
                 let _ = payload.emit(&app);
             },

--- a/gui/src-tauri/src/state.rs
+++ b/gui/src-tauri/src/state.rs
@@ -5,7 +5,7 @@ use tokio::sync::{mpsc, oneshot, Mutex};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
-use pyrat_host::wire::Direction as WireDirection;
+use pyrat::Direction;
 
 use crate::commands::AnalysisPosition;
 
@@ -14,18 +14,18 @@ use crate::commands::AnalysisPosition;
 pub enum AnalysisCmd {
     StartTurn { position: Option<AnalysisPosition> },
     StopTurn,
-    Advance { actions: Option<[WireDirection; 2]> },
+    Advance { actions: Option<[Direction; 2]> },
 }
 
 pub enum AnalysisResp {
     TurnStarted,
     Actions {
-        p1: WireDirection,
-        p2: WireDirection,
+        p1: Direction,
+        p2: Direction,
     },
     Advanced {
-        p1: WireDirection,
-        p2: WireDirection,
+        p1: Direction,
+        p2: Direction,
         game_over: bool,
     },
 }

--- a/server/headless/src/main.rs
+++ b/server/headless/src/main.rs
@@ -165,10 +165,10 @@ fn build_game_record(
             } => {
                 turns.push(TurnRecord {
                     turn: state.turn,
-                    p1_action: p1_action.0,
-                    p2_action: p2_action.0,
-                    p1_position: state.player1_position,
-                    p2_position: state.player2_position,
+                    p1_action: p1_action as u8,
+                    p2_action: p2_action as u8,
+                    p1_position: (state.player1_position.x, state.player1_position.y),
+                    p2_position: (state.player2_position.x, state.player2_position.y),
                     p1_score: state.player1_score,
                     p2_score: state.player2_score,
                     cheese_remaining: state.cheese.len(),

--- a/server/host/Cargo.toml
+++ b/server/host/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 fastrand = "2"
 flatbuffers = "25.2.10"
+pyrat-protocol = { path = "../protocol" }
 pyrat-rust = { path = "../../engine", default-features = false }
 pyrat-wire = { path = "../wire" }
 tokio = { version = "1", features = ["sync", "macros", "io-util", "time", "net", "rt"] }

--- a/server/host/src/game_loop/config.rs
+++ b/server/host/src/game_loop/config.rs
@@ -110,26 +110,22 @@ pub fn build_owned_match_config(
     let walls = game
         .wall_entries()
         .into_iter()
-        .map(|w| ((w.pos1.x, w.pos1.y), (w.pos2.x, w.pos2.y)))
+        .map(|w| (w.pos1, w.pos2))
         .collect();
 
     let mud = game
         .mud_positions()
         .iter()
         .map(|((from, to), value)| {
-            let (p1, p2) = if from < to { (from, to) } else { (to, from) };
-            ((p1.x, p1.y), (p2.x, p2.y), value)
+            if from < to {
+                (from, to, value)
+            } else {
+                (to, from, value)
+            }
         })
         .collect();
 
-    let cheese = game
-        .cheese_positions()
-        .into_iter()
-        .map(|c| (c.x, c.y))
-        .collect();
-
-    let p1 = game.player1_position();
-    let p2 = game.player2_position();
+    let cheese = game.cheese_positions();
 
     OwnedMatchConfig {
         width: game.width(),
@@ -138,8 +134,8 @@ pub fn build_owned_match_config(
         walls,
         mud,
         cheese,
-        player1_start: (p1.x, p1.y),
-        player2_start: (p2.x, p2.y),
+        player1_start: game.player1_position(),
+        player2_start: game.player2_position(),
         controlled_players: vec![],
         timing,
         move_timeout_ms,
@@ -168,9 +164,9 @@ mod tests {
         assert_eq!(cfg.width, 3);
         assert_eq!(cfg.height, 3);
         assert_eq!(cfg.max_turns, game.max_turns());
-        assert_eq!(cfg.player1_start, (0, 0));
-        assert_eq!(cfg.player2_start, (2, 2));
-        assert_eq!(cfg.cheese, vec![(1, 1)]);
+        assert_eq!(cfg.player1_start, Coordinates::new(0, 0));
+        assert_eq!(cfg.player2_start, Coordinates::new(2, 2));
+        assert_eq!(cfg.cheese, vec![Coordinates::new(1, 1)]);
         assert!(cfg.walls.is_empty(), "open maze should have no walls");
         assert!(
             cfg.controlled_players.is_empty(),

--- a/server/host/src/game_loop/events.rs
+++ b/server/host/src/game_loop/events.rs
@@ -8,7 +8,8 @@ use tokio::sync::mpsc;
 use tracing::warn;
 
 use crate::session::messages::{DisconnectReason, HashedTurnState, OwnedInfo, OwnedMatchConfig};
-use pyrat_wire::{Direction, Player};
+use pyrat::Direction;
+use pyrat_wire::Player;
 
 use super::playing::MatchResult;
 

--- a/server/host/src/game_loop/mod.rs
+++ b/server/host/src/game_loop/mod.rs
@@ -19,7 +19,6 @@ pub use playing::{
 };
 pub use probe::{probe_bot, ProbeError, ProbeResult};
 pub use pyrat_protocol::{
-    wire_to_engine_direction as wire_to_engine, HashedTurnState, OwnedInfo, OwnedMatchConfig,
-    OwnedOptionDef, OwnedTurnState,
+    HashedTurnState, OwnedInfo, OwnedMatchConfig, OwnedOptionDef, OwnedTurnState,
 };
 pub use setup::{accept_connections, run_setup, SetupError, SetupResult};

--- a/server/host/src/game_loop/mod.rs
+++ b/server/host/src/game_loop/mod.rs
@@ -6,9 +6,7 @@ mod probe;
 mod setup;
 mod slots;
 
-pub use crate::session::messages::{
-    DisconnectReason, HashedTurnState, OwnedInfo, OwnedMatchConfig, OwnedOptionDef, OwnedTurnState,
-};
+pub use crate::session::messages::DisconnectReason;
 pub use config::{
     build_owned_match_config, BotConfig, MatchSetup, PlayerEntry, PlayingConfig, SessionHandle,
     SetupTiming,
@@ -20,4 +18,7 @@ pub use playing::{
     PlayingError, PlayingState, TurnOutcome,
 };
 pub use probe::{probe_bot, ProbeError, ProbeResult};
+pub use pyrat_protocol::{
+    HashedTurnState, OwnedInfo, OwnedMatchConfig, OwnedOptionDef, OwnedTurnState,
+};
 pub use setup::{accept_connections, run_setup, SetupError, SetupResult};

--- a/server/host/src/game_loop/mod.rs
+++ b/server/host/src/game_loop/mod.rs
@@ -14,11 +14,12 @@ pub use config::{
 pub use events::MatchEvent;
 pub use launch::{launch_bots, BotExitInfo, BotProcesses, LaunchError};
 pub use playing::{
-    determine_result, engine_to_wire, run_one_turn, run_playing, wire_to_engine, MatchResult,
-    PlayingError, PlayingState, TurnOutcome,
+    determine_result, run_one_turn, run_playing, MatchResult, PlayingError, PlayingState,
+    TurnOutcome,
 };
 pub use probe::{probe_bot, ProbeError, ProbeResult};
 pub use pyrat_protocol::{
-    HashedTurnState, OwnedInfo, OwnedMatchConfig, OwnedOptionDef, OwnedTurnState,
+    wire_to_engine_direction as wire_to_engine, HashedTurnState, OwnedInfo, OwnedMatchConfig,
+    OwnedOptionDef, OwnedTurnState,
 };
 pub use setup::{accept_connections, run_setup, SetupError, SetupResult};

--- a/server/host/src/game_loop/playing.rs
+++ b/server/host/src/game_loop/playing.rs
@@ -7,13 +7,12 @@ use tokio::time::Instant;
 use tracing::{debug, warn};
 
 use pyrat::game::game_logic::GameState;
-use pyrat::Direction as EngineDirection;
-use pyrat_protocol::wire_to_engine_direction;
+use pyrat::Direction;
 
 use crate::session::messages::{
     HashedTurnState, HostCommand, OwnedTurnState, SessionId, SessionMsg,
 };
-use pyrat_wire::{Direction as WireDirection, GameResult, Player};
+use pyrat_wire::{GameResult, Player};
 
 use super::config::{PlayingConfig, SessionHandle};
 use super::events::{emit, MatchEvent};
@@ -33,8 +32,8 @@ pub struct MatchResult {
 pub struct PlayingState {
     session_players: HashMap<SessionId, Vec<Player>>,
     disconnected: HashSet<SessionId>,
-    last_p1: EngineDirection,
-    last_p2: EngineDirection,
+    last_p1: Direction,
+    last_p2: Direction,
 }
 
 impl PlayingState {
@@ -51,8 +50,8 @@ impl PlayingState {
         Self {
             session_players,
             disconnected: HashSet::new(),
-            last_p1: EngineDirection::Stay,
-            last_p2: EngineDirection::Stay,
+            last_p1: Direction::Stay,
+            last_p2: Direction::Stay,
         }
     }
 
@@ -62,7 +61,7 @@ impl PlayingState {
     }
 
     /// Record the actions taken this turn (updates last moves for next turn state).
-    pub fn record_actions(&mut self, p1: EngineDirection, p2: EngineDirection) {
+    pub fn record_actions(&mut self, p1: Direction, p2: Direction) {
         self.last_p1 = p1;
         self.last_p2 = p2;
     }
@@ -101,8 +100,8 @@ pub enum PlayingError {
 
 /// Actions collected for a single turn, including timing metadata.
 struct CollectedActions {
-    p1: WireDirection,
-    p2: WireDirection,
+    p1: Direction,
+    p2: Direction,
     p1_think_ms: u32,
     p2_think_ms: u32,
     /// Host-measured wall time from TurnState send to committed action receive.
@@ -187,20 +186,18 @@ pub async fn run_one_turn(
     }
 
     // Step the engine.
-    let p1_move = wire_to_engine_direction(actions.p1);
-    let p2_move = wire_to_engine_direction(actions.p2);
-    let result = game.process_turn(p1_move, p2_move);
+    let result = game.process_turn(actions.p1, actions.p2);
 
-    state.last_p1 = p1_move;
-    state.last_p2 = p2_move;
+    state.last_p1 = actions.p1;
+    state.last_p2 = actions.p2;
 
     // Emit TurnPlayed event.
     emit(
         event_tx,
         MatchEvent::TurnPlayed {
             state: build_turn_state(game, state.last_p1, state.last_p2),
-            p1_action: p1_move,
-            p2_action: p2_move,
+            p1_action: actions.p1,
+            p2_action: actions.p2,
             p1_think_ms: actions.p1_think_ms,
             p2_think_ms: actions.p2_think_ms,
         },
@@ -268,8 +265,8 @@ pub async fn run_playing(
 
 fn build_turn_state(
     game: &GameState,
-    last_p1: EngineDirection,
-    last_p2: EngineDirection,
+    last_p1: Direction,
+    last_p2: Direction,
 ) -> HashedTurnState {
     let p1 = &game.player1;
     let p2 = &game.player2;
@@ -315,7 +312,7 @@ async fn collect_actions(
     event_tx: Option<&mpsc::UnboundedSender<MatchEvent>>,
     send_time: Instant,
 ) -> Result<CollectedActions, PlayingError> {
-    let stay = WireDirection::Stay;
+    let stay = Direction::Stay;
     let mut p1_slot: Option<ActionSlot> = None;
     let mut p2_slot: Option<ActionSlot> = None;
     let mut p1_wall_ms: u32 = 0;
@@ -437,7 +434,7 @@ fn handle_action(
     responded: &mut HashSet<SessionId>,
     session_id: SessionId,
     player: Player,
-    direction: WireDirection,
+    direction: Direction,
     turn: u16,
     current_turn: u16,
     provisional: bool,
@@ -503,7 +500,7 @@ fn handle_disconnect(
                 Player::Player2 => &mut *p2_slot,
                 _ => continue,
             };
-            update_action(slot, WireDirection::Stay, false, 0);
+            update_action(slot, Direction::Stay, false, 0);
             emit(event_tx, MatchEvent::BotDisconnected { player: p, reason });
         }
     }
@@ -538,14 +535,14 @@ async fn handle_timeout(
     responded: &HashSet<SessionId>,
     event_tx: Option<&mpsc::UnboundedSender<MatchEvent>>,
     current_turn: u16,
-    stay: WireDirection,
+    stay: Direction,
 ) {
     for s in sessions {
         if !disconnected.contains(&s.session_id) && !responded.contains(&s.session_id) {
             let _ = s
                 .cmd_tx
                 .send(HostCommand::Timeout {
-                    default_move: wire_to_engine_direction(stay),
+                    default_move: stay,
                 })
                 .await;
             for &p in &s.controlled_players {
@@ -580,7 +577,7 @@ fn resolve_collected(
 
 /// Per-player action state during action collection.
 struct ActionSlot {
-    direction: WireDirection,
+    direction: Direction,
     committed: bool,
     think_ms: u32,
 }
@@ -589,7 +586,7 @@ struct ActionSlot {
 /// committed actions lock the slot.
 fn update_action(
     slot: &mut Option<ActionSlot>,
-    direction: WireDirection,
+    direction: Direction,
     provisional: bool,
     think_ms: u32,
 ) {
@@ -625,10 +622,10 @@ fn both_committed(p1: &Option<ActionSlot>, p2: &Option<ActionSlot>) -> bool {
 }
 
 /// Resolve a slot to a direction: committed > provisional > Stay.
-fn resolve_action(slot: &Option<ActionSlot>) -> WireDirection {
+fn resolve_action(slot: &Option<ActionSlot>) -> Direction {
     slot.as_ref()
         .map(|s| s.direction)
-        .unwrap_or(WireDirection::Stay)
+        .unwrap_or(Direction::Stay)
 }
 
 /// Extract think_ms from a slot (0 if absent).
@@ -659,7 +656,7 @@ mod tests {
     use super::*;
     use crate::session::messages::{HostCommand, SessionId, SessionMsg};
     use pyrat::Coordinates;
-    use pyrat_wire::{Direction as WireDirection, Player};
+    use pyrat_wire::Player;
     use std::collections::{HashMap, HashSet};
     use std::time::Duration;
     use tokio::sync::mpsc;
@@ -718,7 +715,7 @@ mod tests {
             .send(SessionMsg::Action {
                 session_id: SessionId(1),
                 player: Player::Player1,
-                direction: WireDirection::Right,
+                direction: Direction::Right,
                 turn: current_turn,
                 provisional: false,
                 think_ms: 50,
@@ -731,7 +728,7 @@ mod tests {
             .send(SessionMsg::Action {
                 session_id: SessionId(2),
                 player: Player::Player2,
-                direction: WireDirection::Right,
+                direction: Direction::Right,
                 turn: 3,
                 provisional: false,
                 think_ms: 50,
@@ -755,13 +752,13 @@ mod tests {
         .expect("collect_actions should not fail");
 
         // P1 got Right (accepted), P2 got Stay (stale → timeout default).
-        assert_eq!(actions.p1, WireDirection::Right);
-        assert_eq!(actions.p2, WireDirection::Stay);
+        assert_eq!(actions.p1, Direction::Right);
+        assert_eq!(actions.p2, Direction::Stay);
 
         // Session 2 should have received a Timeout command.
         let cmd = cmd_rx2.try_recv().expect("session 2 should get Timeout");
         assert!(
-            matches!(cmd, HostCommand::Timeout { default_move } if default_move == EngineDirection::Stay),
+            matches!(cmd, HostCommand::Timeout { default_move } if default_move == Direction::Stay),
             "expected Timeout with Stay, got {cmd:?}"
         );
 
@@ -812,7 +809,7 @@ mod tests {
             .send(SessionMsg::Action {
                 session_id: SessionId(1),
                 player: Player::Player1,
-                direction: WireDirection::Up,
+                direction: Direction::Up,
                 turn: current_turn,
                 provisional: false,
                 think_ms: 0,
@@ -823,7 +820,7 @@ mod tests {
             .send(SessionMsg::Action {
                 session_id: SessionId(2),
                 player: Player::Player2,
-                direction: WireDirection::Down,
+                direction: Direction::Down,
                 turn: current_turn,
                 provisional: false,
                 think_ms: 0,
@@ -846,8 +843,8 @@ mod tests {
         .await
         .expect("collect_actions should not fail");
 
-        assert_eq!(actions.p1, WireDirection::Up);
-        assert_eq!(actions.p2, WireDirection::Down);
+        assert_eq!(actions.p1, Direction::Up);
+        assert_eq!(actions.p2, Direction::Down);
 
         // Info should have been relayed as BotInfo event.
         let event = event_rx.try_recv().expect("should have BotInfo event");
@@ -891,7 +888,7 @@ mod tests {
             .send(SessionMsg::Action {
                 session_id: SessionId(2),
                 player: Player::Player2,
-                direction: WireDirection::Down,
+                direction: Direction::Down,
                 turn: current_turn,
                 provisional: false,
                 think_ms: 0,
@@ -915,8 +912,8 @@ mod tests {
         .expect("collect_actions should not fail");
 
         // Disconnected player gets STAY, other player's action is used.
-        assert_eq!(actions.p1, WireDirection::Stay);
-        assert_eq!(actions.p2, WireDirection::Down);
+        assert_eq!(actions.p1, Direction::Stay);
+        assert_eq!(actions.p2, Direction::Down);
         assert!(disconnected.contains(&SessionId(1)));
     }
 
@@ -938,7 +935,7 @@ mod tests {
             .send(SessionMsg::Action {
                 session_id: SessionId(1),
                 player: Player::Player1,
-                direction: WireDirection::Left,
+                direction: Direction::Left,
                 turn: current_turn,
                 provisional: true,
                 think_ms: 0,
@@ -949,7 +946,7 @@ mod tests {
             .send(SessionMsg::Action {
                 session_id: SessionId(1),
                 player: Player::Player1,
-                direction: WireDirection::Up,
+                direction: Direction::Up,
                 turn: current_turn,
                 provisional: false,
                 think_ms: 0, // rejected — missing think_ms
@@ -962,7 +959,7 @@ mod tests {
             .send(SessionMsg::Action {
                 session_id: SessionId(2),
                 player: Player::Player2,
-                direction: WireDirection::Down,
+                direction: Direction::Down,
                 turn: current_turn,
                 provisional: false,
                 think_ms: 50,
@@ -986,8 +983,8 @@ mod tests {
         .expect("collect_actions should not fail");
 
         // P1 gets provisional Left (committed was rejected), P2 gets committed Down.
-        assert_eq!(actions.p1, WireDirection::Left);
-        assert_eq!(actions.p2, WireDirection::Down);
+        assert_eq!(actions.p1, Direction::Left);
+        assert_eq!(actions.p2, Direction::Down);
     }
 
     /// Committed action within think margin is accepted.
@@ -1014,7 +1011,7 @@ mod tests {
             .send(SessionMsg::Action {
                 session_id: SessionId(1),
                 player: Player::Player1,
-                direction: WireDirection::Right,
+                direction: Direction::Right,
                 turn: current_turn,
                 provisional: false,
                 think_ms: 1050,
@@ -1027,7 +1024,7 @@ mod tests {
             .send(SessionMsg::Action {
                 session_id: SessionId(2),
                 player: Player::Player2,
-                direction: WireDirection::Left,
+                direction: Direction::Left,
                 turn: current_turn,
                 provisional: false,
                 think_ms: 1200,
@@ -1049,9 +1046,9 @@ mod tests {
         .await
         .expect("collect_actions should not fail");
 
-        assert_eq!(actions.p1, WireDirection::Right);
+        assert_eq!(actions.p1, Direction::Right);
         // P2's committed was rejected, no provisional → Stay at timeout
-        assert_eq!(actions.p2, WireDirection::Stay);
+        assert_eq!(actions.p2, Direction::Stay);
     }
 
     /// Late Info (sent for a previous turn) is forwarded with the turn
@@ -1094,7 +1091,7 @@ mod tests {
             .send(SessionMsg::Action {
                 session_id: SessionId(1),
                 player: Player::Player1,
-                direction: WireDirection::Up,
+                direction: Direction::Up,
                 turn: current_turn,
                 provisional: false,
                 think_ms: 0,
@@ -1105,7 +1102,7 @@ mod tests {
             .send(SessionMsg::Action {
                 session_id: SessionId(2),
                 player: Player::Player2,
-                direction: WireDirection::Down,
+                direction: Direction::Down,
                 turn: current_turn,
                 provisional: false,
                 think_ms: 0,
@@ -1165,8 +1162,8 @@ mod tests {
             player1_mud_turns: 0,
             player2_mud_turns: 0,
             cheese: vec![Coordinates::new(5, 5), Coordinates::new(10, 7)],
-            player1_last_move: EngineDirection::Up,
-            player2_last_move: EngineDirection::Down,
+            player1_last_move: Direction::Up,
+            player2_last_move: Direction::Down,
         }
     }
 
@@ -1244,14 +1241,14 @@ mod tests {
             (
                 "p1 last move",
                 OwnedTurnState {
-                    player1_last_move: EngineDirection::Right,
+                    player1_last_move: Direction::Right,
                     ..base.clone()
                 },
             ),
             (
                 "p2 last move",
                 OwnedTurnState {
-                    player2_last_move: EngineDirection::Left,
+                    player2_last_move: Direction::Left,
                     ..base.clone()
                 },
             ),

--- a/server/host/src/game_loop/playing.rs
+++ b/server/host/src/game_loop/playing.rs
@@ -8,6 +8,7 @@ use tracing::{debug, warn};
 
 use pyrat::game::game_logic::GameState;
 use pyrat::Direction as EngineDirection;
+use pyrat_protocol::wire_to_engine_direction;
 
 use crate::session::messages::{
     HashedTurnState, HostCommand, OwnedTurnState, SessionId, SessionMsg,
@@ -109,19 +110,6 @@ struct CollectedActions {
     p2_wall_ms: u32,
 }
 
-// ── Direction conversion ─────────────────────────────
-
-/// Convert a wire Direction (u8 newtype) to an engine Direction enum.
-///
-/// Same discriminant values: Up=0, Right=1, Down=2, Left=3, Stay=4.
-pub fn wire_to_engine(d: WireDirection) -> EngineDirection {
-    EngineDirection::try_from(d.0).unwrap_or(EngineDirection::Stay)
-}
-
-pub fn engine_to_wire(d: EngineDirection) -> WireDirection {
-    WireDirection(d as u8)
-}
-
 // ── Turn loop ────────────────────────────────────────
 
 /// Execute one turn of the playing phase: send turn state, collect actions,
@@ -199,8 +187,8 @@ pub async fn run_one_turn(
     }
 
     // Step the engine.
-    let p1_move = wire_to_engine(actions.p1);
-    let p2_move = wire_to_engine(actions.p2);
+    let p1_move = wire_to_engine_direction(actions.p1);
+    let p2_move = wire_to_engine_direction(actions.p2);
     let result = game.process_turn(p1_move, p2_move);
 
     state.last_p1 = p1_move;
@@ -557,7 +545,7 @@ async fn handle_timeout(
             let _ = s
                 .cmd_tx
                 .send(HostCommand::Timeout {
-                    default_move: wire_to_engine(stay),
+                    default_move: wire_to_engine_direction(stay),
                 })
                 .await;
             for &p in &s.controlled_players {

--- a/server/host/src/game_loop/playing.rs
+++ b/server/host/src/game_loop/playing.rs
@@ -263,11 +263,7 @@ pub async fn run_playing(
 
 // ── Helpers ──────────────────────────────────────────
 
-fn build_turn_state(
-    game: &GameState,
-    last_p1: Direction,
-    last_p2: Direction,
-) -> HashedTurnState {
+fn build_turn_state(game: &GameState, last_p1: Direction, last_p2: Direction) -> HashedTurnState {
     let p1 = &game.player1;
     let p2 = &game.player2;
     let hash = game.state_hash();
@@ -541,9 +537,7 @@ async fn handle_timeout(
         if !disconnected.contains(&s.session_id) && !responded.contains(&s.session_id) {
             let _ = s
                 .cmd_tx
-                .send(HostCommand::Timeout {
-                    default_move: stay,
-                })
+                .send(HostCommand::Timeout { default_move: stay })
                 .await;
             for &p in &s.controlled_players {
                 emit(

--- a/server/host/src/game_loop/playing.rs
+++ b/server/host/src/game_loop/playing.rs
@@ -7,7 +7,7 @@ use tokio::time::Instant;
 use tracing::{debug, warn};
 
 use pyrat::game::game_logic::GameState;
-use pyrat::{Coordinates, Direction as EngineDirection};
+use pyrat::Direction as EngineDirection;
 
 use crate::session::messages::{
     HashedTurnState, HostCommand, OwnedTurnState, SessionId, SessionMsg,
@@ -32,8 +32,8 @@ pub struct MatchResult {
 pub struct PlayingState {
     session_players: HashMap<SessionId, Vec<Player>>,
     disconnected: HashSet<SessionId>,
-    last_p1: WireDirection,
-    last_p2: WireDirection,
+    last_p1: EngineDirection,
+    last_p2: EngineDirection,
 }
 
 impl PlayingState {
@@ -50,8 +50,8 @@ impl PlayingState {
         Self {
             session_players,
             disconnected: HashSet::new(),
-            last_p1: WireDirection::Stay,
-            last_p2: WireDirection::Stay,
+            last_p1: EngineDirection::Stay,
+            last_p2: EngineDirection::Stay,
         }
     }
 
@@ -61,7 +61,7 @@ impl PlayingState {
     }
 
     /// Record the actions taken this turn (updates last moves for next turn state).
-    pub fn record_actions(&mut self, p1: WireDirection, p2: WireDirection) {
+    pub fn record_actions(&mut self, p1: EngineDirection, p2: EngineDirection) {
         self.last_p1 = p1;
         self.last_p2 = p2;
     }
@@ -203,16 +203,16 @@ pub async fn run_one_turn(
     let p2_move = wire_to_engine(actions.p2);
     let result = game.process_turn(p1_move, p2_move);
 
-    state.last_p1 = engine_to_wire(p1_move);
-    state.last_p2 = engine_to_wire(p2_move);
+    state.last_p1 = p1_move;
+    state.last_p2 = p2_move;
 
     // Emit TurnPlayed event.
     emit(
         event_tx,
         MatchEvent::TurnPlayed {
             state: build_turn_state(game, state.last_p1, state.last_p2),
-            p1_action: actions.p1,
-            p2_action: actions.p2,
+            p1_action: p1_move,
+            p2_action: p2_move,
             p1_think_ms: actions.p1_think_ms,
             p2_think_ms: actions.p2_think_ms,
         },
@@ -280,8 +280,8 @@ pub async fn run_playing(
 
 fn build_turn_state(
     game: &GameState,
-    last_p1: WireDirection,
-    last_p2: WireDirection,
+    last_p1: EngineDirection,
+    last_p2: EngineDirection,
 ) -> HashedTurnState {
     let p1 = &game.player1;
     let p2 = &game.player2;
@@ -289,18 +289,13 @@ fn build_turn_state(
     HashedTurnState::with_hash(
         OwnedTurnState {
             turn: game.turn,
-            player1_position: (p1.current_pos.x, p1.current_pos.y),
-            player2_position: (p2.current_pos.x, p2.current_pos.y),
+            player1_position: p1.current_pos,
+            player2_position: p2.current_pos,
             player1_score: p1.score,
             player2_score: p2.score,
             player1_mud_turns: p1.mud_timer,
             player2_mud_turns: p2.mud_timer,
-            cheese: game
-                .cheese
-                .get_all_cheese_positions()
-                .into_iter()
-                .map(|c: Coordinates| (c.x, c.y))
-                .collect(),
+            cheese: game.cheese.get_all_cheese_positions(),
             player1_last_move: last_p1,
             player2_last_move: last_p2,
         },
@@ -561,7 +556,9 @@ async fn handle_timeout(
         if !disconnected.contains(&s.session_id) && !responded.contains(&s.session_id) {
             let _ = s
                 .cmd_tx
-                .send(HostCommand::Timeout { default_move: stay })
+                .send(HostCommand::Timeout {
+                    default_move: wire_to_engine(stay),
+                })
                 .await;
             for &p in &s.controlled_players {
                 emit(
@@ -673,6 +670,7 @@ pub fn determine_result(game: &GameState) -> MatchResult {
 mod tests {
     use super::*;
     use crate::session::messages::{HostCommand, SessionId, SessionMsg};
+    use pyrat::Coordinates;
     use pyrat_wire::{Direction as WireDirection, Player};
     use std::collections::{HashMap, HashSet};
     use std::time::Duration;
@@ -775,7 +773,7 @@ mod tests {
         // Session 2 should have received a Timeout command.
         let cmd = cmd_rx2.try_recv().expect("session 2 should get Timeout");
         assert!(
-            matches!(cmd, HostCommand::Timeout { default_move } if default_move == WireDirection::Stay),
+            matches!(cmd, HostCommand::Timeout { default_move } if default_move == EngineDirection::Stay),
             "expected Timeout with Stay, got {cmd:?}"
         );
 
@@ -1172,15 +1170,15 @@ mod tests {
     fn baseline_turn_state() -> OwnedTurnState {
         OwnedTurnState {
             turn: 5,
-            player1_position: (1, 2),
-            player2_position: (3, 4),
+            player1_position: Coordinates::new(1, 2),
+            player2_position: Coordinates::new(3, 4),
             player1_score: 2.0,
             player2_score: 1.5,
             player1_mud_turns: 0,
             player2_mud_turns: 0,
-            cheese: vec![(5, 5), (10, 7)],
-            player1_last_move: WireDirection::Up,
-            player2_last_move: WireDirection::Down,
+            cheese: vec![Coordinates::new(5, 5), Coordinates::new(10, 7)],
+            player1_last_move: EngineDirection::Up,
+            player2_last_move: EngineDirection::Down,
         }
     }
 
@@ -1202,14 +1200,14 @@ mod tests {
             (
                 "p1 position",
                 OwnedTurnState {
-                    player1_position: (2, 2),
+                    player1_position: Coordinates::new(2, 2),
                     ..base.clone()
                 },
             ),
             (
                 "p2 position",
                 OwnedTurnState {
-                    player2_position: (3, 5),
+                    player2_position: Coordinates::new(3, 5),
                     ..base.clone()
                 },
             ),
@@ -1244,28 +1242,28 @@ mod tests {
             (
                 "one less cheese",
                 OwnedTurnState {
-                    cheese: vec![(5, 5)],
+                    cheese: vec![Coordinates::new(5, 5)],
                     ..base.clone()
                 },
             ),
             (
                 "cheese offset by 1",
                 OwnedTurnState {
-                    cheese: vec![(5, 6), (10, 7)],
+                    cheese: vec![Coordinates::new(5, 6), Coordinates::new(10, 7)],
                     ..base.clone()
                 },
             ),
             (
                 "p1 last move",
                 OwnedTurnState {
-                    player1_last_move: WireDirection::Right,
+                    player1_last_move: EngineDirection::Right,
                     ..base.clone()
                 },
             ),
             (
                 "p2 last move",
                 OwnedTurnState {
-                    player2_last_move: WireDirection::Left,
+                    player2_last_move: EngineDirection::Left,
                     ..base.clone()
                 },
             ),

--- a/server/host/src/game_loop/setup.rs
+++ b/server/host/src/game_loop/setup.rs
@@ -9,7 +9,7 @@ use tracing::{debug, info, info_span, warn, Instrument};
 use crate::session::messages::{HashedTurnState, HostCommand, OwnedTurnState};
 use crate::session::{run_session, SessionConfig, SessionId, SessionMsg};
 
-use pyrat_wire::{Direction as WireDirection, Player};
+use pyrat_wire::Player;
 
 use super::config::{MatchSetup, SessionHandle};
 use super::events::{emit, MatchEvent};
@@ -255,8 +255,8 @@ pub async fn run_setup(
         player1_mud_turns: 0,
         player2_mud_turns: 0,
         cheese: setup.match_config.cheese.clone(),
-        player1_last_move: WireDirection::Stay,
-        player2_last_move: WireDirection::Stay,
+        player1_last_move: pyrat::Direction::Stay,
+        player2_last_move: pyrat::Direction::Stay,
     })
     .state_hash();
 

--- a/server/host/src/session/codec.rs
+++ b/server/host/src/session/codec.rs
@@ -2,18 +2,20 @@
 
 use flatbuffers::FlatBufferBuilder;
 
+use pyrat::Coordinates;
+use pyrat_protocol::{engine_to_wire_direction, wire_to_engine_direction};
+
 use crate::session::messages::{HostCommand, OwnedInfo, OwnedMatchConfig, OwnedOptionDef};
 use pyrat_wire::{self as wire, BotMessage, HostMessage, HostPacket, HostPacketArgs, Vec2};
 
 // ── Helpers ─────────────────────────────────────────
 
-fn vec2_to_tuple(v: &Vec2) -> (u8, u8) {
-    (v.x(), v.y())
+fn vec2_to_coords(v: &Vec2) -> Coordinates {
+    Coordinates::new(v.x(), v.y())
 }
 
-#[allow(dead_code)] // Used by extract_match_config; consumed by game loop later.
-fn vec2_opt(v: Option<&Vec2>) -> (u8, u8) {
-    v.map_or((0, 0), vec2_to_tuple)
+fn vec2_opt(v: Option<&Vec2>) -> Coordinates {
+    v.map_or(Coordinates::new(0, 0), vec2_to_coords)
 }
 
 // ── Extraction: borrowed FlatBuffers → owned types ──
@@ -98,11 +100,14 @@ pub fn extract_bot_packet(buf: &[u8]) -> Result<(BotMessage, BotPayload), String
         BotPayload::Info(OwnedInfo {
             player: info.player(),
             multipv: info.multipv(),
-            target: info.target().map(vec2_to_tuple),
+            target: info.target().map(vec2_to_coords),
             depth: info.depth(),
             nodes: info.nodes(),
             score: info.score(),
-            pv: info.pv().map(|p| p.iter().collect()).unwrap_or_default(),
+            pv: info
+                .pv()
+                .map(|p| p.iter().map(wire_to_engine_direction).collect())
+                .unwrap_or_default(),
             message: info.message().unwrap_or("").to_owned(),
             turn: info.turn(),
             state_hash: info.state_hash(),
@@ -142,12 +147,12 @@ pub fn serialize_host_command(fbb: &mut FlatBufferBuilder<'_>, cmd: &HostCommand
             let walls: Vec<_> = cfg
                 .walls
                 .iter()
-                .map(|&((x1, y1), (x2, y2))| {
+                .map(|(c1, c2)| {
                     wire::Wall::create(
                         fbb,
                         &wire::WallArgs {
-                            pos1: Some(&Vec2::new(x1, y1)),
-                            pos2: Some(&Vec2::new(x2, y2)),
+                            pos1: Some(&Vec2::new(c1.x, c1.y)),
+                            pos2: Some(&Vec2::new(c2.x, c2.y)),
                         },
                     )
                 })
@@ -157,20 +162,20 @@ pub fn serialize_host_command(fbb: &mut FlatBufferBuilder<'_>, cmd: &HostCommand
             let muds: Vec<_> = cfg
                 .mud
                 .iter()
-                .map(|&((x1, y1), (x2, y2), v)| {
+                .map(|(c1, c2, v)| {
                     wire::Mud::create(
                         fbb,
                         &wire::MudArgs {
-                            pos1: Some(&Vec2::new(x1, y1)),
-                            pos2: Some(&Vec2::new(x2, y2)),
-                            value: v,
+                            pos1: Some(&Vec2::new(c1.x, c1.y)),
+                            pos2: Some(&Vec2::new(c2.x, c2.y)),
+                            value: *v,
                         },
                     )
                 })
                 .collect();
             let muds = fbb.create_vector(&muds);
 
-            let cheese_vec: Vec<Vec2> = cfg.cheese.iter().map(|&(x, y)| Vec2::new(x, y)).collect();
+            let cheese_vec: Vec<Vec2> = cfg.cheese.iter().map(|c| Vec2::new(c.x, c.y)).collect();
             let cheese = fbb.create_vector(&cheese_vec);
 
             let players = fbb.create_vector(&cfg.controlled_players);
@@ -184,8 +189,8 @@ pub fn serialize_host_command(fbb: &mut FlatBufferBuilder<'_>, cmd: &HostCommand
                     walls: Some(walls),
                     mud: Some(muds),
                     cheese: Some(cheese),
-                    player1_start: Some(&Vec2::new(cfg.player1_start.0, cfg.player1_start.1)),
-                    player2_start: Some(&Vec2::new(cfg.player2_start.0, cfg.player2_start.1)),
+                    player1_start: Some(&Vec2::new(cfg.player1_start.x, cfg.player1_start.y)),
+                    player2_start: Some(&Vec2::new(cfg.player2_start.x, cfg.player2_start.y)),
                     controlled_players: Some(players),
                     timing: cfg.timing,
                     move_timeout_ms: cfg.move_timeout_ms,
@@ -204,7 +209,7 @@ pub fn serialize_host_command(fbb: &mut FlatBufferBuilder<'_>, cmd: &HostCommand
             (HostMessage::StartPreprocessing, off.as_union_value())
         },
         HostCommand::TurnState(ts) => {
-            let cheese_vec: Vec<Vec2> = ts.cheese.iter().map(|&(x, y)| Vec2::new(x, y)).collect();
+            let cheese_vec: Vec<Vec2> = ts.cheese.iter().map(|c| Vec2::new(c.x, c.y)).collect();
             let cheese = fbb.create_vector(&cheese_vec);
 
             let off = wire::TurnState::create(
@@ -212,20 +217,20 @@ pub fn serialize_host_command(fbb: &mut FlatBufferBuilder<'_>, cmd: &HostCommand
                 &wire::TurnStateArgs {
                     turn: ts.turn,
                     player1_position: Some(&Vec2::new(
-                        ts.player1_position.0,
-                        ts.player1_position.1,
+                        ts.player1_position.x,
+                        ts.player1_position.y,
                     )),
                     player2_position: Some(&Vec2::new(
-                        ts.player2_position.0,
-                        ts.player2_position.1,
+                        ts.player2_position.x,
+                        ts.player2_position.y,
                     )),
                     player1_score: ts.player1_score,
                     player2_score: ts.player2_score,
                     player1_mud_turns: ts.player1_mud_turns,
                     player2_mud_turns: ts.player2_mud_turns,
                     cheese: Some(cheese),
-                    player1_last_move: ts.player1_last_move,
-                    player2_last_move: ts.player2_last_move,
+                    player1_last_move: engine_to_wire_direction(ts.player1_last_move),
+                    player2_last_move: engine_to_wire_direction(ts.player2_last_move),
                     state_hash: ts.state_hash(),
                 },
             );
@@ -235,7 +240,7 @@ pub fn serialize_host_command(fbb: &mut FlatBufferBuilder<'_>, cmd: &HostCommand
             let off = wire::Timeout::create(
                 fbb,
                 &wire::TimeoutArgs {
-                    default_move: *default_move,
+                    default_move: engine_to_wire_direction(*default_move),
                 },
             );
             (HostMessage::Timeout, off.as_union_value())
@@ -315,7 +320,7 @@ pub fn extract_match_config(mc: &wire::MatchConfig<'_>) -> OwnedMatchConfig {
             .unwrap_or_default(),
         cheese: mc
             .cheese()
-            .map(|cs| (0..cs.len()).map(|i| vec2_to_tuple(cs.get(i))).collect())
+            .map(|cs| (0..cs.len()).map(|i| vec2_to_coords(cs.get(i))).collect())
             .unwrap_or_default(),
         player1_start: vec2_opt(mc.player1_start()),
         player2_start: vec2_opt(mc.player2_start()),
@@ -333,6 +338,7 @@ pub fn extract_match_config(mc: &wire::MatchConfig<'_>) -> OwnedMatchConfig {
 mod tests {
     use super::*;
     use crate::session::messages::{HashedTurnState, OwnedTurnState};
+    use pyrat::Coordinates;
     use pyrat_wire::{Direction, GameResult, Player, TimingMode};
 
     // Helper: build a BotPacket with Identify
@@ -514,11 +520,14 @@ mod tests {
             width: 21,
             height: 15,
             max_turns: 300,
-            walls: vec![((0, 0), (0, 1)), ((1, 2), (2, 2))],
-            mud: vec![((3, 3), (3, 4), 5)],
-            cheese: vec![(10, 7), (5, 3)],
-            player1_start: (20, 14),
-            player2_start: (0, 0),
+            walls: vec![
+                (Coordinates::new(0, 0), Coordinates::new(0, 1)),
+                (Coordinates::new(1, 2), Coordinates::new(2, 2)),
+            ],
+            mud: vec![(Coordinates::new(3, 3), Coordinates::new(3, 4), 5)],
+            cheese: vec![Coordinates::new(10, 7), Coordinates::new(5, 3)],
+            player1_start: Coordinates::new(20, 14),
+            player2_start: Coordinates::new(0, 0),
             controlled_players: vec![Player::Player1],
             timing: TimingMode::Wait,
             move_timeout_ms: 1000,
@@ -554,15 +563,15 @@ mod tests {
         let mut fbb = FlatBufferBuilder::new();
         let ts = HashedTurnState::new(OwnedTurnState {
             turn: 42,
-            player1_position: (10, 7),
-            player2_position: (0, 0),
+            player1_position: Coordinates::new(10, 7),
+            player2_position: Coordinates::new(0, 0),
             player1_score: 3.0,
             player2_score: 2.5,
             player1_mud_turns: 0,
             player2_mud_turns: 2,
-            cheese: vec![(5, 5), (15, 10)],
-            player1_last_move: Direction::Up,
-            player2_last_move: Direction::Right,
+            cheese: vec![Coordinates::new(5, 5), Coordinates::new(15, 10)],
+            player1_last_move: pyrat::Direction::Up,
+            player2_last_move: pyrat::Direction::Right,
         });
         let expected_hash = ts.state_hash();
         let cmd = HostCommand::TurnState(Box::new(ts));
@@ -622,7 +631,7 @@ mod tests {
     fn round_trip_timeout() {
         let mut fbb = FlatBufferBuilder::new();
         let cmd = HostCommand::Timeout {
-            default_move: Direction::Stay,
+            default_move: pyrat::Direction::Stay,
         };
         let bytes = serialize_host_command(&mut fbb, &cmd);
         let packet = flatbuffers::root::<HostPacket>(&bytes).unwrap();
@@ -706,11 +715,11 @@ mod tests {
             BotPayload::Info(info) => {
                 assert_eq!(info.player, Player::Player2);
                 assert_eq!(info.multipv, 3);
-                assert_eq!(info.target, Some((10, 7)));
+                assert_eq!(info.target, Some(Coordinates::new(10, 7)));
                 assert_eq!(info.depth, 5);
                 assert_eq!(info.nodes, 42000);
                 assert!((info.score.unwrap() - 2.5).abs() < f32::EPSILON);
-                assert_eq!(info.pv, vec![Direction::Up, Direction::Left]);
+                assert_eq!(info.pv, vec![pyrat::Direction::Up, pyrat::Direction::Left]);
                 assert_eq!(info.message, "depth 5");
                 assert_eq!(info.turn, 7);
                 assert_eq!(info.state_hash, 0xDEAD_BEEF_CAFE_BABE);
@@ -744,7 +753,7 @@ mod tests {
         let bytes = serialize_host_command(
             &mut fbb,
             &HostCommand::Timeout {
-                default_move: Direction::Down,
+                default_move: pyrat::Direction::Down,
             },
         );
         let packet = flatbuffers::root::<HostPacket>(&bytes).unwrap();

--- a/server/host/src/session/messages.rs
+++ b/server/host/src/session/messages.rs
@@ -1,9 +1,11 @@
-use std::hash::{Hash, Hasher};
-use std::ops::Deref;
-
 use tokio::sync::mpsc;
 
-use pyrat_wire::{Direction, GameResult, OptionType, Player, TimingMode};
+use pyrat_wire::{GameResult, Player};
+
+// Re-export protocol types so internal `use crate::session::messages::*` paths stay valid.
+pub use pyrat_protocol::{
+    HashedTurnState, MudEntry, OwnedInfo, OwnedMatchConfig, OwnedOptionDef, OwnedTurnState,
+};
 
 // ── Session identity ────────────────────────────────
 
@@ -14,139 +16,6 @@ pub struct SessionId(pub u64);
 impl SessionId {
     /// Placeholder ID for non-game sessions (stubs, test harnesses, etc.).
     pub const STUB: Self = Self(u64::MAX);
-}
-
-// ── Owned types extracted from FlatBuffers ──────────
-
-/// Owned copy of a bot-declared option (from Identify).
-#[derive(Debug, Clone)]
-pub struct OwnedOptionDef {
-    pub name: String,
-    pub option_type: OptionType,
-    pub default_value: String,
-    pub min: i32,
-    pub max: i32,
-    pub choices: Vec<String>,
-}
-
-/// Owned copy of a bot Info message.
-#[derive(Debug, Clone)]
-pub struct OwnedInfo {
-    pub player: Player,
-    pub multipv: u16,
-    pub target: Option<(u8, u8)>,
-    pub depth: u16,
-    pub nodes: u32,
-    pub score: Option<f32>,
-    pub pv: Vec<Direction>,
-    pub message: String,
-    pub turn: u16,
-    pub state_hash: u64,
-}
-
-/// Mud entry: (pos1, pos2, mud_value).
-pub type MudEntry = ((u8, u8), (u8, u8), u8);
-
-/// Owned match configuration sent to the bot.
-#[derive(Debug, Clone)]
-pub struct OwnedMatchConfig {
-    pub width: u8,
-    pub height: u8,
-    pub max_turns: u16,
-    pub walls: Vec<((u8, u8), (u8, u8))>,
-    pub mud: Vec<MudEntry>,
-    pub cheese: Vec<(u8, u8)>,
-    pub player1_start: (u8, u8),
-    pub player2_start: (u8, u8),
-    pub controlled_players: Vec<Player>,
-    pub timing: TimingMode,
-    pub move_timeout_ms: u32,
-    pub preprocessing_timeout_ms: u32,
-}
-
-/// Owned turn state sent to the bot each turn.
-///
-/// Contains the raw game-position fields. Does **not** include `state_hash`,
-/// which is a derived value. Use [`HashedTurnState`] to pair a turn state with
-/// its content-addressable hash.
-///
-/// If you add or change position-defining fields here, update
-/// [`HashedTurnState::compute_hash`] in this same file.
-#[derive(Debug, Clone)]
-pub struct OwnedTurnState {
-    pub turn: u16,
-    pub player1_position: (u8, u8),
-    pub player2_position: (u8, u8),
-    pub player1_score: f32,
-    pub player2_score: f32,
-    pub player1_mud_turns: u8,
-    pub player2_mud_turns: u8,
-    pub cheese: Vec<(u8, u8)>,
-    pub player1_last_move: Direction,
-    pub player2_last_move: Direction,
-}
-
-/// An [`OwnedTurnState`] paired with a content-addressable hash of its
-/// position-defining fields.
-///
-/// The hash is computed once at construction time. Two states that a bot would
-/// analyze differently will hash differently.
-#[derive(Debug, Clone)]
-pub struct HashedTurnState {
-    inner: OwnedTurnState,
-    state_hash: u64,
-}
-
-impl HashedTurnState {
-    /// Wrap a turn state, computing the hash from its fields.
-    pub fn new(ts: OwnedTurnState) -> Self {
-        let state_hash = Self::compute_hash(&ts);
-        Self {
-            inner: ts,
-            state_hash,
-        }
-    }
-
-    /// Wrap a turn state with a pre-computed hash (from `GameState::state_hash()`).
-    pub fn with_hash(ts: OwnedTurnState, state_hash: u64) -> Self {
-        Self {
-            inner: ts,
-            state_hash,
-        }
-    }
-
-    /// The content-addressable hash for this turn state.
-    pub fn state_hash(&self) -> u64 {
-        self.state_hash
-    }
-
-    /// Deterministic hash of all game-position fields.
-    ///
-    /// Two states that a bot would analyze differently must hash differently.
-    /// If you add a field to [`OwnedTurnState`], update this function.
-    fn compute_hash(ts: &OwnedTurnState) -> u64 {
-        let mut h = std::collections::hash_map::DefaultHasher::new();
-        ts.turn.hash(&mut h);
-        ts.player1_position.hash(&mut h);
-        ts.player2_position.hash(&mut h);
-        // Hash scores as half-point u16 to avoid float instability
-        ((ts.player1_score * 2.0) as u16).hash(&mut h);
-        ((ts.player2_score * 2.0) as u16).hash(&mut h);
-        ts.player1_mud_turns.hash(&mut h);
-        ts.player2_mud_turns.hash(&mut h);
-        ts.cheese.hash(&mut h);
-        ts.player1_last_move.0.hash(&mut h);
-        ts.player2_last_move.0.hash(&mut h);
-        h.finish()
-    }
-}
-
-impl Deref for HashedTurnState {
-    type Target = OwnedTurnState;
-
-    fn deref(&self) -> &OwnedTurnState {
-        &self.inner
-    }
 }
 
 // ── Session → Game loop ─────────────────────────────
@@ -179,7 +48,7 @@ pub enum SessionMsg {
     Action {
         session_id: SessionId,
         player: Player,
-        direction: Direction,
+        direction: pyrat_wire::Direction,
         turn: u16,
         provisional: bool,
         think_ms: u32,
@@ -226,7 +95,7 @@ pub enum HostCommand {
     },
     TurnState(Box<HashedTurnState>),
     Timeout {
-        default_move: Direction,
+        default_move: pyrat::Direction,
     },
     GameOver {
         result: GameResult,

--- a/server/host/src/session/messages.rs
+++ b/server/host/src/session/messages.rs
@@ -48,7 +48,7 @@ pub enum SessionMsg {
     Action {
         session_id: SessionId,
         player: Player,
-        direction: pyrat_wire::Direction,
+        direction: pyrat::Direction,
         turn: u16,
         provisional: bool,
         think_ms: u32,

--- a/server/host/src/session/mod.rs
+++ b/server/host/src/session/mod.rs
@@ -16,6 +16,7 @@ use tokio::time::Instant;
 use tracing::{debug, info, trace, warn};
 
 use codec::serialize_host_command;
+use pyrat_protocol::wire_to_engine_direction;
 use pyrat_wire::framing::{FrameError, FrameReader, FrameWriter};
 use pyrat_wire::{BotMessage, Player};
 
@@ -459,7 +460,7 @@ async fn handle_bot_frame(
             SessionMsg::Action {
                 session_id,
                 player,
-                direction,
+                direction: wire_to_engine_direction(direction),
                 turn,
                 provisional,
                 think_ms,

--- a/server/host/src/stub.rs
+++ b/server/host/src/stub.rs
@@ -138,7 +138,7 @@ async fn run_stub(
                             depth: 1,
                             nodes: 1,
                             score: Some(0.0),
-                            pv: vec![dir],
+                            pv: vec![pyrat_protocol::wire_to_engine_direction(dir)],
                             message: "stub".into(),
                             turn,
                             state_hash: 0,

--- a/server/host/src/stub.rs
+++ b/server/host/src/stub.rs
@@ -10,7 +10,8 @@ use tracing::debug;
 
 use crate::session::messages::{HostCommand, OwnedInfo, SessionMsg};
 use crate::session::SessionId;
-use pyrat_wire::{Direction, Player};
+use pyrat::Direction;
+use pyrat_wire::Player;
 
 /// The four movement directions (excludes Stay).
 const MOVES: [Direction; 4] = [
@@ -138,7 +139,7 @@ async fn run_stub(
                             depth: 1,
                             nodes: 1,
                             score: Some(0.0),
-                            pv: vec![pyrat_protocol::wire_to_engine_direction(dir)],
+                            pv: vec![dir],
                             message: "stub".into(),
                             turn,
                             state_hash: 0,

--- a/server/host/tests/common/mod.rs
+++ b/server/host/tests/common/mod.rs
@@ -97,9 +97,9 @@ pub fn simple_match_config() -> OwnedMatchConfig {
         max_turns: 300,
         walls: vec![],
         mud: vec![],
-        cheese: vec![(10, 7)],
-        player1_start: (20, 14),
-        player2_start: (0, 0),
+        cheese: vec![Coordinates::new(10, 7)],
+        player1_start: Coordinates::new(20, 14),
+        player2_start: Coordinates::new(0, 0),
         controlled_players: vec![], // setup phase fills this
         timing: TimingMode::Wait,
         move_timeout_ms: 1000,

--- a/server/host/tests/session_integration.rs
+++ b/server/host/tests/session_integration.rs
@@ -7,6 +7,9 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time::timeout;
 
+use pyrat::Coordinates;
+use pyrat::Direction as EngineDirection;
+
 use pyrat_host::session::messages::*;
 use pyrat_host::session::{run_session, SessionConfig};
 use pyrat_host::wire::framing::{FrameReader, FrameWriter};
@@ -167,15 +170,15 @@ async fn happy_path_full_lifecycle() {
         .send(HostCommand::TurnState(Box::new(HashedTurnState::new(
             OwnedTurnState {
                 turn: 1,
-                player1_position: (20, 14),
-                player2_position: (0, 0),
+                player1_position: Coordinates::new(20, 14),
+                player2_position: Coordinates::new(0, 0),
                 player1_score: 0.0,
                 player2_score: 0.0,
                 player1_mud_turns: 0,
                 player2_mud_turns: 0,
-                cheese: vec![(10, 7)],
-                player1_last_move: Direction::Stay,
-                player2_last_move: Direction::Stay,
+                cheese: vec![Coordinates::new(10, 7)],
+                player1_last_move: EngineDirection::Stay,
+                player2_last_move: EngineDirection::Stay,
             },
         ))))
         .await
@@ -673,15 +676,15 @@ async fn stop_sends_wire_stop_and_session_stays_alive() {
         .send(HostCommand::TurnState(Box::new(HashedTurnState::new(
             OwnedTurnState {
                 turn: 1,
-                player1_position: (20, 14),
-                player2_position: (0, 0),
+                player1_position: Coordinates::new(20, 14),
+                player2_position: Coordinates::new(0, 0),
                 player1_score: 0.0,
                 player2_score: 0.0,
                 player1_mud_turns: 0,
                 player2_mud_turns: 0,
-                cheese: vec![(10, 7)],
-                player1_last_move: Direction::Stay,
-                player2_last_move: Direction::Stay,
+                cheese: vec![Coordinates::new(10, 7)],
+                player1_last_move: EngineDirection::Stay,
+                player2_last_move: EngineDirection::Stay,
             },
         ))))
         .await

--- a/server/host/tests/session_integration.rs
+++ b/server/host/tests/session_integration.rs
@@ -201,7 +201,7 @@ async fn happy_path_full_lifecycle() {
             ..
         } => {
             assert_eq!(player, Player::Player1);
-            assert_eq!(direction, Direction::Left);
+            assert_eq!(direction, EngineDirection::Left);
             assert_eq!(turn, 1);
         },
         other => panic!("expected Action, got {other:?}"),
@@ -359,7 +359,7 @@ async fn ownership_validation_rejects_non_controlled_player() {
             player, direction, ..
         } => {
             assert_eq!(player, Player::Player1);
-            assert_eq!(direction, Direction::Down);
+            assert_eq!(direction, EngineDirection::Down);
         },
         other => panic!("expected Action, got {other:?}"),
     }
@@ -597,7 +597,7 @@ async fn default_player_inference_single_bot() {
             player, direction, ..
         } => {
             assert_eq!(player, Player::Player2, "should be inferred as Python");
-            assert_eq!(direction, Direction::Up);
+            assert_eq!(direction, EngineDirection::Up);
         },
         other => panic!("expected Action, got {other:?}"),
     }

--- a/server/protocol/Cargo.toml
+++ b/server/protocol/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "pyrat-protocol"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+pyrat-rust = { path = "../../engine", default-features = false }
+pyrat-wire = { path = "../wire" }
+
+[lints]
+workspace = true

--- a/server/protocol/src/lib.rs
+++ b/server/protocol/src/lib.rs
@@ -1,8 +1,8 @@
 //! Protocol vocabulary for the PyRat host-bot communication.
 //!
-//! This crate defines the owned types that both the host and SDK use to
-//! represent protocol messages. The FlatBuffers codec converts at the wire
-//! boundary; from that point on, everything speaks these types.
+//! This crate defines the owned types shared between host and SDK for
+//! protocol messages. The FlatBuffers codec converts at the wire boundary;
+//! from that point on, everything speaks these types.
 //!
 //! The [`HostMsg`] and [`BotMsg`] enums define the Player trait pipe vocabulary:
 //! what the Match sends and receives through `Player::send()`/`Player::recv()`.

--- a/server/protocol/src/lib.rs
+++ b/server/protocol/src/lib.rs
@@ -1,0 +1,17 @@
+//! Protocol vocabulary for the PyRat host-bot communication.
+//!
+//! This crate defines the owned types that both the host and SDK use to
+//! represent protocol messages. The FlatBuffers codec converts at the wire
+//! boundary; from that point on, everything speaks these types.
+//!
+//! The [`HostMsg`] and [`BotMsg`] enums define the Player trait pipe vocabulary:
+//! what the Match sends and receives through `Player::send()`/`Player::recv()`.
+
+mod messages;
+mod types;
+
+pub use messages::*;
+pub use types::*;
+
+// Re-export wire types that are protocol concepts without engine equivalents.
+pub use pyrat_wire::{GameResult, OptionType, Player, TimingMode};

--- a/server/protocol/src/messages.rs
+++ b/server/protocol/src/messages.rs
@@ -1,0 +1,150 @@
+//! Protocol message enums: the vocabulary of the Player trait pipe.
+//!
+//! `HostMsg` is what the host sends to a player. `BotMsg` is what a player
+//! sends back. The Match drives the protocol by sending and receiving these
+//! messages through the Player trait's `send`/`recv` methods.
+//!
+//! These enums define the *new* protocol from the protocol spec. They are
+//! distinct from the host-internal `HostCommand`/`SessionMsg` channel types,
+//! which will eventually be replaced.
+
+use pyrat::Direction;
+use pyrat_wire::{GameResult, Player};
+
+use crate::{OwnedInfo, OwnedMatchConfig, OwnedOptionDef, OwnedTurnState};
+
+// ── Search limits ───────────────────────────────────
+
+/// Search limits sent with Go/GoState, analogous to UCI `go` variants.
+///
+/// All fields are optional. Unset = unconstrained.
+#[derive(Debug, Clone, Default)]
+pub struct SearchLimits {
+    /// Think for up to N milliseconds. `None` = no time limit.
+    pub timeout_ms: Option<u32>,
+    /// Search to depth N. `None` = no depth limit.
+    pub depth: Option<u16>,
+    /// Search N nodes. `None` = no node limit.
+    pub nodes: Option<u32>,
+}
+
+// ── Host → Player ───────────────────────────────────
+
+/// Message from host to player.
+///
+/// The Match sends these through `Player::send()`. Each variant corresponds
+/// to a protocol message from the spec.
+#[derive(Debug)]
+pub enum HostMsg {
+    /// Waiting phase: assign player slot after Identify.
+    Welcome { player_slot: Player },
+
+    /// Lobby phase: configure options and send match config.
+    Configure {
+        options: Vec<(String, String)>,
+        match_config: Box<OwnedMatchConfig>,
+    },
+
+    /// Playing phase: begin preprocessing.
+    GoPreprocess { state_hash: u64 },
+
+    /// Playing phase: delta update after a turn. Both directions, new turn
+    /// number, and the hash of the resulting state.
+    Advance {
+        p1_dir: Direction,
+        p2_dir: Direction,
+        turn: u16,
+        new_hash: u64,
+    },
+
+    /// Playing phase: start thinking. Player is already synced via Advance/SyncOk.
+    Go {
+        state_hash: u64,
+        limits: SearchLimits,
+    },
+
+    /// Playing phase: start thinking on an arbitrary state. No prior sync needed.
+    /// Used for analysis mode, restart, and reconnection recovery.
+    GoState {
+        turn_state: Box<OwnedTurnState>,
+        state_hash: u64,
+        limits: SearchLimits,
+    },
+
+    /// Playing phase: stop thinking, send best action immediately.
+    Stop,
+
+    /// Any phase: full reconstruction payload, response to Resync.
+    FullState {
+        match_config: Box<OwnedMatchConfig>,
+        turn_state: Box<OwnedTurnState>,
+    },
+
+    /// Any phase: protocol violation, followed by disconnect.
+    ProtocolError { reason: String },
+
+    /// End: game is over.
+    GameOver {
+        result: GameResult,
+        player1_score: f32,
+        player2_score: f32,
+    },
+}
+
+// ── Player → Host ───────────────────────────────────
+
+/// Message from player to host.
+///
+/// The Match receives these through `Player::recv()`.
+#[derive(Debug)]
+pub enum BotMsg {
+    /// Waiting phase: identify and declare configurable options.
+    Identify {
+        name: String,
+        author: String,
+        agent_id: String,
+        options: Vec<OwnedOptionDef>,
+    },
+
+    /// Lobby phase: ready with state hash (initial sync).
+    Ready { state_hash: u64 },
+
+    /// Playing phase: preprocessing complete.
+    PreprocessingDone,
+
+    /// Playing phase: state sync confirmed after Advance.
+    SyncOk { hash: u64 },
+
+    /// Any phase: client detected hash mismatch, requests FullState.
+    Resync { my_hash: u64 },
+
+    /// Playing phase: committed action for this turn.
+    Action {
+        direction: Direction,
+        player: Player,
+        turn: u16,
+        state_hash: u64,
+        think_ms: u32,
+    },
+
+    /// Playing phase: provisional best-so-far action. Host holds latest
+    /// as fallback if the bot doesn't commit in time.
+    Provisional {
+        direction: Direction,
+        player: Player,
+        turn: u16,
+        state_hash: u64,
+    },
+
+    /// Playing phase: analysis/debug info (sideband). Host forwards to
+    /// event stream without inspecting.
+    Info(OwnedInfo),
+
+    /// Playing phase: render commands for GUI visualization (sideband).
+    /// Body TBD (separate brief).
+    RenderCommands {
+        player: Player,
+        turn: u16,
+        state_hash: u64,
+    },
+}

--- a/server/protocol/src/messages.rs
+++ b/server/protocol/src/messages.rs
@@ -17,7 +17,9 @@ use crate::{OwnedInfo, OwnedMatchConfig, OwnedOptionDef, OwnedTurnState};
 
 /// Search limits sent with Go/GoState, analogous to UCI `go` variants.
 ///
-/// All fields are optional. Unset = unconstrained.
+/// All fields are optional. Unset = unconstrained. Combines into a single
+/// flat struct: `go timeout 100`, `go depth 5`, `go nodes 10000`, or
+/// `go infinite` (all fields `None`).
 #[derive(Debug, Clone, Default)]
 pub struct SearchLimits {
     /// Think for up to N milliseconds. `None` = no time limit.
@@ -37,19 +39,39 @@ pub struct SearchLimits {
 #[derive(Debug)]
 pub enum HostMsg {
     /// Waiting phase: assign player slot after Identify.
+    ///
+    /// Sent once per client in response to [`BotMsg::Identify`]. The server
+    /// assigns the slot; the client does not choose. Once all players are
+    /// welcomed, the match transitions to the Lobby phase.
     Welcome { player_slot: Player },
 
     /// Lobby phase: configure options and send match config.
+    ///
+    /// Batches option overrides and the full maze/timing configuration in one
+    /// message. The client loads the config, computes the initial state hash,
+    /// and responds with [`BotMsg::Ready`]. Options may be empty if the bot
+    /// declared none in Identify.
     Configure {
         options: Vec<(String, String)>,
         match_config: Box<OwnedMatchConfig>,
     },
 
     /// Playing phase: begin preprocessing.
+    ///
+    /// Sent once per match, before the turn loop. The client may send
+    /// [`BotMsg::Info`] and [`BotMsg::RenderCommands`] during preprocessing
+    /// (but not [`BotMsg::Provisional`]). Ends when the client sends
+    /// [`BotMsg::PreprocessingDone`].
     GoPreprocess { state_hash: u64 },
 
-    /// Playing phase: delta update after a turn. Both directions, new turn
-    /// number, and the hash of the resulting state.
+    /// Playing phase: delta update after a turn.
+    ///
+    /// Carries both directions, the new turn number, and the hash of the
+    /// resulting state. The client applies the directions locally and verifies
+    /// `new_hash` against its own computation. On match, it responds with
+    /// [`BotMsg::SyncOk`]. On mismatch, it sends [`BotMsg::Resync`].
+    ///
+    /// Not sent before the first turn (players are already synced from Ready).
     Advance {
         p1_dir: Direction,
         p2_dir: Direction,
@@ -57,14 +79,22 @@ pub enum HostMsg {
         new_hash: u64,
     },
 
-    /// Playing phase: start thinking. Player is already synced via Advance/SyncOk.
+    /// Playing phase: start thinking.
+    ///
+    /// Lightweight: hash + search limits only. The player is already synced
+    /// via the Advance/SyncOk exchange. Sent to both players simultaneously
+    /// after both have sent [`BotMsg::SyncOk`] (fairness gate). On the first
+    /// turn, sent directly after all Ready messages (no preceding Advance).
     Go {
         state_hash: u64,
         limits: SearchLimits,
     },
 
-    /// Playing phase: start thinking on an arbitrary state. No prior sync needed.
-    /// Used for analysis mode, restart, and reconnection recovery.
+    /// Playing phase: start thinking on an arbitrary state.
+    ///
+    /// Self-contained: carries full turn state, hash, and search limits. No
+    /// prior Advance/SyncOk exchange needed. Used for analysis mode (GUI sends
+    /// arbitrary position), restart, and reconnection recovery.
     GoState {
         turn_state: Box<OwnedTurnState>,
         state_hash: u64,
@@ -72,18 +102,37 @@ pub enum HostMsg {
     },
 
     /// Playing phase: stop thinking, send best action immediately.
+    ///
+    /// No fields. The bot sends its best [`BotMsg::Action`] as soon as
+    /// possible (best effort). The server resolves on its own schedule:
+    /// committed Action > latest Provisional > STAY. Covers both
+    /// deadline-fired (timeout) and consumer-triggered (GUI pause) stops.
     Stop,
 
-    /// Any phase: full reconstruction payload, response to Resync.
+    /// Any phase: full reconstruction payload, response to [`BotMsg::Resync`].
+    ///
+    /// Carries MatchConfig + TurnState (~2-4 KB). The client loads it,
+    /// recomputes the hash, and sends [`BotMsg::SyncOk`]. The current phase
+    /// is preserved: recovery returns to where the client was, not back to
+    /// the start.
     FullState {
         match_config: Box<OwnedMatchConfig>,
         turn_state: Box<OwnedTurnState>,
     },
 
     /// Any phase: protocol violation, followed by disconnect.
+    ///
+    /// Terminal. No recoverable protocol errors: if a client violates the
+    /// protocol, the server cannot trust it. Sideband errors (malformed Info
+    /// or RenderCommands) are a different category: logged and dropped, since
+    /// they don't affect game state.
     ProtocolError { reason: String },
 
     /// End: game is over.
+    ///
+    /// Sent instead of [`Advance`](Self::Advance) when the game ends.
+    /// Transitions to PostMatch: clients have a cleanup window (persist data,
+    /// diagnostics, final Info) before the connection closes.
     GameOver {
         result: GameResult,
         player1_score: f32,
@@ -99,6 +148,11 @@ pub enum HostMsg {
 #[derive(Debug)]
 pub enum BotMsg {
     /// Waiting phase: identify and declare configurable options.
+    ///
+    /// First message after connect. `options` are UCI-style declarations
+    /// (name, type, default, constraints) advertising knobs the host or GUI
+    /// can set. Empty list if the bot has no configurable parameters. Server
+    /// responds with [`HostMsg::Welcome`].
     Identify {
         name: String,
         author: String,
@@ -107,18 +161,39 @@ pub enum BotMsg {
     },
 
     /// Lobby phase: ready with state hash (initial sync).
+    ///
+    /// This IS the initial sync: no separate exchange needed. The server
+    /// verifies the hash against its own state. All hashes match → transition
+    /// to Playing. Mismatch → the match cannot start.
     Ready { state_hash: u64 },
 
     /// Playing phase: preprocessing complete.
+    ///
+    /// Transitions the player to Idle. Next message from the host will be
+    /// [`HostMsg::Go`] (first turn) or [`HostMsg::Advance`] (if waiting for
+    /// the other player to finish preprocessing).
     PreprocessingDone,
 
     /// Playing phase: state sync confirmed after Advance.
+    ///
+    /// Part of the fairness gate: the server waits for both players to send
+    /// SyncOk before sending [`HostMsg::Go`] to either. Near-instant (just a
+    /// hash compare on the client side).
     SyncOk { hash: u64 },
 
     /// Any phase: client detected hash mismatch, requests FullState.
+    ///
+    /// Triggers [`HostMsg::FullState`] from the server. After loading the
+    /// full state, the client sends [`SyncOk`](Self::SyncOk) to resume.
+    /// Valid in any InMatch state (Preprocessing, WaitingForSyncOk,
+    /// WaitingForAction). Phase is preserved.
     Resync { my_hash: u64 },
 
     /// Playing phase: committed action for this turn.
+    ///
+    /// `state_hash` tags which game state the move was computed for,
+    /// enabling stale-action detection. `think_ms` reports actual wall-clock
+    /// time spent thinking (for display and diagnostics, not enforcement).
     Action {
         direction: Direction,
         player: Player,
@@ -127,8 +202,12 @@ pub enum BotMsg {
         think_ms: u32,
     },
 
-    /// Playing phase: provisional best-so-far action. Host holds latest
-    /// as fallback if the bot doesn't commit in time.
+    /// Playing phase: provisional best-so-far action (sideband).
+    ///
+    /// The host holds the latest provisional as a timeout fallback. If a
+    /// newer provisional arrives before the previous one was consumed, it
+    /// replaces it (not queued). Resolution order on timeout:
+    /// committed Action > latest Provisional > STAY.
     Provisional {
         direction: Direction,
         player: Player,
@@ -136,12 +215,19 @@ pub enum BotMsg {
         state_hash: u64,
     },
 
-    /// Playing phase: analysis/debug info (sideband). Host forwards to
-    /// event stream without inspecting.
+    /// Playing phase: analysis/debug info (sideband).
+    ///
+    /// Observer-facing: the host forwards to the event stream without
+    /// inspecting contents. Tagged with `state_hash` for correlation with
+    /// the game state being analyzed. Valid during both Preprocessing and
+    /// Thinking.
     Info(OwnedInfo),
 
     /// Playing phase: render commands for GUI visualization (sideband).
-    /// Body TBD (separate brief).
+    ///
+    /// Same forwarding model as [`Info`](Self::Info): observer-facing, host
+    /// never inspects. Tagged with player, turn, and state_hash. Body format
+    /// TBD (separate brief).
     RenderCommands {
         player: Player,
         turn: u16,

--- a/server/protocol/src/messages.rs
+++ b/server/protocol/src/messages.rs
@@ -7,6 +7,10 @@
 //! These enums define the *new* protocol from the protocol spec. They are
 //! distinct from the host-internal `HostCommand`/`SessionMsg` channel types,
 //! which will eventually be replaced.
+//!
+//! **Status: spec-only.** Not yet consumed by host or SDK. The current host
+//! uses `HostCommand`/`SessionMsg` internally. These enums will be wired in
+//! when the Player trait is implemented.
 
 use pyrat::Direction;
 use pyrat_wire::{GameResult, Player};

--- a/server/protocol/src/types.rs
+++ b/server/protocol/src/types.rs
@@ -1,0 +1,258 @@
+//! Owned protocol types extracted from FlatBuffers messages.
+//!
+//! These types are the canonical representations of protocol data. Both the host
+//! and SDK use them. The codec (in the host or SDK) converts between FlatBuffers
+//! wire format and these owned types at the boundary.
+//!
+//! All position and direction fields use engine types (`Coordinates`, `Direction`).
+//! The codec is the only place that touches wire representations.
+
+use std::hash::{Hash, Hasher};
+use std::ops::Deref;
+
+use pyrat::{Coordinates, Direction};
+use pyrat_wire::{GameResult, OptionType, Player, TimingMode};
+
+// ── Direction conversion ────────────────────────────
+
+/// Convert a wire Direction to an engine Direction.
+pub fn wire_to_engine_direction(d: pyrat_wire::Direction) -> Direction {
+    Direction::try_from(d.0).unwrap_or(Direction::Stay)
+}
+
+/// Convert an engine Direction to a wire Direction.
+pub fn engine_to_wire_direction(d: Direction) -> pyrat_wire::Direction {
+    pyrat_wire::Direction(d as u8)
+}
+
+// ── Bot option declaration ──────────────────────────
+
+/// A bot-declared configurable option (from Identify).
+///
+/// Bots declare these in their Identify message to advertise knobs the host
+/// or GUI can set before the match starts. Mirrors UCI option declarations.
+#[derive(Debug, Clone)]
+pub struct OwnedOptionDef {
+    pub name: String,
+    pub option_type: OptionType,
+    pub default_value: String,
+    pub min: i32,
+    pub max: i32,
+    pub choices: Vec<String>,
+}
+
+// ── Bot analysis info ───────────────────────────────
+
+/// Analysis/debug info sent by a bot during thinking or preprocessing.
+///
+/// Tagged with player, turn, and state_hash for correlation. The host
+/// forwards these to the event stream without inspecting them.
+#[derive(Debug, Clone)]
+pub struct OwnedInfo {
+    pub player: Player,
+    pub multipv: u16,
+    pub target: Option<Coordinates>,
+    pub depth: u16,
+    pub nodes: u32,
+    pub score: Option<f32>,
+    pub pv: Vec<Direction>,
+    pub message: String,
+    pub turn: u16,
+    pub state_hash: u64,
+}
+
+// ── Match configuration ─────────────────────────────
+
+/// Mud entry: (pos1, pos2, mud_value).
+pub type MudEntry = (Coordinates, Coordinates, u8);
+
+/// Match configuration sent to bots during the Lobby phase.
+///
+/// Contains the maze layout, player positions, cheese, timing, and
+/// which players this connection controls.
+#[derive(Debug, Clone)]
+pub struct OwnedMatchConfig {
+    pub width: u8,
+    pub height: u8,
+    pub max_turns: u16,
+    pub walls: Vec<(Coordinates, Coordinates)>,
+    pub mud: Vec<MudEntry>,
+    pub cheese: Vec<Coordinates>,
+    pub player1_start: Coordinates,
+    pub player2_start: Coordinates,
+    pub controlled_players: Vec<Player>,
+    pub timing: TimingMode,
+    pub move_timeout_ms: u32,
+    pub preprocessing_timeout_ms: u32,
+}
+
+// ── Turn state ──────────────────────────────────────
+
+/// Game position state sent to bots each turn.
+///
+/// Contains the raw game-position fields. Does **not** include `state_hash`,
+/// which is a derived value. Use [`HashedTurnState`] to pair a turn state with
+/// its content-addressable hash.
+///
+/// If you add or change position-defining fields here, update
+/// [`HashedTurnState::compute_hash`] in this same file.
+#[derive(Debug, Clone)]
+pub struct OwnedTurnState {
+    pub turn: u16,
+    pub player1_position: Coordinates,
+    pub player2_position: Coordinates,
+    pub player1_score: f32,
+    pub player2_score: f32,
+    pub player1_mud_turns: u8,
+    pub player2_mud_turns: u8,
+    pub cheese: Vec<Coordinates>,
+    pub player1_last_move: Direction,
+    pub player2_last_move: Direction,
+}
+
+/// An [`OwnedTurnState`] paired with a content-addressable hash of its
+/// position-defining fields.
+///
+/// The hash is computed once at construction time. Two states that a bot would
+/// analyze differently will hash differently.
+#[derive(Debug, Clone)]
+pub struct HashedTurnState {
+    inner: OwnedTurnState,
+    state_hash: u64,
+}
+
+impl HashedTurnState {
+    /// Wrap a turn state, computing the hash from its fields.
+    pub fn new(ts: OwnedTurnState) -> Self {
+        let state_hash = Self::compute_hash(&ts);
+        Self {
+            inner: ts,
+            state_hash,
+        }
+    }
+
+    /// Wrap a turn state with a pre-computed hash (from `GameState::state_hash()`).
+    pub fn with_hash(ts: OwnedTurnState, state_hash: u64) -> Self {
+        Self {
+            inner: ts,
+            state_hash,
+        }
+    }
+
+    /// The content-addressable hash for this turn state.
+    pub fn state_hash(&self) -> u64 {
+        self.state_hash
+    }
+
+    /// Deterministic hash of all game-position fields.
+    ///
+    /// Two states that a bot would analyze differently must hash differently.
+    /// If you add a field to [`OwnedTurnState`], update this function.
+    fn compute_hash(ts: &OwnedTurnState) -> u64 {
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        ts.turn.hash(&mut h);
+        ts.player1_position.hash(&mut h);
+        ts.player2_position.hash(&mut h);
+        // Hash scores as half-point u16 to avoid float instability
+        ((ts.player1_score * 2.0) as u16).hash(&mut h);
+        ((ts.player2_score * 2.0) as u16).hash(&mut h);
+        ts.player1_mud_turns.hash(&mut h);
+        ts.player2_mud_turns.hash(&mut h);
+        ts.cheese.hash(&mut h);
+        ts.player1_last_move.hash(&mut h);
+        ts.player2_last_move.hash(&mut h);
+        h.finish()
+    }
+}
+
+impl Deref for HashedTurnState {
+    type Target = OwnedTurnState;
+
+    fn deref(&self) -> &OwnedTurnState {
+        &self.inner
+    }
+}
+
+// ── Game over ───────────────────────────────────────
+
+/// Game result data extracted from a GameOver message.
+#[derive(Debug, Clone)]
+pub struct GameOverData {
+    pub result: GameResult,
+    pub player1_score: f32,
+    pub player2_score: f32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_turn_state() -> OwnedTurnState {
+        OwnedTurnState {
+            turn: 42,
+            player1_position: Coordinates::new(10, 7),
+            player2_position: Coordinates::new(0, 0),
+            player1_score: 3.0,
+            player2_score: 2.5,
+            player1_mud_turns: 0,
+            player2_mud_turns: 2,
+            cheese: vec![Coordinates::new(5, 5), Coordinates::new(15, 10)],
+            player1_last_move: Direction::Up,
+            player2_last_move: Direction::Right,
+        }
+    }
+
+    #[test]
+    fn hashed_turn_state_new_computes_deterministic_hash() {
+        let a = HashedTurnState::new(sample_turn_state());
+        let b = HashedTurnState::new(sample_turn_state());
+        assert_eq!(a.state_hash(), b.state_hash());
+    }
+
+    #[test]
+    fn hashed_turn_state_with_hash_stores_provided_hash() {
+        let ts = sample_turn_state();
+        let hts = HashedTurnState::with_hash(ts, 0xDEAD_BEEF);
+        assert_eq!(hts.state_hash(), 0xDEAD_BEEF);
+    }
+
+    #[test]
+    fn different_states_produce_different_hashes() {
+        let ts_a = sample_turn_state();
+        let mut ts_b = sample_turn_state();
+        ts_b.player1_position = Coordinates::new(5, 5);
+
+        let a = HashedTurnState::new(ts_a);
+        let b = HashedTurnState::new(ts_b);
+        assert_ne!(a.state_hash(), b.state_hash());
+    }
+
+    #[test]
+    fn deref_accesses_inner_fields() {
+        let hts = HashedTurnState::new(sample_turn_state());
+        assert_eq!(hts.turn, 42);
+        assert_eq!(hts.player1_position, Coordinates::new(10, 7));
+    }
+
+    /// Verify that `Coordinates` hashes identically to the `(u8, u8)` tuple
+    /// it replaced, and engine `Direction` hashes identically to the raw `u8`
+    /// discriminant used previously. This ensures no hash compatibility break.
+    #[test]
+    fn hash_compatibility_with_old_tuple_representation() {
+        use std::collections::hash_map::DefaultHasher;
+
+        // Coordinates vs (u8, u8)
+        let mut h1 = DefaultHasher::new();
+        let mut h2 = DefaultHasher::new();
+        Coordinates::new(10, 7).hash(&mut h1);
+        (10u8, 7u8).hash(&mut h2);
+        assert_eq!(h1.finish(), h2.finish());
+
+        // Engine Direction vs raw u8 discriminant
+        let mut h1 = DefaultHasher::new();
+        let mut h2 = DefaultHasher::new();
+        Direction::Up.hash(&mut h1);
+        0u8.hash(&mut h2);
+        assert_eq!(h1.finish(), h2.finish());
+    }
+}

--- a/server/protocol/src/types.rs
+++ b/server/protocol/src/types.rs
@@ -11,13 +11,20 @@ use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 
 use pyrat::{Coordinates, Direction};
-use pyrat_wire::{GameResult, OptionType, Player, TimingMode};
+use pyrat_wire::{OptionType, Player, TimingMode};
 
 // ── Direction conversion ────────────────────────────
 
 /// Convert a wire Direction to an engine Direction.
 pub fn wire_to_engine_direction(d: pyrat_wire::Direction) -> Direction {
-    Direction::try_from(d.0).unwrap_or(Direction::Stay)
+    match d {
+        pyrat_wire::Direction::Up => Direction::Up,
+        pyrat_wire::Direction::Right => Direction::Right,
+        pyrat_wire::Direction::Down => Direction::Down,
+        pyrat_wire::Direction::Left => Direction::Left,
+        pyrat_wire::Direction::Stay => Direction::Stay,
+        _ => Direction::Stay,
+    }
 }
 
 /// Convert an engine Direction to a wire Direction.
@@ -171,16 +178,6 @@ impl Deref for HashedTurnState {
     fn deref(&self) -> &OwnedTurnState {
         &self.inner
     }
-}
-
-// ── Game over ───────────────────────────────────────
-
-/// Game result data extracted from a GameOver message.
-#[derive(Debug, Clone)]
-pub struct GameOverData {
-    pub result: GameResult,
-    pub player1_score: f32,
-    pub player2_score: f32,
 }
 
 #[cfg(test)]

--- a/tools/bot-check/src/check.rs
+++ b/tools/bot-check/src/check.rs
@@ -299,7 +299,7 @@ pub async fn run_check(bot_dir: &Path) -> CheckReport {
                         timed_out = true;
                     },
                     MatchEvent::TurnPlayed { p1_action, .. } => {
-                        action_name = Some(p1_action.variant_name().unwrap_or("?"));
+                        action_name = Some(format!("{p1_action:?}"));
                     },
                     _ => {},
                 }
@@ -312,7 +312,7 @@ pub async fn run_check(bot_dir: &Path) -> CheckReport {
                     t.elapsed(),
                 ));
             } else {
-                let action = action_name.unwrap_or("?");
+                let action = action_name.as_deref().unwrap_or("?");
                 let outcome_str = match outcome {
                     TurnOutcome::Continue => "",
                     TurnOutcome::GameOver(_) => " (game over)",


### PR DESCRIPTION
## Motivation

The host and SDK both need to work with protocol data: match configs, turn states, player info, direction conversions. Today each maintains its own copy. The host has `session/messages.rs` with owned types and `session/codec.rs` with conversion logic. The SDK has `wire.rs` with structurally identical types and its own converters. When one changes, the other drifts.

This is the first stage of a three-part migration (types → codec → SDK) to consolidate protocol vocabulary into a single neutral crate.

## Solution

New `pyrat-protocol` crate at `server/protocol/`. Three things live here:

### Owned protocol types

`OwnedMatchConfig`, `OwnedTurnState`, `OwnedInfo`, `HashedTurnState`, etc. moved from the host's `session/messages.rs`. Positions are now `Coordinates` (not `(u8, u8)` tuples), directions are engine `Direction` (not the wire `Direction(u8)` newtype). The codec is the only place that touches wire representations.

```rust
// Before: tuples everywhere, wire types leak into game logic
pub struct OwnedTurnState {
    pub player1_position: (u8, u8),
    pub player1_last_move: wire::Direction,  // u8 newtype
    ...
}

// After: engine types, wire boundary is the codec
pub struct OwnedTurnState {
    pub player1_position: Coordinates,
    pub player1_last_move: Direction,  // engine enum
    ...
}
```

### Protocol message enums (spec-only)

`HostMsg` and `BotMsg` define the Player trait pipe vocabulary from the protocol spec. Each variant is documented with its phase, purpose, and cross-references to the response message. These are not yet consumed by host or SDK. They're the target for the Player trait implementation.

### Wire boundary enforcement

`SessionMsg::Action.direction` converted from `pyrat_wire::Direction` to `pyrat::Direction`. The conversion now happens at the session boundary (`session/mod.rs`), so wire types never reach business logic. This eliminated all `WireDirection` usage from `playing.rs`, `stub.rs`, and the GUI.

Direction conversion uses an exhaustive match on all known wire variants instead of `try_from(d.0).unwrap_or(Stay)`.

The full cascade: host game_loop, session codec, stub bot, GUI (commands, match_runner, state), headless runner, and bot-check tool all updated.

## Test Plan

- `cargo test -p pyrat-protocol` (5 tests, including hash compatibility between old tuple and new Coordinates representations)
- `cargo test -p pyrat-host` (102 tests across unit, integration, and orchestration)
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo check` on GUI, headless, and bot-check
- Grep verified no `WireDirection` or `wire::Direction` outside codec and wire-level tests