### PR TITLE
Add shared FlatBuffers codec to pyrat-protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3065,6 +3065,7 @@ dependencies = [
 name = "pyrat-protocol"
 version = "0.1.0"
 dependencies = [
+ "flatbuffers",
  "pyrat-rust",
  "pyrat-wire",
 ]
@@ -3088,6 +3089,7 @@ version = "0.1.0"
 dependencies = [
  "flatbuffers",
  "pyrat-engine-interface",
+ "pyrat-protocol",
  "pyrat-rust",
  "pyrat-sdk-derive",
  "pyrat-wire",

--- a/botpack/greedy/Cargo.lock
+++ b/botpack/greedy/Cargo.lock
@@ -203,6 +203,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyrat-protocol"
+version = "0.1.0"
+dependencies = [
+ "flatbuffers",
+ "pyrat-rust",
+ "pyrat-wire",
+]
+
+[[package]]
 name = "pyrat-rust"
 version = "0.2.0"
 dependencies = [
@@ -216,6 +225,7 @@ version = "0.1.0"
 dependencies = [
  "flatbuffers",
  "pyrat-engine-interface",
+ "pyrat-protocol",
  "pyrat-rust",
  "pyrat-sdk-derive",
  "pyrat-wire",

--- a/botpack/smart-random/Cargo.lock
+++ b/botpack/smart-random/Cargo.lock
@@ -203,6 +203,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyrat-protocol"
+version = "0.1.0"
+dependencies = [
+ "flatbuffers",
+ "pyrat-rust",
+ "pyrat-wire",
+]
+
+[[package]]
 name = "pyrat-rust"
 version = "0.2.0"
 dependencies = [
@@ -216,6 +225,7 @@ version = "0.1.0"
 dependencies = [
  "flatbuffers",
  "pyrat-engine-interface",
+ "pyrat-protocol",
  "pyrat-rust",
  "pyrat-sdk-derive",
  "pyrat-wire",

--- a/gui/src-tauri/src/match_runner.rs
+++ b/gui/src-tauri/src/match_runner.rs
@@ -10,9 +10,10 @@ use pyrat::game::game_logic::GameState;
 use pyrat::{Coordinates, Direction as EngineDirection};
 use pyrat_host::game_loop::{
     build_owned_match_config, determine_result, run_playing, run_setup, HashedTurnState,
-    MatchEvent, MatchSetup, OwnedTurnState, PlayerEntry, PlayingConfig, PlayingState, SetupTiming,
+    MatchEvent, MatchSetup, OwnedInfo, OwnedTurnState, PlayerEntry, PlayingConfig, PlayingState,
+    SetupTiming,
 };
-use pyrat_host::session::messages::{HostCommand, OwnedInfo, SessionId, SessionMsg};
+use pyrat_host::session::messages::{HostCommand, SessionId, SessionMsg};
 use pyrat_host::stub::spawn_stub_bot;
 use pyrat_host::wire::{GameResult, Player, TimingMode};
 

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 pyrat-wire = { path = "../../server/wire" }
+pyrat-protocol = { path = "../../server/protocol" }
 pyrat-engine-interface = { path = "../../interface" }
 pyrat = { package = "pyrat-rust", path = "../../engine", default-features = false }
 pyrat-sdk-derive = { path = "derive" }

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -701,7 +701,7 @@ mod tests {
         // out, and by the time the turn_loop drains the queue it finds a new
         // TurnState followed immediately by GameOver.
         msg_tx
-            .send(HostMsg::TurnState(HashedTurnState::with_hash(
+            .send(HostMsg::TurnState(HashedTurnState::with_unverified_hash(
                 OwnedTurnState {
                     turn: 2,
                     player1_position: pyrat::Coordinates::new(0, 0),

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -650,7 +650,7 @@ mod tests {
     /// With the fix: think() sees the game is over and exits immediately.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn turn_state_does_not_clobber_game_over_stopped_flag() {
-        use crate::wire::{GameOverData, MatchConfigData, TurnStateData};
+        use pyrat_protocol::{HashedTurnState, OwnedGameOver, OwnedMatchConfig, OwnedTurnState};
         use std::sync::atomic::AtomicU32;
 
         // Bot that spins in think(), counting iterations until should_stop().
@@ -671,7 +671,7 @@ mod tests {
         }
 
         // Minimal game state with a short move timeout.
-        let cfg = MatchConfigData {
+        let cfg = OwnedMatchConfig {
             width: 3,
             height: 3,
             max_turns: 10,
@@ -701,23 +701,25 @@ mod tests {
         // out, and by the time the turn_loop drains the queue it finds a new
         // TurnState followed immediately by GameOver.
         msg_tx
-            .send(HostMsg::TurnState(TurnStateData {
-                turn: 2,
-                player1_position: pyrat::Coordinates::new(0, 0),
-                player2_position: pyrat::Coordinates::new(2, 2),
-                player1_score: 0.0,
-                player2_score: 0.0,
-                player1_mud_turns: 0,
-                player2_mud_turns: 0,
-                cheese: vec![pyrat::Coordinates::new(1, 1)],
-                player1_last_move: pyrat::Direction::Stay,
-                player2_last_move: pyrat::Direction::Stay,
-                state_hash: 0,
-            }))
+            .send(HostMsg::TurnState(HashedTurnState::with_hash(
+                OwnedTurnState {
+                    turn: 2,
+                    player1_position: pyrat::Coordinates::new(0, 0),
+                    player2_position: pyrat::Coordinates::new(2, 2),
+                    player1_score: 0.0,
+                    player2_score: 0.0,
+                    player1_mud_turns: 0,
+                    player2_mud_turns: 0,
+                    cheese: vec![pyrat::Coordinates::new(1, 1)],
+                    player1_last_move: pyrat::Direction::Stay,
+                    player2_last_move: pyrat::Direction::Stay,
+                },
+                0,
+            )))
             .unwrap();
 
         msg_tx
-            .send(HostMsg::GameOver(GameOverData {
+            .send(HostMsg::GameOver(OwnedGameOver {
                 result: GameResult::Draw,
                 player1_score: 0.0,
                 player2_score: 0.0,

--- a/sdk/rust/src/options.rs
+++ b/sdk/rust/src/options.rs
@@ -1,17 +1,7 @@
 //! Options trait and option definition types.
 
-use pyrat_wire::OptionType;
-
 /// Owned option definition sent during Identify.
-#[derive(Debug, Clone)]
-pub struct SdkOptionDef {
-    pub name: String,
-    pub option_type: OptionType,
-    pub default_value: String,
-    pub min: i32,
-    pub max: i32,
-    pub choices: Vec<String>,
-}
+pub type SdkOptionDef = pyrat_protocol::OwnedOptionDef;
 
 /// Trait for bot option declaration and application.
 ///

--- a/sdk/rust/src/state.rs
+++ b/sdk/rust/src/state.rs
@@ -43,7 +43,8 @@ impl GameState {
     /// Build from match configuration received during setup.
     pub fn from_config(cfg: &OwnedMatchConfig) -> Result<Self, String> {
         let walls: Vec<(Coordinates, Coordinates)> = cfg.walls.clone();
-        let mud: Vec<(Coordinates, Coordinates, u8)> = cfg.mud.clone();
+        let mud: Vec<(Coordinates, Coordinates, u8)> =
+            cfg.mud.iter().map(|m| (m.pos1, m.pos2, m.turns)).collect();
 
         let view = GameView::from_config(
             cfg.width,
@@ -351,7 +352,7 @@ mod tests {
     }
 
     fn test_turn_state() -> HashedTurnState {
-        HashedTurnState::with_hash(
+        HashedTurnState::with_unverified_hash(
             OwnedTurnState {
                 turn: 5,
                 player1_position: Coordinates::new(1, 1),
@@ -502,7 +503,7 @@ mod tests {
         let original_cheese_count = cfg.cheese.len();
 
         // Simulate mid-game: one cheese collected, player has some score
-        state.update(HashedTurnState::with_hash(
+        state.update(HashedTurnState::with_unverified_hash(
             OwnedTurnState {
                 turn: 10,
                 player1_position: Coordinates::new(2, 2),

--- a/sdk/rust/src/state.rs
+++ b/sdk/rust/src/state.rs
@@ -11,10 +11,10 @@ use pyrat_engine_interface::pathfinding::FullPathResult;
 use pyrat_engine_interface::GameView;
 use pyrat_wire::Player;
 
-use crate::wire::{MatchConfigData, TurnStateData};
+use pyrat_protocol::{HashedTurnState, OwnedMatchConfig};
 use crate::GameSim;
 
-/// SDK-facing game state. Built once from `MatchConfigData`, updated each turn.
+/// SDK-facing game state. Built once from `OwnedMatchConfig`, updated each turn.
 pub struct GameState {
     view: GameView,
     my_player: Player,
@@ -41,7 +41,7 @@ pub struct GameState {
 
 impl GameState {
     /// Build from match configuration received during setup.
-    pub fn from_config(cfg: &MatchConfigData) -> Result<Self, String> {
+    pub fn from_config(cfg: &OwnedMatchConfig) -> Result<Self, String> {
         let walls: Vec<(Coordinates, Coordinates)> = cfg.walls.clone();
         let mud: Vec<(Coordinates, Coordinates, u8)> = cfg.mud.clone();
 
@@ -84,7 +84,9 @@ impl GameState {
     }
 
     /// Update dynamic state from a TurnState message.
-    pub fn update(&mut self, ts: TurnStateData) {
+    pub fn update(&mut self, hts: HashedTurnState) {
+        let hash = hts.state_hash();
+        let ts = hts.into_inner();
         self.turn = ts.turn;
         self.player1_position = ts.player1_position;
         self.player2_position = ts.player2_position;
@@ -95,7 +97,7 @@ impl GameState {
         self.player1_last_move = ts.player1_last_move;
         self.player2_last_move = ts.player2_last_move;
         self.cheese = ts.cheese;
-        self.state_hash = ts.state_hash;
+        self.state_hash = hash;
     }
 
     // ── Perspective helpers ─────────────────────────
@@ -330,10 +332,11 @@ impl GameState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pyrat_protocol::OwnedTurnState;
     use pyrat_wire::TimingMode;
 
-    fn test_config() -> MatchConfigData {
-        MatchConfigData {
+    fn test_config() -> OwnedMatchConfig {
+        OwnedMatchConfig {
             width: 5,
             height: 5,
             max_turns: 300,
@@ -349,20 +352,22 @@ mod tests {
         }
     }
 
-    fn test_turn_state() -> TurnStateData {
-        TurnStateData {
-            turn: 5,
-            player1_position: Coordinates::new(1, 1),
-            player2_position: Coordinates::new(3, 3),
-            player1_score: 1.0,
-            player2_score: 0.5,
-            player1_mud_turns: 0,
-            player2_mud_turns: 2,
-            cheese: vec![Coordinates::new(4, 4)],
-            player1_last_move: Direction::Right,
-            player2_last_move: Direction::Left,
-            state_hash: 0xABCD,
-        }
+    fn test_turn_state() -> HashedTurnState {
+        HashedTurnState::with_hash(
+            OwnedTurnState {
+                turn: 5,
+                player1_position: Coordinates::new(1, 1),
+                player2_position: Coordinates::new(3, 3),
+                player1_score: 1.0,
+                player2_score: 0.5,
+                player1_mud_turns: 0,
+                player2_mud_turns: 2,
+                cheese: vec![Coordinates::new(4, 4)],
+                player1_last_move: Direction::Right,
+                player2_last_move: Direction::Left,
+            },
+            0xABCD,
+        )
     }
 
     #[test]
@@ -477,19 +482,21 @@ mod tests {
         let original_cheese_count = cfg.cheese.len();
 
         // Simulate mid-game: one cheese collected, player has some score
-        state.update(TurnStateData {
-            turn: 10,
-            player1_position: Coordinates::new(2, 2),
-            player2_position: Coordinates::new(0, 0),
-            player1_score: 1.0,
-            player2_score: 0.0,
-            player1_mud_turns: 0,
-            player2_mud_turns: 0,
-            cheese: vec![Coordinates::new(4, 4)], // one cheese collected
-            player1_last_move: Direction::Stay,
-            player2_last_move: Direction::Stay,
-            state_hash: 0,
-        });
+        state.update(HashedTurnState::with_hash(
+            OwnedTurnState {
+                turn: 10,
+                player1_position: Coordinates::new(2, 2),
+                player2_position: Coordinates::new(0, 0),
+                player1_score: 1.0,
+                player2_score: 0.0,
+                player1_mud_turns: 0,
+                player2_mud_turns: 0,
+                cheese: vec![Coordinates::new(4, 4)], // one cheese collected
+                player1_last_move: Direction::Stay,
+                player2_last_move: Direction::Stay,
+            },
+            0,
+        ));
 
         let sim = state.to_sim();
 

--- a/sdk/rust/src/state.rs
+++ b/sdk/rust/src/state.rs
@@ -11,8 +11,8 @@ use pyrat_engine_interface::pathfinding::FullPathResult;
 use pyrat_engine_interface::GameView;
 use pyrat_wire::Player;
 
-use pyrat_protocol::{HashedTurnState, OwnedMatchConfig, OwnedTurnState};
 use crate::GameSim;
+use pyrat_protocol::{HashedTurnState, OwnedMatchConfig, OwnedTurnState};
 
 /// SDK-facing game state. Built once from `OwnedMatchConfig`, updated each turn.
 pub struct GameState {

--- a/sdk/rust/src/state.rs
+++ b/sdk/rust/src/state.rs
@@ -11,7 +11,7 @@ use pyrat_engine_interface::pathfinding::FullPathResult;
 use pyrat_engine_interface::GameView;
 use pyrat_wire::Player;
 
-use pyrat_protocol::{HashedTurnState, OwnedMatchConfig};
+use pyrat_protocol::{HashedTurnState, OwnedMatchConfig, OwnedTurnState};
 use crate::GameSim;
 
 /// SDK-facing game state. Built once from `OwnedMatchConfig`, updated each turn.
@@ -225,24 +225,22 @@ impl GameState {
 
     /// Compute the initial state hash from turn-0 fields.
     ///
-    /// Uses the same algorithm as `HashedTurnState::compute_hash` in the host,
-    /// so the SDK can verify that host and bot agree on the initial game state.
+    /// Delegates to `HashedTurnState::new` so the hash algorithm is defined in
+    /// one place. The SDK uses this to verify agreement with the host.
     pub fn compute_initial_hash(&self) -> u64 {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
-
-        let mut h = DefaultHasher::new();
-        0u16.hash(&mut h); // turn = 0
-        self.player1_position.hash(&mut h);
-        self.player2_position.hash(&mut h);
-        0u16.hash(&mut h); // scores: (0.0 * 2.0) as u16
-        0u16.hash(&mut h);
-        0u8.hash(&mut h); // mud turns
-        0u8.hash(&mut h);
-        self.cheese.hash(&mut h);
-        pyrat_wire::Direction::Stay.0.hash(&mut h);
-        pyrat_wire::Direction::Stay.0.hash(&mut h);
-        h.finish()
+        let ts = OwnedTurnState {
+            turn: 0,
+            player1_position: self.player1_position,
+            player2_position: self.player2_position,
+            player1_score: 0.0,
+            player2_score: 0.0,
+            player1_mud_turns: 0,
+            player2_mud_turns: 0,
+            cheese: self.cheese.clone(),
+            player1_last_move: Direction::Stay,
+            player2_last_move: Direction::Stay,
+        };
+        HashedTurnState::new(ts).state_hash()
     }
 
     // ── Convenience (delegate to GameView/pathfinding) ──
@@ -368,6 +366,28 @@ mod tests {
             },
             0xABCD,
         )
+    }
+
+    #[test]
+    fn compute_initial_hash_matches_hashed_turn_state() {
+        let cfg = test_config();
+        let state = GameState::from_config(&cfg).unwrap();
+
+        let expected = HashedTurnState::new(OwnedTurnState {
+            turn: 0,
+            player1_position: cfg.player1_start,
+            player2_position: cfg.player2_start,
+            player1_score: 0.0,
+            player2_score: 0.0,
+            player1_mud_turns: 0,
+            player2_mud_turns: 0,
+            cheese: cfg.cheese.clone(),
+            player1_last_move: Direction::Stay,
+            player2_last_move: Direction::Stay,
+        })
+        .state_hash();
+
+        assert_eq!(state.compute_initial_hash(), expected);
     }
 
     #[test]

--- a/sdk/rust/src/wire.rs
+++ b/sdk/rust/src/wire.rs
@@ -1,97 +1,27 @@
 //! Wire codec: extract HostPackets to owned types, build BotPackets.
 //!
-//! Mirror of `server/host/src/session/codec.rs` but in the opposite direction —
-//! we extract `HostPacket`s and build `BotPacket`s.
+//! Extraction of per-table data is delegated to `pyrat_protocol::codec`.
+//! This module handles packet dispatch and bot packet builders.
 
 use flatbuffers::FlatBufferBuilder;
-use pyrat::Coordinates;
+use pyrat_protocol::{
+    engine_to_wire_direction, extract_game_over, extract_match_config, extract_turn_state,
+    wire_to_engine_direction, HashedTurnState, OwnedGameOver, OwnedMatchConfig,
+};
 use pyrat_wire::{self as wire, BotMessage, HostMessage, Vec2};
 
-// ── Direction conversion ─────────────────────────────
-
-/// Convert a wire Direction to an engine Direction.
-fn wire_to_engine_dir(d: wire::Direction) -> pyrat::Direction {
-    match d {
-        wire::Direction::Up => pyrat::Direction::Up,
-        wire::Direction::Right => pyrat::Direction::Right,
-        wire::Direction::Down => pyrat::Direction::Down,
-        wire::Direction::Left => pyrat::Direction::Left,
-        _ => pyrat::Direction::Stay,
-    }
-}
-
-/// Convert an engine Direction to a wire Direction.
-fn engine_to_wire_dir(d: pyrat::Direction) -> wire::Direction {
-    match d {
-        pyrat::Direction::Up => wire::Direction::Up,
-        pyrat::Direction::Right => wire::Direction::Right,
-        pyrat::Direction::Down => wire::Direction::Down,
-        pyrat::Direction::Left => wire::Direction::Left,
-        pyrat::Direction::Stay => wire::Direction::Stay,
-    }
-}
-
-fn vec2_to_coords(v: &Vec2) -> Coordinates {
-    Coordinates::new(v.x(), v.y())
-}
-
-fn vec2_opt(v: Option<&Vec2>) -> Coordinates {
-    v.map_or(Coordinates::new(0, 0), vec2_to_coords)
-}
-
 // ── Owned extraction types ───────────────────────────
-
-/// Owned match configuration extracted from wire MatchConfig.
-#[derive(Debug, Clone)]
-pub struct MatchConfigData {
-    pub width: u8,
-    pub height: u8,
-    pub max_turns: u16,
-    pub walls: Vec<(Coordinates, Coordinates)>,
-    pub mud: Vec<(Coordinates, Coordinates, u8)>,
-    pub cheese: Vec<Coordinates>,
-    pub player1_start: Coordinates,
-    pub player2_start: Coordinates,
-    pub controlled_players: Vec<wire::Player>,
-    pub timing: wire::TimingMode,
-    pub move_timeout_ms: u32,
-    pub preprocessing_timeout_ms: u32,
-}
-
-/// Owned turn state extracted from wire TurnState.
-#[derive(Debug, Clone)]
-pub struct TurnStateData {
-    pub turn: u16,
-    pub player1_position: Coordinates,
-    pub player2_position: Coordinates,
-    pub player1_score: f32,
-    pub player2_score: f32,
-    pub player1_mud_turns: u8,
-    pub player2_mud_turns: u8,
-    pub cheese: Vec<Coordinates>,
-    pub player1_last_move: pyrat::Direction,
-    pub player2_last_move: pyrat::Direction,
-    pub state_hash: u64,
-}
-
-/// Owned game-over data extracted from wire GameOver.
-#[derive(Debug, Clone)]
-pub struct GameOverData {
-    pub result: wire::GameResult,
-    pub player1_score: f32,
-    pub player2_score: f32,
-}
 
 /// Parsed host message.
 #[derive(Debug)]
 #[allow(dead_code)] // Fields are extracted for completeness; not all are consumed.
 pub enum HostMsg {
     SetOption { name: String, value: String },
-    MatchConfig(MatchConfigData),
+    MatchConfig(OwnedMatchConfig),
     StartPreprocessing { state_hash: u64 },
-    TurnState(TurnStateData),
+    TurnState(HashedTurnState),
     Timeout { default_move: pyrat::Direction },
-    GameOver(GameOverData),
+    GameOver(OwnedGameOver),
     Ping,
     Stop,
 }
@@ -136,84 +66,18 @@ pub fn extract_host_msg(buf: &[u8]) -> Result<HostMsg, String> {
         HostMessage::Timeout => {
             let t = packet.message_as_timeout().ok_or("missing Timeout body")?;
             Ok(HostMsg::Timeout {
-                default_move: wire_to_engine_dir(t.default_move()),
+                default_move: wire_to_engine_direction(t.default_move()),
             })
         },
         HostMessage::GameOver => {
             let go = packet
                 .message_as_game_over()
                 .ok_or("missing GameOver body")?;
-            Ok(HostMsg::GameOver(GameOverData {
-                result: go.result(),
-                player1_score: go.player1_score(),
-                player2_score: go.player2_score(),
-            }))
+            Ok(HostMsg::GameOver(extract_game_over(&go)))
         },
         HostMessage::Ping => Ok(HostMsg::Ping),
         HostMessage::Stop => Ok(HostMsg::Stop),
         _ => Err(format!("unknown HostMessage type: {}", msg_type.0)),
-    }
-}
-
-fn extract_match_config(mc: &wire::MatchConfig<'_>) -> MatchConfigData {
-    MatchConfigData {
-        width: mc.width(),
-        height: mc.height(),
-        max_turns: mc.max_turns(),
-        walls: mc
-            .walls()
-            .map(|ws| {
-                (0..ws.len())
-                    .map(|i| {
-                        let w = ws.get(i);
-                        (vec2_opt(w.pos1()), vec2_opt(w.pos2()))
-                    })
-                    .collect()
-            })
-            .unwrap_or_default(),
-        mud: mc
-            .mud()
-            .map(|ms| {
-                (0..ms.len())
-                    .map(|i| {
-                        let m = ms.get(i);
-                        (vec2_opt(m.pos1()), vec2_opt(m.pos2()), m.value())
-                    })
-                    .collect()
-            })
-            .unwrap_or_default(),
-        cheese: mc
-            .cheese()
-            .map(|cs| (0..cs.len()).map(|i| vec2_to_coords(cs.get(i))).collect())
-            .unwrap_or_default(),
-        player1_start: vec2_opt(mc.player1_start()),
-        player2_start: vec2_opt(mc.player2_start()),
-        controlled_players: mc
-            .controlled_players()
-            .map(|ps| ps.iter().collect())
-            .unwrap_or_default(),
-        timing: mc.timing(),
-        move_timeout_ms: mc.move_timeout_ms(),
-        preprocessing_timeout_ms: mc.preprocessing_timeout_ms(),
-    }
-}
-
-fn extract_turn_state(ts: &wire::TurnState<'_>) -> TurnStateData {
-    TurnStateData {
-        turn: ts.turn(),
-        player1_position: vec2_opt(ts.player1_position()),
-        player2_position: vec2_opt(ts.player2_position()),
-        player1_score: ts.player1_score(),
-        player2_score: ts.player2_score(),
-        player1_mud_turns: ts.player1_mud_turns(),
-        player2_mud_turns: ts.player2_mud_turns(),
-        cheese: ts
-            .cheese()
-            .map(|cs| (0..cs.len()).map(|i| vec2_to_coords(cs.get(i))).collect())
-            .unwrap_or_default(),
-        player1_last_move: wire_to_engine_dir(ts.player1_last_move()),
-        player2_last_move: wire_to_engine_dir(ts.player2_last_move()),
-        state_hash: ts.state_hash(),
     }
 }
 
@@ -331,7 +195,7 @@ pub fn build_action_full(
     provisional: bool,
     think_ms: u32,
 ) -> Vec<u8> {
-    let wire_dir = engine_to_wire_dir(direction);
+    let wire_dir = engine_to_wire_direction(direction);
     build_bot_frame(BotMessage::Action, move |fbb| {
         wire::Action::create(
             fbb,
@@ -368,7 +232,8 @@ pub fn build_info(
             Some(fbb.create_string(message))
         };
 
-        let pv_vec: Vec<wire::Direction> = pv.iter().map(|&d| engine_to_wire_dir(d)).collect();
+        let pv_vec: Vec<wire::Direction> =
+            pv.iter().map(|&d| engine_to_wire_direction(d)).collect();
         let pv_off = if pv_vec.is_empty() {
             None
         } else {
@@ -399,10 +264,8 @@ pub fn build_info(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pyrat::Coordinates;
     use pyrat_wire::{Direction as WireDir, GameResult, Player, TimingMode};
-
-    // Use host codec's serialize_host_command to build HostPackets for extraction tests.
-    // We inline minimal builders here instead, since we don't depend on pyrat-host.
 
     fn build_host_packet<F>(msg_type: HostMessage, build_msg: F) -> Vec<u8>
     where
@@ -537,25 +400,25 @@ mod tests {
         });
 
         match extract_host_msg(&buf).unwrap() {
-            HostMsg::TurnState(ts) => {
-                assert_eq!(ts.turn, 42);
-                assert_eq!(ts.player1_position, Coordinates::new(10, 7));
-                assert_eq!(ts.player2_position, Coordinates::new(0, 0));
-                assert!((ts.player1_score - 3.0).abs() < f32::EPSILON);
-                assert!((ts.player2_score - 2.5).abs() < f32::EPSILON);
-                assert_eq!(ts.player1_mud_turns, 0);
-                assert_eq!(ts.player2_mud_turns, 2);
-                assert_eq!(ts.cheese.len(), 2);
-                assert_eq!(ts.player1_last_move, pyrat::Direction::Up);
-                assert_eq!(ts.player2_last_move, pyrat::Direction::Right);
-                assert_eq!(ts.state_hash, 0xFEED_FACE_1234_5678);
+            HostMsg::TurnState(hts) => {
+                assert_eq!(hts.turn, 42);
+                assert_eq!(hts.player1_position, Coordinates::new(10, 7));
+                assert_eq!(hts.player2_position, Coordinates::new(0, 0));
+                assert!((hts.player1_score - 3.0).abs() < f32::EPSILON);
+                assert!((hts.player2_score - 2.5).abs() < f32::EPSILON);
+                assert_eq!(hts.player1_mud_turns, 0);
+                assert_eq!(hts.player2_mud_turns, 2);
+                assert_eq!(hts.cheese.len(), 2);
+                assert_eq!(hts.player1_last_move, pyrat::Direction::Up);
+                assert_eq!(hts.player2_last_move, pyrat::Direction::Right);
+                assert_eq!(hts.state_hash(), 0xFEED_FACE_1234_5678);
             },
             _ => panic!("expected TurnState"),
         }
     }
 
     #[test]
-    fn extract_game_over() {
+    fn extract_game_over_test() {
         let buf = build_host_packet(HostMessage::GameOver, |fbb| {
             wire::GameOver::create(
                 fbb,
@@ -718,19 +581,5 @@ mod tests {
         assert!(info.target().is_none());
         assert!(info.pv().is_none());
         assert!(info.message().is_none());
-    }
-
-    #[test]
-    fn direction_conversion_roundtrip() {
-        for (w, e) in [
-            (WireDir::Up, pyrat::Direction::Up),
-            (WireDir::Right, pyrat::Direction::Right),
-            (WireDir::Down, pyrat::Direction::Down),
-            (WireDir::Left, pyrat::Direction::Left),
-            (WireDir::Stay, pyrat::Direction::Stay),
-        ] {
-            assert_eq!(wire_to_engine_dir(w), e);
-            assert_eq!(engine_to_wire_dir(e), w);
-        }
     }
 }

--- a/sdk/rust/src/wire.rs
+++ b/sdk/rust/src/wire.rs
@@ -363,7 +363,7 @@ mod tests {
                 assert_eq!(cfg.walls[0].0, Coordinates::new(0, 0));
                 assert_eq!(cfg.walls[0].1, Coordinates::new(0, 1));
                 assert_eq!(cfg.mud.len(), 1);
-                assert_eq!(cfg.mud[0].2, 5);
+                assert_eq!(cfg.mud[0].turns, 5);
                 assert_eq!(cfg.cheese.len(), 2);
                 assert_eq!(cfg.player1_start, Coordinates::new(20, 14));
                 assert_eq!(cfg.player2_start, Coordinates::new(0, 0));

--- a/server/host/src/game_loop/config.rs
+++ b/server/host/src/game_loop/config.rs
@@ -4,8 +4,9 @@ use std::time::Duration;
 use pyrat::game::game_logic::GameState;
 use tokio::sync::mpsc;
 
-use crate::session::messages::{HostCommand, OwnedMatchConfig};
+use crate::session::messages::HostCommand;
 use crate::session::SessionId;
+use pyrat_protocol::{MudEntry, OwnedMatchConfig};
 use pyrat_wire::{Player, TimingMode};
 
 /// Which player a bot controls, identified by agent_id.
@@ -116,12 +117,9 @@ pub fn build_owned_match_config(
     let mud = game
         .mud_positions()
         .iter()
-        .map(|((from, to), value)| {
-            if from < to {
-                (from, to, value)
-            } else {
-                (to, from, value)
-            }
+        .map(|((from, to), turns)| {
+            let (pos1, pos2) = if from < to { (from, to) } else { (to, from) };
+            MudEntry { pos1, pos2, turns }
         })
         .collect();
 
@@ -188,9 +186,14 @@ mod tests {
         assert!(!cfg.walls.is_empty(), "classic 7×5 maze should have walls");
 
         // Mud entries should be normalized: pos1 <= pos2.
-        for &(p1, p2, value) in &cfg.mud {
-            assert!(p1 <= p2, "mud entry not normalized: {p1:?} > {p2:?}");
-            assert!(value >= 2, "mud value should be >= 2, got {value}");
+        for m in &cfg.mud {
+            assert!(
+                m.pos1 <= m.pos2,
+                "mud entry not normalized: {:?} > {:?}",
+                m.pos1,
+                m.pos2
+            );
+            assert!(m.turns >= 2, "mud value should be >= 2, got {}", m.turns);
         }
     }
 }

--- a/server/host/src/game_loop/events.rs
+++ b/server/host/src/game_loop/events.rs
@@ -7,8 +7,9 @@
 use tokio::sync::mpsc;
 use tracing::warn;
 
-use crate::session::messages::{DisconnectReason, HashedTurnState, OwnedInfo, OwnedMatchConfig};
+use crate::session::messages::DisconnectReason;
 use pyrat::Direction;
+use pyrat_protocol::{HashedTurnState, OwnedInfo, OwnedMatchConfig};
 use pyrat_wire::Player;
 
 use super::playing::MatchResult;

--- a/server/host/src/game_loop/playing.rs
+++ b/server/host/src/game_loop/playing.rs
@@ -9,9 +9,8 @@ use tracing::{debug, warn};
 use pyrat::game::game_logic::GameState;
 use pyrat::Direction;
 
-use crate::session::messages::{
-    HashedTurnState, HostCommand, OwnedTurnState, SessionId, SessionMsg,
-};
+use crate::session::messages::{HostCommand, SessionId, SessionMsg};
+use pyrat_protocol::{HashedTurnState, OwnedInfo, OwnedTurnState};
 use pyrat_wire::{GameResult, Player};
 
 use super::config::{PlayingConfig, SessionHandle};
@@ -267,7 +266,7 @@ fn build_turn_state(game: &GameState, last_p1: Direction, last_p2: Direction) ->
     let p1 = &game.player1;
     let p2 = &game.player2;
     let hash = game.state_hash();
-    HashedTurnState::with_hash(
+    HashedTurnState::with_unverified_hash(
         OwnedTurnState {
             turn: game.turn,
             player1_position: p1.current_pos,
@@ -507,7 +506,7 @@ fn handle_info(
     session_players: &HashMap<SessionId, Vec<Player>>,
     event_tx: Option<&mpsc::UnboundedSender<MatchEvent>>,
     session_id: SessionId,
-    info: crate::session::messages::OwnedInfo,
+    info: OwnedInfo,
 ) {
     if let Some(players) = session_players.get(&session_id) {
         if let Some(&sender) = players.first() {
@@ -782,7 +781,7 @@ mod tests {
         game_tx
             .send(SessionMsg::Info {
                 session_id: SessionId(1),
-                info: crate::session::messages::OwnedInfo {
+                info: OwnedInfo {
                     player: Player::Player1,
                     multipv: 1,
                     target: None,
@@ -1064,7 +1063,7 @@ mod tests {
         game_tx
             .send(SessionMsg::Info {
                 session_id: SessionId(1),
-                info: crate::session::messages::OwnedInfo {
+                info: OwnedInfo {
                     player: Player::Player1,
                     multipv: 1,
                     target: None,
@@ -1143,7 +1142,7 @@ mod tests {
         }
     }
 
-    use crate::session::messages::HashedTurnState;
+    use pyrat_protocol::HashedTurnState;
 
     /// Helper: baseline state for hash distinctness tests.
     fn baseline_turn_state() -> OwnedTurnState {

--- a/server/host/src/game_loop/probe.rs
+++ b/server/host/src/game_loop/probe.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 use tokio::net::TcpListener;
 use tracing::debug;
 
-use crate::session::messages::OwnedOptionDef;
 use crate::session::{extract_bot_packet, BotPayload};
+use pyrat_protocol::OwnedOptionDef;
 use pyrat_wire::framing::FrameReader;
 
 use super::config::BotConfig;

--- a/server/host/src/game_loop/setup.rs
+++ b/server/host/src/game_loop/setup.rs
@@ -6,8 +6,9 @@ use tokio::sync::mpsc;
 use tokio::time::Instant;
 use tracing::{debug, info, info_span, warn, Instrument};
 
-use crate::session::messages::{HashedTurnState, HostCommand, OwnedTurnState};
+use crate::session::messages::HostCommand;
 use crate::session::{run_session, SessionConfig, SessionId, SessionMsg};
+use pyrat_protocol::{HashedTurnState, OwnedTurnState};
 
 use pyrat_wire::Player;
 

--- a/server/host/src/game_loop/setup.rs
+++ b/server/host/src/game_loop/setup.rs
@@ -194,12 +194,12 @@ pub async fn run_setup(
                         return Err(SetupError::AllDisconnected);
                     };
                     match msg {
-                        SessionMsg::Ready { session_id } => {
-                            if handles.contains_key(&session_id) {
-                                ready_set.insert(session_id);
-                                if all_keys_in(&handles, &ready_set) {
-                                    break;
-                                }
+                        SessionMsg::Ready { session_id }
+                            if handles.contains_key(&session_id) =>
+                        {
+                            ready_set.insert(session_id);
+                            if all_keys_in(&handles, &ready_set) {
+                                break;
                             }
                         }
                         SessionMsg::PreprocessingDone { session_id } => {
@@ -293,12 +293,12 @@ pub async fn run_setup(
                         return Err(SetupError::AllDisconnected);
                     };
                     match msg {
-                        SessionMsg::PreprocessingDone { session_id } => {
-                            if handles.contains_key(&session_id) {
-                                done_set.insert(session_id);
-                                if all_keys_in(&handles, &done_set) {
-                                    break;
-                                }
+                        SessionMsg::PreprocessingDone { session_id }
+                            if handles.contains_key(&session_id) =>
+                        {
+                            done_set.insert(session_id);
+                            if all_keys_in(&handles, &done_set) {
+                                break;
                             }
                         }
                         SessionMsg::Disconnected { session_id, reason } => {

--- a/server/host/src/session/codec.rs
+++ b/server/host/src/session/codec.rs
@@ -1,10 +1,17 @@
-//! FlatBuffers codec: borrowed→owned extraction and owned→bytes serialization.
+//! Host-side FlatBuffers codec.
+//!
+//! Dispatches incoming `BotPacket`s by message type and delegates per-table
+//! extraction to `pyrat_protocol::codec`. Serializes outgoing `HostCommand`s
+//! into finished FlatBuffer bytes.
 
 use flatbuffers::FlatBufferBuilder;
 
-use pyrat_protocol::{engine_to_wire_direction, extract_info, extract_option_defs};
+use pyrat_protocol::{
+    coords_to_vec2, engine_to_wire_direction, extract_info, extract_option_defs, OwnedInfo,
+    OwnedOptionDef,
+};
 
-use crate::session::messages::{HostCommand, OwnedInfo, OwnedOptionDef};
+use crate::session::messages::HostCommand;
 use pyrat_wire::{self as wire, BotMessage, HostMessage, HostPacket, HostPacketArgs, Vec2};
 
 // ── Extraction: borrowed FlatBuffers → owned types ──
@@ -106,8 +113,8 @@ pub fn serialize_host_command(fbb: &mut FlatBufferBuilder<'_>, cmd: &HostCommand
                     wire::Wall::create(
                         fbb,
                         &wire::WallArgs {
-                            pos1: Some(&Vec2::new(c1.x, c1.y)),
-                            pos2: Some(&Vec2::new(c2.x, c2.y)),
+                            pos1: Some(&coords_to_vec2(*c1)),
+                            pos2: Some(&coords_to_vec2(*c2)),
                         },
                     )
                 })
@@ -117,20 +124,20 @@ pub fn serialize_host_command(fbb: &mut FlatBufferBuilder<'_>, cmd: &HostCommand
             let muds: Vec<_> = cfg
                 .mud
                 .iter()
-                .map(|(c1, c2, v)| {
+                .map(|m| {
                     wire::Mud::create(
                         fbb,
                         &wire::MudArgs {
-                            pos1: Some(&Vec2::new(c1.x, c1.y)),
-                            pos2: Some(&Vec2::new(c2.x, c2.y)),
-                            value: *v,
+                            pos1: Some(&coords_to_vec2(m.pos1)),
+                            pos2: Some(&coords_to_vec2(m.pos2)),
+                            value: m.turns,
                         },
                     )
                 })
                 .collect();
             let muds = fbb.create_vector(&muds);
 
-            let cheese_vec: Vec<Vec2> = cfg.cheese.iter().map(|c| Vec2::new(c.x, c.y)).collect();
+            let cheese_vec: Vec<Vec2> = cfg.cheese.iter().copied().map(coords_to_vec2).collect();
             let cheese = fbb.create_vector(&cheese_vec);
 
             let players = fbb.create_vector(&cfg.controlled_players);
@@ -144,8 +151,8 @@ pub fn serialize_host_command(fbb: &mut FlatBufferBuilder<'_>, cmd: &HostCommand
                     walls: Some(walls),
                     mud: Some(muds),
                     cheese: Some(cheese),
-                    player1_start: Some(&Vec2::new(cfg.player1_start.x, cfg.player1_start.y)),
-                    player2_start: Some(&Vec2::new(cfg.player2_start.x, cfg.player2_start.y)),
+                    player1_start: Some(&coords_to_vec2(cfg.player1_start)),
+                    player2_start: Some(&coords_to_vec2(cfg.player2_start)),
                     controlled_players: Some(players),
                     timing: cfg.timing,
                     move_timeout_ms: cfg.move_timeout_ms,
@@ -164,21 +171,15 @@ pub fn serialize_host_command(fbb: &mut FlatBufferBuilder<'_>, cmd: &HostCommand
             (HostMessage::StartPreprocessing, off.as_union_value())
         },
         HostCommand::TurnState(ts) => {
-            let cheese_vec: Vec<Vec2> = ts.cheese.iter().map(|c| Vec2::new(c.x, c.y)).collect();
+            let cheese_vec: Vec<Vec2> = ts.cheese.iter().copied().map(coords_to_vec2).collect();
             let cheese = fbb.create_vector(&cheese_vec);
 
             let off = wire::TurnState::create(
                 fbb,
                 &wire::TurnStateArgs {
                     turn: ts.turn,
-                    player1_position: Some(&Vec2::new(
-                        ts.player1_position.x,
-                        ts.player1_position.y,
-                    )),
-                    player2_position: Some(&Vec2::new(
-                        ts.player2_position.x,
-                        ts.player2_position.y,
-                    )),
+                    player1_position: Some(&coords_to_vec2(ts.player1_position)),
+                    player2_position: Some(&coords_to_vec2(ts.player2_position)),
                     player1_score: ts.player1_score,
                     player2_score: ts.player2_score,
                     player1_mud_turns: ts.player1_mud_turns,
@@ -245,9 +246,10 @@ pub fn serialize_host_command(fbb: &mut FlatBufferBuilder<'_>, cmd: &HostCommand
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::session::messages::{HashedTurnState, OwnedMatchConfig, OwnedTurnState};
     use pyrat::Coordinates;
-    use pyrat_protocol::extract_match_config;
+    use pyrat_protocol::{
+        extract_match_config, HashedTurnState, MudEntry, OwnedMatchConfig, OwnedTurnState,
+    };
     use pyrat_wire::{Direction, GameResult, Player, TimingMode};
 
     // Helper: build a BotPacket with Identify
@@ -433,7 +435,11 @@ mod tests {
                 (Coordinates::new(0, 0), Coordinates::new(0, 1)),
                 (Coordinates::new(1, 2), Coordinates::new(2, 2)),
             ],
-            mud: vec![(Coordinates::new(3, 3), Coordinates::new(3, 4), 5)],
+            mud: vec![MudEntry {
+                pos1: Coordinates::new(3, 3),
+                pos2: Coordinates::new(3, 4),
+                turns: 5,
+            }],
             cheese: vec![Coordinates::new(10, 7), Coordinates::new(5, 3)],
             player1_start: Coordinates::new(20, 14),
             player2_start: Coordinates::new(0, 0),

--- a/server/host/src/session/codec.rs
+++ b/server/host/src/session/codec.rs
@@ -245,15 +245,11 @@ pub fn serialize_host_command(fbb: &mut FlatBufferBuilder<'_>, cmd: &HostCommand
     fbb.finished_data().to_vec()
 }
 
-// Re-export from protocol crate. Currently used in tests; will be consumed
-// by the game loop once it needs to extract config from wire directly.
-#[allow(unused_imports)]
-pub use pyrat_protocol::extract_match_config;
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::session::messages::{HashedTurnState, OwnedMatchConfig, OwnedTurnState};
+    use pyrat_protocol::extract_match_config;
     use pyrat::Coordinates;
     use pyrat_wire::{Direction, GameResult, Player, TimingMode};
 

--- a/server/host/src/session/codec.rs
+++ b/server/host/src/session/codec.rs
@@ -2,21 +2,10 @@
 
 use flatbuffers::FlatBufferBuilder;
 
-use pyrat::Coordinates;
-use pyrat_protocol::{engine_to_wire_direction, wire_to_engine_direction};
+use pyrat_protocol::{engine_to_wire_direction, extract_info, extract_option_defs};
 
-use crate::session::messages::{HostCommand, OwnedInfo, OwnedMatchConfig, OwnedOptionDef};
+use crate::session::messages::{HostCommand, OwnedInfo, OwnedOptionDef};
 use pyrat_wire::{self as wire, BotMessage, HostMessage, HostPacket, HostPacketArgs, Vec2};
-
-// ── Helpers ─────────────────────────────────────────
-
-fn vec2_to_coords(v: &Vec2) -> Coordinates {
-    Coordinates::new(v.x(), v.y())
-}
-
-fn vec2_opt(v: Option<&Vec2>) -> Coordinates {
-    v.map_or(Coordinates::new(0, 0), vec2_to_coords)
-}
 
 // ── Extraction: borrowed FlatBuffers → owned types ──
 
@@ -55,24 +44,7 @@ pub fn extract_bot_packet(buf: &[u8]) -> Result<(BotMessage, BotPayload), String
             .ok_or("missing Identify body")?;
         let options = id
             .options()
-            .map(|opts| {
-                (0..opts.len())
-                    .map(|i| {
-                        let o = opts.get(i);
-                        OwnedOptionDef {
-                            name: o.name().unwrap_or("").to_owned(),
-                            option_type: o.type_(),
-                            default_value: o.default_value().unwrap_or("").to_owned(),
-                            min: o.min(),
-                            max: o.max(),
-                            choices: o
-                                .choices()
-                                .map(|c| (0..c.len()).map(|j| c.get(j).to_owned()).collect())
-                                .unwrap_or_default(),
-                        }
-                    })
-                    .collect()
-            })
+            .map(extract_option_defs)
             .unwrap_or_default();
         BotPayload::Identify {
             name: id.name().unwrap_or("").to_owned(),
@@ -97,21 +69,7 @@ pub fn extract_bot_packet(buf: &[u8]) -> Result<(BotMessage, BotPayload), String
         BotPayload::Pong
     } else if msg_type == BotMessage::Info {
         let info = packet.message_as_info().ok_or("missing Info body")?;
-        BotPayload::Info(OwnedInfo {
-            player: info.player(),
-            multipv: info.multipv(),
-            target: info.target().map(vec2_to_coords),
-            depth: info.depth(),
-            nodes: info.nodes(),
-            score: info.score(),
-            pv: info
-                .pv()
-                .map(|p| p.iter().map(wire_to_engine_direction).collect())
-                .unwrap_or_default(),
-            message: info.message().unwrap_or("").to_owned(),
-            turn: info.turn(),
-            state_hash: info.state_hash(),
-        })
+        BotPayload::Info(extract_info(&info))
     } else if msg_type == BotMessage::RenderCommands {
         BotPayload::RenderCommands
     } else {
@@ -287,57 +245,15 @@ pub fn serialize_host_command(fbb: &mut FlatBufferBuilder<'_>, cmd: &HostCommand
     fbb.finished_data().to_vec()
 }
 
-// ── Round-trip helper for MatchConfig extraction ────
-
-/// Extract an `OwnedMatchConfig` from a wire `MatchConfig` table.
-#[allow(dead_code)] // Will be consumed by game loop; currently tested only.
-pub fn extract_match_config(mc: &wire::MatchConfig<'_>) -> OwnedMatchConfig {
-    OwnedMatchConfig {
-        width: mc.width(),
-        height: mc.height(),
-        max_turns: mc.max_turns(),
-        walls: mc
-            .walls()
-            .map(|ws| {
-                (0..ws.len())
-                    .map(|i| {
-                        let w = ws.get(i);
-                        (vec2_opt(w.pos1()), vec2_opt(w.pos2()))
-                    })
-                    .collect()
-            })
-            .unwrap_or_default(),
-        mud: mc
-            .mud()
-            .map(|ms| {
-                (0..ms.len())
-                    .map(|i| {
-                        let m = ms.get(i);
-                        (vec2_opt(m.pos1()), vec2_opt(m.pos2()), m.value())
-                    })
-                    .collect()
-            })
-            .unwrap_or_default(),
-        cheese: mc
-            .cheese()
-            .map(|cs| (0..cs.len()).map(|i| vec2_to_coords(cs.get(i))).collect())
-            .unwrap_or_default(),
-        player1_start: vec2_opt(mc.player1_start()),
-        player2_start: vec2_opt(mc.player2_start()),
-        controlled_players: mc
-            .controlled_players()
-            .map(|ps| ps.iter().collect())
-            .unwrap_or_default(),
-        timing: mc.timing(),
-        move_timeout_ms: mc.move_timeout_ms(),
-        preprocessing_timeout_ms: mc.preprocessing_timeout_ms(),
-    }
-}
+// Re-export from protocol crate. Currently used in tests; will be consumed
+// by the game loop once it needs to extract config from wire directly.
+#[allow(unused_imports)]
+pub use pyrat_protocol::extract_match_config;
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::session::messages::{HashedTurnState, OwnedTurnState};
+    use crate::session::messages::{HashedTurnState, OwnedMatchConfig, OwnedTurnState};
     use pyrat::Coordinates;
     use pyrat_wire::{Direction, GameResult, Player, TimingMode};
 

--- a/server/host/src/session/codec.rs
+++ b/server/host/src/session/codec.rs
@@ -42,10 +42,7 @@ pub fn extract_bot_packet(buf: &[u8]) -> Result<(BotMessage, BotPayload), String
         let id = packet
             .message_as_identify()
             .ok_or("missing Identify body")?;
-        let options = id
-            .options()
-            .map(extract_option_defs)
-            .unwrap_or_default();
+        let options = id.options().map(extract_option_defs).unwrap_or_default();
         BotPayload::Identify {
             name: id.name().unwrap_or("").to_owned(),
             author: id.author().unwrap_or("").to_owned(),
@@ -249,8 +246,8 @@ pub fn serialize_host_command(fbb: &mut FlatBufferBuilder<'_>, cmd: &HostCommand
 mod tests {
     use super::*;
     use crate::session::messages::{HashedTurnState, OwnedMatchConfig, OwnedTurnState};
-    use pyrat_protocol::extract_match_config;
     use pyrat::Coordinates;
+    use pyrat_protocol::extract_match_config;
     use pyrat_wire::{Direction, GameResult, Player, TimingMode};
 
     // Helper: build a BotPacket with Identify

--- a/server/host/src/session/messages.rs
+++ b/server/host/src/session/messages.rs
@@ -1,11 +1,7 @@
 use tokio::sync::mpsc;
 
+use pyrat_protocol::{HashedTurnState, OwnedInfo, OwnedMatchConfig, OwnedOptionDef};
 use pyrat_wire::{GameResult, Player};
-
-// Re-export protocol types so internal `use crate::session::messages::*` paths stay valid.
-pub use pyrat_protocol::{
-    HashedTurnState, MudEntry, OwnedInfo, OwnedMatchConfig, OwnedOptionDef, OwnedTurnState,
-};
 
 // ── Session identity ────────────────────────────────
 

--- a/server/host/src/stub.rs
+++ b/server/host/src/stub.rs
@@ -8,9 +8,10 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tracing::debug;
 
-use crate::session::messages::{HostCommand, OwnedInfo, SessionMsg};
+use crate::session::messages::{HostCommand, SessionMsg};
 use crate::session::SessionId;
 use pyrat::Direction;
+use pyrat_protocol::OwnedInfo;
 use pyrat_wire::Player;
 
 /// The four movement directions (excludes Stay).

--- a/server/host/tests/common/mod.rs
+++ b/server/host/tests/common/mod.rs
@@ -14,6 +14,7 @@ use pyrat_host::session::messages::*;
 use pyrat_host::session::{run_session, SessionConfig, SessionId};
 use pyrat_host::wire::framing::{FrameReader, FrameWriter};
 use pyrat_host::wire::*;
+use pyrat_protocol::OwnedMatchConfig;
 
 /// Build a framed BotPacket from a closure that builds the inner message.
 pub fn build_bot_frame<F>(msg_type: BotMessage, build_msg: F) -> Vec<u8>

--- a/server/host/tests/session_integration.rs
+++ b/server/host/tests/session_integration.rs
@@ -14,6 +14,7 @@ use pyrat_host::session::messages::*;
 use pyrat_host::session::{run_session, SessionConfig};
 use pyrat_host::wire::framing::{FrameReader, FrameWriter};
 use pyrat_host::wire::*;
+use pyrat_protocol::{HashedTurnState, OwnedMatchConfig, OwnedTurnState};
 
 use common::*;
 

--- a/server/protocol/Cargo.toml
+++ b/server/protocol/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 pyrat-rust = { path = "../../engine", default-features = false }
 pyrat-wire = { path = "../wire" }
+flatbuffers = "25.2.10"
 
 [lints]
 workspace = true

--- a/server/protocol/src/codec.rs
+++ b/server/protocol/src/codec.rs
@@ -351,7 +351,19 @@ mod tests {
     #[test]
     fn extract_info_empty_optional_fields() {
         let mut fbb = FlatBufferBuilder::new();
-        build_wire_info(&mut fbb, Player::Player1, 0, None, 0, 0, None, &[], "", 0, 0);
+        build_wire_info(
+            &mut fbb,
+            Player::Player1,
+            0,
+            None,
+            0,
+            0,
+            None,
+            &[],
+            "",
+            0,
+            0,
+        );
         let buf = fbb.finished_data();
         let info_fb = flatbuffers::root::<wire::Info>(buf).unwrap();
 

--- a/server/protocol/src/codec.rs
+++ b/server/protocol/src/codec.rs
@@ -25,6 +25,7 @@ pub(crate) fn vec2_to_coords(v: &Vec2) -> Coordinates {
 
 /// Convert an optional wire `Vec2` to engine `Coordinates`, defaulting to (0,0).
 pub(crate) fn vec2_opt(v: Option<&Vec2>) -> Coordinates {
+    debug_assert!(v.is_some(), "expected required Vec2 field, got None");
     v.map_or(Coordinates::new(0, 0), vec2_to_coords)
 }
 

--- a/server/protocol/src/codec.rs
+++ b/server/protocol/src/codec.rs
@@ -1,0 +1,535 @@
+//! FlatBuffers → owned type extraction.
+//!
+//! Shared extraction functions used by both the host and SDK codecs.
+//! Each consumer dispatches on packet type locally; the per-table extraction
+//! logic lives here.
+//!
+//! This module covers the **extraction direction only** (wire → owned).
+//! Serialization (owned → wire) stays in each consumer because it's coupled
+//! to their local enum structure (`HostCommand`, bot builders).
+
+use pyrat::Coordinates;
+use pyrat_wire::{self as wire, Vec2};
+
+use crate::{
+    wire_to_engine_direction, HashedTurnState, OwnedGameOver, OwnedInfo, OwnedMatchConfig,
+    OwnedOptionDef, OwnedTurnState,
+};
+
+// ── Coordinate helpers (crate-internal) ─────────────
+
+/// Convert a wire `Vec2` to engine `Coordinates`.
+pub(crate) fn vec2_to_coords(v: &Vec2) -> Coordinates {
+    Coordinates::new(v.x(), v.y())
+}
+
+/// Convert an optional wire `Vec2` to engine `Coordinates`, defaulting to (0,0).
+pub(crate) fn vec2_opt(v: Option<&Vec2>) -> Coordinates {
+    v.map_or(Coordinates::new(0, 0), vec2_to_coords)
+}
+
+// ── Extraction functions ────────────────────────────
+
+/// Extract an [`OwnedMatchConfig`] from a wire `MatchConfig` table.
+pub fn extract_match_config(mc: &wire::MatchConfig<'_>) -> OwnedMatchConfig {
+    OwnedMatchConfig {
+        width: mc.width(),
+        height: mc.height(),
+        max_turns: mc.max_turns(),
+        walls: mc
+            .walls()
+            .map(|ws| {
+                (0..ws.len())
+                    .map(|i| {
+                        let w = ws.get(i);
+                        (vec2_opt(w.pos1()), vec2_opt(w.pos2()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+        mud: mc
+            .mud()
+            .map(|ms| {
+                (0..ms.len())
+                    .map(|i| {
+                        let m = ms.get(i);
+                        (vec2_opt(m.pos1()), vec2_opt(m.pos2()), m.value())
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+        cheese: mc
+            .cheese()
+            .map(|cs| (0..cs.len()).map(|i| vec2_to_coords(cs.get(i))).collect())
+            .unwrap_or_default(),
+        player1_start: vec2_opt(mc.player1_start()),
+        player2_start: vec2_opt(mc.player2_start()),
+        controlled_players: mc
+            .controlled_players()
+            .map(|ps| ps.iter().collect())
+            .unwrap_or_default(),
+        timing: mc.timing(),
+        move_timeout_ms: mc.move_timeout_ms(),
+        preprocessing_timeout_ms: mc.preprocessing_timeout_ms(),
+    }
+}
+
+/// Extract a [`HashedTurnState`] from a wire `TurnState` table.
+///
+/// Trusts the wire-provided `state_hash` rather than recomputing it.
+/// The host computed the hash from the same fields; recomputing would be
+/// wasteful and would couple the consumer to the hash algorithm.
+pub fn extract_turn_state(ts: &wire::TurnState<'_>) -> HashedTurnState {
+    let owned = OwnedTurnState {
+        turn: ts.turn(),
+        player1_position: vec2_opt(ts.player1_position()),
+        player2_position: vec2_opt(ts.player2_position()),
+        player1_score: ts.player1_score(),
+        player2_score: ts.player2_score(),
+        player1_mud_turns: ts.player1_mud_turns(),
+        player2_mud_turns: ts.player2_mud_turns(),
+        cheese: ts
+            .cheese()
+            .map(|cs| (0..cs.len()).map(|i| vec2_to_coords(cs.get(i))).collect())
+            .unwrap_or_default(),
+        player1_last_move: wire_to_engine_direction(ts.player1_last_move()),
+        player2_last_move: wire_to_engine_direction(ts.player2_last_move()),
+    };
+    HashedTurnState::with_hash(owned, ts.state_hash())
+}
+
+/// Extract an [`OwnedInfo`] from a wire `Info` table.
+pub fn extract_info(info: &wire::Info<'_>) -> OwnedInfo {
+    OwnedInfo {
+        player: info.player(),
+        multipv: info.multipv(),
+        target: info.target().map(vec2_to_coords),
+        depth: info.depth(),
+        nodes: info.nodes(),
+        score: info.score(),
+        pv: info
+            .pv()
+            .map(|p| p.iter().map(wire_to_engine_direction).collect())
+            .unwrap_or_default(),
+        message: info.message().unwrap_or("").to_owned(),
+        turn: info.turn(),
+        state_hash: info.state_hash(),
+    }
+}
+
+/// Extract an [`OwnedGameOver`] from a wire `GameOver` table.
+pub fn extract_game_over(go: &wire::GameOver<'_>) -> OwnedGameOver {
+    OwnedGameOver {
+        result: go.result(),
+        player1_score: go.player1_score(),
+        player2_score: go.player2_score(),
+    }
+}
+
+/// Extract option definitions from a FlatBuffers vector of `OptionDef` tables.
+pub fn extract_option_defs(
+    opts: flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<wire::OptionDef<'_>>>,
+) -> Vec<OwnedOptionDef> {
+    (0..opts.len())
+        .map(|i| {
+            let o = opts.get(i);
+            OwnedOptionDef {
+                name: o.name().unwrap_or("").to_owned(),
+                option_type: o.type_(),
+                default_value: o.default_value().unwrap_or("").to_owned(),
+                min: o.min(),
+                max: o.max(),
+                choices: o
+                    .choices()
+                    .map(|c| (0..c.len()).map(|j| c.get(j).to_owned()).collect())
+                    .unwrap_or_default(),
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flatbuffers::FlatBufferBuilder;
+    use pyrat_wire::{
+        Direction as WireDir, GameResult, HostMessage, HostPacket, HostPacketArgs, Player,
+        TimingMode,
+    };
+
+    // ── MatchConfig ─────────────────────────────────
+
+    #[test]
+    fn extract_match_config_roundtrip() {
+        let mut fbb = FlatBufferBuilder::new();
+
+        let walls_data = vec![wire::Wall::create(
+            &mut fbb,
+            &wire::WallArgs {
+                pos1: Some(&Vec2::new(0, 0)),
+                pos2: Some(&Vec2::new(0, 1)),
+            },
+        )];
+        let walls = fbb.create_vector(&walls_data);
+
+        let muds_data = vec![wire::Mud::create(
+            &mut fbb,
+            &wire::MudArgs {
+                pos1: Some(&Vec2::new(3, 3)),
+                pos2: Some(&Vec2::new(3, 4)),
+                value: 5,
+            },
+        )];
+        let muds = fbb.create_vector(&muds_data);
+
+        let cheese_vec = vec![Vec2::new(10, 7), Vec2::new(5, 3)];
+        let cheese = fbb.create_vector(&cheese_vec);
+
+        let players = fbb.create_vector(&[Player::Player1]);
+
+        let mc = wire::MatchConfig::create(
+            &mut fbb,
+            &wire::MatchConfigArgs {
+                width: 21,
+                height: 15,
+                max_turns: 300,
+                walls: Some(walls),
+                mud: Some(muds),
+                cheese: Some(cheese),
+                player1_start: Some(&Vec2::new(20, 14)),
+                player2_start: Some(&Vec2::new(0, 0)),
+                controlled_players: Some(players),
+                timing: TimingMode::Wait,
+                move_timeout_ms: 1000,
+                preprocessing_timeout_ms: 5000,
+            },
+        );
+        fbb.finish(mc, None);
+        let buf = fbb.finished_data();
+        let mc = flatbuffers::root::<wire::MatchConfig>(buf).unwrap();
+
+        let cfg = extract_match_config(&mc);
+        assert_eq!(cfg.width, 21);
+        assert_eq!(cfg.height, 15);
+        assert_eq!(cfg.max_turns, 300);
+        assert_eq!(cfg.walls.len(), 1);
+        assert_eq!(cfg.walls[0].0, Coordinates::new(0, 0));
+        assert_eq!(cfg.walls[0].1, Coordinates::new(0, 1));
+        assert_eq!(cfg.mud.len(), 1);
+        assert_eq!(cfg.mud[0].2, 5);
+        assert_eq!(cfg.cheese.len(), 2);
+        assert_eq!(cfg.cheese[0], Coordinates::new(10, 7));
+        assert_eq!(cfg.player1_start, Coordinates::new(20, 14));
+        assert_eq!(cfg.player2_start, Coordinates::new(0, 0));
+        assert_eq!(cfg.controlled_players, vec![Player::Player1]);
+        assert_eq!(cfg.move_timeout_ms, 1000);
+        assert_eq!(cfg.preprocessing_timeout_ms, 5000);
+    }
+
+    // ── TurnState ───────────────────────────────────
+
+    #[test]
+    fn extract_turn_state_roundtrip() {
+        let mut fbb = FlatBufferBuilder::new();
+
+        let cheese_vec = vec![Vec2::new(5, 5), Vec2::new(15, 10)];
+        let cheese = fbb.create_vector(&cheese_vec);
+
+        let ts = wire::TurnState::create(
+            &mut fbb,
+            &wire::TurnStateArgs {
+                turn: 42,
+                player1_position: Some(&Vec2::new(10, 7)),
+                player2_position: Some(&Vec2::new(0, 0)),
+                player1_score: 3.0,
+                player2_score: 2.5,
+                player1_mud_turns: 0,
+                player2_mud_turns: 2,
+                cheese: Some(cheese),
+                player1_last_move: WireDir::Up,
+                player2_last_move: WireDir::Right,
+                state_hash: 0xFEED_FACE_1234_5678,
+            },
+        );
+        fbb.finish(ts, None);
+        let buf = fbb.finished_data();
+        let ts = flatbuffers::root::<wire::TurnState>(buf).unwrap();
+
+        let hts = extract_turn_state(&ts);
+        assert_eq!(hts.turn, 42);
+        assert_eq!(hts.player1_position, Coordinates::new(10, 7));
+        assert_eq!(hts.player2_position, Coordinates::new(0, 0));
+        assert!((hts.player1_score - 3.0).abs() < f32::EPSILON);
+        assert!((hts.player2_score - 2.5).abs() < f32::EPSILON);
+        assert_eq!(hts.player1_mud_turns, 0);
+        assert_eq!(hts.player2_mud_turns, 2);
+        assert_eq!(hts.cheese.len(), 2);
+        assert_eq!(hts.player1_last_move, pyrat::Direction::Up);
+        assert_eq!(hts.player2_last_move, pyrat::Direction::Right);
+        assert_eq!(hts.state_hash(), 0xFEED_FACE_1234_5678);
+    }
+
+    // ── Info ────────────────────────────────────────
+
+    #[allow(clippy::too_many_arguments)]
+    fn build_wire_info(
+        fbb: &mut FlatBufferBuilder<'_>,
+        player: Player,
+        multipv: u16,
+        target: Option<(u8, u8)>,
+        depth: u16,
+        nodes: u32,
+        score: Option<f32>,
+        pv: &[WireDir],
+        message: &str,
+        turn: u16,
+        state_hash: u64,
+    ) {
+        let msg = if message.is_empty() {
+            None
+        } else {
+            Some(fbb.create_string(message))
+        };
+        let pv_off = if pv.is_empty() {
+            None
+        } else {
+            Some(fbb.create_vector(pv))
+        };
+        let target_v = target.map(|(x, y)| Vec2::new(x, y));
+
+        let info = wire::Info::create(
+            fbb,
+            &wire::InfoArgs {
+                player,
+                multipv,
+                target: target_v.as_ref(),
+                depth,
+                nodes,
+                score,
+                pv: pv_off,
+                message: msg,
+                turn,
+                state_hash,
+            },
+        );
+        fbb.finish(info, None);
+    }
+
+    #[test]
+    fn extract_info_all_fields() {
+        let mut fbb = FlatBufferBuilder::new();
+        build_wire_info(
+            &mut fbb,
+            Player::Player2,
+            3,
+            Some((10, 7)),
+            5,
+            42000,
+            Some(2.5),
+            &[WireDir::Up, WireDir::Left],
+            "depth 5",
+            7,
+            0xDEAD_BEEF_CAFE_BABE,
+        );
+        let buf = fbb.finished_data();
+        let info_fb = flatbuffers::root::<wire::Info>(buf).unwrap();
+
+        let info = extract_info(&info_fb);
+        assert_eq!(info.player, Player::Player2);
+        assert_eq!(info.multipv, 3);
+        assert_eq!(info.target, Some(Coordinates::new(10, 7)));
+        assert_eq!(info.depth, 5);
+        assert_eq!(info.nodes, 42000);
+        assert!((info.score.unwrap() - 2.5).abs() < f32::EPSILON);
+        assert_eq!(info.pv, vec![pyrat::Direction::Up, pyrat::Direction::Left]);
+        assert_eq!(info.message, "depth 5");
+        assert_eq!(info.turn, 7);
+        assert_eq!(info.state_hash, 0xDEAD_BEEF_CAFE_BABE);
+    }
+
+    #[test]
+    fn extract_info_empty_optional_fields() {
+        let mut fbb = FlatBufferBuilder::new();
+        build_wire_info(&mut fbb, Player::Player1, 0, None, 0, 0, None, &[], "", 0, 0);
+        let buf = fbb.finished_data();
+        let info_fb = flatbuffers::root::<wire::Info>(buf).unwrap();
+
+        let info = extract_info(&info_fb);
+        assert!(info.target.is_none());
+        assert!(info.score.is_none());
+        assert!(info.pv.is_empty());
+        assert!(info.message.is_empty());
+    }
+
+    // ── GameOver ────────────────────────────────────
+
+    #[test]
+    fn extract_game_over_roundtrip() {
+        let mut fbb = FlatBufferBuilder::new();
+        let go = wire::GameOver::create(
+            &mut fbb,
+            &wire::GameOverArgs {
+                result: GameResult::Draw,
+                player1_score: 5.0,
+                player2_score: 5.0,
+            },
+        );
+        fbb.finish(go, None);
+        let buf = fbb.finished_data();
+        let go_fb = flatbuffers::root::<wire::GameOver>(buf).unwrap();
+
+        let go = extract_game_over(&go_fb);
+        assert_eq!(go.result, GameResult::Draw);
+        assert!((go.player1_score - 5.0).abs() < f32::EPSILON);
+        assert!((go.player2_score - 5.0).abs() < f32::EPSILON);
+    }
+
+    // ── OptionDefs ──────────────────────────────────
+
+    #[test]
+    fn extract_option_defs_roundtrip() {
+        let mut fbb = FlatBufferBuilder::new();
+
+        let name = fbb.create_string("Hash");
+        let default = fbb.create_string("128");
+        let c1 = fbb.create_string("64");
+        let c2 = fbb.create_string("128");
+        let choices = fbb.create_vector(&[c1, c2]);
+
+        let opt = wire::OptionDef::create(
+            &mut fbb,
+            &wire::OptionDefArgs {
+                name: Some(name),
+                type_: pyrat_wire::OptionType::Combo,
+                default_value: Some(default),
+                min: 0,
+                max: 256,
+                choices: Some(choices),
+            },
+        );
+        let opts_vec = fbb.create_vector(&[opt]);
+
+        // Wrap in an Identify to get a proper table we can root-parse.
+        let bot_name = fbb.create_string("Bot");
+        let bot_author = fbb.create_string("Author");
+        let id = wire::Identify::create(
+            &mut fbb,
+            &wire::IdentifyArgs {
+                name: Some(bot_name),
+                author: Some(bot_author),
+                options: Some(opts_vec),
+                agent_id: None,
+            },
+        );
+        fbb.finish(id, None);
+        let buf = fbb.finished_data();
+        let id_fb = flatbuffers::root::<wire::Identify>(buf).unwrap();
+
+        let defs = extract_option_defs(id_fb.options().unwrap());
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].name, "Hash");
+        assert_eq!(defs[0].option_type, pyrat_wire::OptionType::Combo);
+        assert_eq!(defs[0].default_value, "128");
+        assert_eq!(defs[0].choices, vec!["64", "128"]);
+    }
+
+    // ── Cross-crate envelope test ───────────────────
+
+    /// Build a full `HostPacket` envelope containing a `MatchConfig`,
+    /// as the host serializer would produce. Extract through the shared
+    /// function and verify fields match.
+    #[test]
+    fn extract_match_config_from_host_packet_envelope() {
+        let mut fbb = FlatBufferBuilder::new();
+
+        let cheese_vec = vec![Vec2::new(2, 2)];
+        let cheese = fbb.create_vector(&cheese_vec);
+        let players = fbb.create_vector(&[Player::Player1]);
+
+        let mc = wire::MatchConfig::create(
+            &mut fbb,
+            &wire::MatchConfigArgs {
+                width: 5,
+                height: 5,
+                max_turns: 100,
+                walls: None,
+                mud: None,
+                cheese: Some(cheese),
+                player1_start: Some(&Vec2::new(4, 4)),
+                player2_start: Some(&Vec2::new(0, 0)),
+                controlled_players: Some(players),
+                timing: TimingMode::Wait,
+                move_timeout_ms: 500,
+                preprocessing_timeout_ms: 3000,
+            },
+        );
+
+        let packet = HostPacket::create(
+            &mut fbb,
+            &HostPacketArgs {
+                message_type: HostMessage::MatchConfig,
+                message: Some(mc.as_union_value()),
+            },
+        );
+        fbb.finish(packet, None);
+        let buf = fbb.finished_data();
+
+        // Parse the envelope, then extract the inner table.
+        let packet = flatbuffers::root::<HostPacket>(buf).unwrap();
+        assert_eq!(packet.message_type(), HostMessage::MatchConfig);
+        let mc = packet.message_as_match_config().unwrap();
+
+        let cfg = extract_match_config(&mc);
+        assert_eq!(cfg.width, 5);
+        assert_eq!(cfg.height, 5);
+        assert_eq!(cfg.cheese.len(), 1);
+        assert_eq!(cfg.cheese[0], Coordinates::new(2, 2));
+        assert_eq!(cfg.player1_start, Coordinates::new(4, 4));
+        assert_eq!(cfg.move_timeout_ms, 500);
+    }
+
+    /// Build a full `HostPacket` envelope containing a `TurnState`,
+    /// extract through the shared function, verify hash is trusted from wire.
+    #[test]
+    fn extract_turn_state_from_host_packet_envelope() {
+        let mut fbb = FlatBufferBuilder::new();
+
+        let cheese_vec = vec![Vec2::new(2, 2)];
+        let cheese = fbb.create_vector(&cheese_vec);
+
+        let ts = wire::TurnState::create(
+            &mut fbb,
+            &wire::TurnStateArgs {
+                turn: 10,
+                player1_position: Some(&Vec2::new(1, 1)),
+                player2_position: Some(&Vec2::new(3, 3)),
+                player1_score: 1.0,
+                player2_score: 0.0,
+                player1_mud_turns: 0,
+                player2_mud_turns: 0,
+                cheese: Some(cheese),
+                player1_last_move: WireDir::Right,
+                player2_last_move: WireDir::Left,
+                state_hash: 0xABCD_EF01,
+            },
+        );
+
+        let packet = HostPacket::create(
+            &mut fbb,
+            &HostPacketArgs {
+                message_type: HostMessage::TurnState,
+                message: Some(ts.as_union_value()),
+            },
+        );
+        fbb.finish(packet, None);
+        let buf = fbb.finished_data();
+
+        let packet = flatbuffers::root::<HostPacket>(buf).unwrap();
+        let ts = packet.message_as_turn_state().unwrap();
+
+        let hts = extract_turn_state(&ts);
+        assert_eq!(hts.turn, 10);
+        assert_eq!(hts.player1_position, Coordinates::new(1, 1));
+        assert_eq!(hts.state_hash(), 0xABCD_EF01);
+    }
+}

--- a/server/protocol/src/codec.rs
+++ b/server/protocol/src/codec.rs
@@ -1,32 +1,46 @@
 //! FlatBuffers → owned type extraction.
 //!
 //! Shared extraction functions used by both the host and SDK codecs.
-//! Each consumer dispatches on packet type locally; the per-table extraction
-//! logic lives here.
+//! Host receives `BotPacket`, SDK receives `HostPacket` — the message-type
+//! sets are disjoint, so dispatch is local. The per-table extraction logic
+//! is identical and lives here.
 //!
 //! This module covers the **extraction direction only** (wire → owned).
 //! Serialization (owned → wire) stays in each consumer because it's coupled
-//! to their local enum structure (`HostCommand`, bot builders).
+//! to their local enum structure (`HostCommand`, bot builders). [`coords_to_vec2`]
+//! is the one serialization-side helper that lives here, as a mirror of
+//! [`vec2_to_coords`].
 
 use pyrat::Coordinates;
 use pyrat_wire::{self as wire, Vec2};
 
 use crate::{
-    wire_to_engine_direction, HashedTurnState, OwnedGameOver, OwnedInfo, OwnedMatchConfig,
-    OwnedOptionDef, OwnedTurnState,
+    wire_to_engine_direction, HashedTurnState, MudEntry, OwnedGameOver, OwnedInfo,
+    OwnedMatchConfig, OwnedOptionDef, OwnedTurnState,
 };
 
-// ── Coordinate helpers (crate-internal) ─────────────
+// ── Coordinate helpers ──────────────────────────────
 
 /// Convert a wire `Vec2` to engine `Coordinates`.
 pub(crate) fn vec2_to_coords(v: &Vec2) -> Coordinates {
     Coordinates::new(v.x(), v.y())
 }
 
-/// Convert an optional wire `Vec2` to engine `Coordinates`, defaulting to (0,0).
+/// Extract a required wire `Vec2` as engine `Coordinates`.
+///
+/// Panics in debug builds if the field is missing; returns `(0, 0)` in release
+/// builds (the schema marks these fields required, so `None` indicates a
+/// protocol violation that should not occur in practice).
 pub(crate) fn vec2_opt(v: Option<&Vec2>) -> Coordinates {
     debug_assert!(v.is_some(), "expected required Vec2 field, got None");
     v.map_or(Coordinates::new(0, 0), vec2_to_coords)
+}
+
+/// Convert engine `Coordinates` to a wire `Vec2`.
+///
+/// Mirror of [`vec2_to_coords`]. Use at the serialization boundary.
+pub fn coords_to_vec2(c: Coordinates) -> Vec2 {
+    Vec2::new(c.x, c.y)
 }
 
 // ── Extraction functions ────────────────────────────
@@ -54,7 +68,11 @@ pub fn extract_match_config(mc: &wire::MatchConfig<'_>) -> OwnedMatchConfig {
                 (0..ms.len())
                     .map(|i| {
                         let m = ms.get(i);
-                        (vec2_opt(m.pos1()), vec2_opt(m.pos2()), m.value())
+                        MudEntry {
+                            pos1: vec2_opt(m.pos1()),
+                            pos2: vec2_opt(m.pos2()),
+                            turns: m.value(),
+                        }
                     })
                     .collect()
             })
@@ -80,6 +98,11 @@ pub fn extract_match_config(mc: &wire::MatchConfig<'_>) -> OwnedMatchConfig {
 /// Trusts the wire-provided `state_hash` rather than recomputing it.
 /// The host computed the hash from the same fields; recomputing would be
 /// wasteful and would couple the consumer to the hash algorithm.
+///
+/// The hash is a correlation tag, not a trust boundary. Host/SDK agreement
+/// on initial state is verified once at the setup-phase handshake (see the
+/// SDK's `compute_initial_hash`); per-turn hashes ride along on the wire
+/// after that.
 pub fn extract_turn_state(ts: &wire::TurnState<'_>) -> HashedTurnState {
     let owned = OwnedTurnState {
         turn: ts.turn(),
@@ -96,7 +119,7 @@ pub fn extract_turn_state(ts: &wire::TurnState<'_>) -> HashedTurnState {
         player1_last_move: wire_to_engine_direction(ts.player1_last_move()),
         player2_last_move: wire_to_engine_direction(ts.player2_last_move()),
     };
-    HashedTurnState::with_hash(owned, ts.state_hash())
+    HashedTurnState::with_unverified_hash(owned, ts.state_hash())
 }
 
 /// Extract an [`OwnedInfo`] from a wire `Info` table.
@@ -217,7 +240,7 @@ mod tests {
         assert_eq!(cfg.walls[0].0, Coordinates::new(0, 0));
         assert_eq!(cfg.walls[0].1, Coordinates::new(0, 1));
         assert_eq!(cfg.mud.len(), 1);
-        assert_eq!(cfg.mud[0].2, 5);
+        assert_eq!(cfg.mud[0].turns, 5);
         assert_eq!(cfg.cheese.len(), 2);
         assert_eq!(cfg.cheese[0], Coordinates::new(10, 7));
         assert_eq!(cfg.player1_start, Coordinates::new(20, 14));

--- a/server/protocol/src/lib.rs
+++ b/server/protocol/src/lib.rs
@@ -7,9 +7,11 @@
 //! The [`HostMsg`] and [`BotMsg`] enums define the Player trait pipe vocabulary:
 //! what the Match sends and receives through `Player::send()`/`Player::recv()`.
 
+mod codec;
 mod messages;
 mod types;
 
+pub use codec::*;
 pub use messages::*;
 pub use types::*;
 

--- a/server/protocol/src/types.rs
+++ b/server/protocol/src/types.rs
@@ -23,11 +23,17 @@ pub fn wire_to_engine_direction(d: pyrat_wire::Direction) -> Direction {
         pyrat_wire::Direction::Down => Direction::Down,
         pyrat_wire::Direction::Left => Direction::Left,
         pyrat_wire::Direction::Stay => Direction::Stay,
-        _ => Direction::Stay,
+        _ => {
+            debug_assert!(false, "unknown wire Direction discriminant: {}", d.0);
+            Direction::Stay
+        }
     }
 }
 
 /// Convert an engine Direction to a wire Direction.
+///
+/// Relies on engine `Direction` discriminants (0–4) matching wire `Direction`
+/// constants. The `direction_conversion_roundtrip` test verifies this.
 pub fn engine_to_wire_direction(d: Direction) -> pyrat_wire::Direction {
     pyrat_wire::Direction(d as u8)
 }
@@ -246,6 +252,22 @@ mod tests {
         let hts = HashedTurnState::new(sample_turn_state());
         assert_eq!(hts.turn, 42);
         assert_eq!(hts.player1_position, Coordinates::new(10, 7));
+    }
+
+    #[test]
+    fn direction_conversion_roundtrip() {
+        use pyrat_wire::Direction as WireDir;
+
+        for (w, e) in [
+            (WireDir::Up, Direction::Up),
+            (WireDir::Right, Direction::Right),
+            (WireDir::Down, Direction::Down),
+            (WireDir::Left, Direction::Left),
+            (WireDir::Stay, Direction::Stay),
+        ] {
+            assert_eq!(wire_to_engine_direction(w), e);
+            assert_eq!(engine_to_wire_direction(e), w);
+        }
     }
 
     /// Verify that `Coordinates` hashes identically to the `(u8, u8)` tuple

--- a/server/protocol/src/types.rs
+++ b/server/protocol/src/types.rs
@@ -11,7 +11,7 @@ use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 
 use pyrat::{Coordinates, Direction};
-use pyrat_wire::{OptionType, Player, TimingMode};
+use pyrat_wire::{GameResult, OptionType, Player, TimingMode};
 
 // ── Direction conversion ────────────────────────────
 
@@ -93,6 +93,16 @@ pub struct OwnedMatchConfig {
     pub preprocessing_timeout_ms: u32,
 }
 
+// ── Game over ──────────────────────────────────────
+
+/// Game-over result data sent to bots at the end of a match.
+#[derive(Debug, Clone)]
+pub struct OwnedGameOver {
+    pub result: GameResult,
+    pub player1_score: f32,
+    pub player2_score: f32,
+}
+
 // ── Turn state ──────────────────────────────────────
 
 /// Game position state sent to bots each turn.
@@ -149,6 +159,13 @@ impl HashedTurnState {
     /// The content-addressable hash for this turn state.
     pub fn state_hash(&self) -> u64 {
         self.state_hash
+    }
+
+    /// Consume the wrapper and return the inner turn state.
+    ///
+    /// Use `state_hash()` before calling this if you need the hash.
+    pub fn into_inner(self) -> OwnedTurnState {
+        self.inner
     }
 
     /// Deterministic hash of all game-position fields.

--- a/server/protocol/src/types.rs
+++ b/server/protocol/src/types.rs
@@ -33,7 +33,9 @@ pub fn wire_to_engine_direction(d: pyrat_wire::Direction) -> Direction {
 /// Convert an engine Direction to a wire Direction.
 ///
 /// Relies on engine `Direction` discriminants (0–4) matching wire `Direction`
-/// constants. The `direction_conversion_roundtrip` test verifies this.
+/// constants. The `direction_conversion_roundtrip` test checks the 5 current
+/// variants; if you add a new engine direction, update both the wire schema
+/// and that test.
 pub fn engine_to_wire_direction(d: Direction) -> pyrat_wire::Direction {
     pyrat_wire::Direction(d as u8)
 }
@@ -76,8 +78,14 @@ pub struct OwnedInfo {
 
 // ── Match configuration ─────────────────────────────
 
-/// Mud entry: (pos1, pos2, mud_value).
-pub type MudEntry = (Coordinates, Coordinates, u8);
+/// A single mud passage between two cells, with the number of turns it takes
+/// to cross.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MudEntry {
+    pub pos1: Coordinates,
+    pub pos2: Coordinates,
+    pub turns: u8,
+}
 
 /// Match configuration sent to bots during the Lobby phase.
 ///
@@ -115,10 +123,7 @@ pub struct OwnedGameOver {
 ///
 /// Contains the raw game-position fields. Does **not** include `state_hash`,
 /// which is a derived value. Use [`HashedTurnState`] to pair a turn state with
-/// its content-addressable hash.
-///
-/// If you add or change position-defining fields here, update
-/// [`HashedTurnState::compute_hash`] in this same file.
+/// a fingerprint of its fields.
 #[derive(Debug, Clone)]
 pub struct OwnedTurnState {
     pub turn: u16,
@@ -133,11 +138,12 @@ pub struct OwnedTurnState {
     pub player2_last_move: Direction,
 }
 
-/// An [`OwnedTurnState`] paired with a content-addressable hash of its
+/// An [`OwnedTurnState`] paired with a 64-bit fingerprint of its
 /// position-defining fields.
 ///
 /// The hash is computed once at construction time. Two states that a bot would
-/// analyze differently will hash differently.
+/// analyze differently will hash differently. The hash is not collision-resistant;
+/// it's a correlation tag, not a trust boundary.
 #[derive(Debug, Clone)]
 pub struct HashedTurnState {
     inner: OwnedTurnState,
@@ -154,15 +160,21 @@ impl HashedTurnState {
         }
     }
 
-    /// Wrap a turn state with a pre-computed hash (from `GameState::state_hash()`).
-    pub fn with_hash(ts: OwnedTurnState, state_hash: u64) -> Self {
+    /// Wrap a turn state with a hash supplied by the producer, without
+    /// recomputing it.
+    ///
+    /// The caller vouches that `state_hash` matches the fields in `ts`. The
+    /// wrapper does not verify this. Name chosen to advertise the trust:
+    /// mismatches are only caught by the setup-phase hash handshake in
+    /// consumers.
+    pub fn with_unverified_hash(ts: OwnedTurnState, state_hash: u64) -> Self {
         Self {
             inner: ts,
             state_hash,
         }
     }
 
-    /// The content-addressable hash for this turn state.
+    /// The fingerprint hash for this turn state.
     pub fn state_hash(&self) -> u64 {
         self.state_hash
     }
@@ -229,10 +241,22 @@ mod tests {
         assert_eq!(a.state_hash(), b.state_hash());
     }
 
+    /// Pinned hash for `sample_turn_state()` — catches silent changes to the
+    /// hasher, field ordering, or score quantization. If this test fails after
+    /// an intentional change, recompute the expected value once and update it.
     #[test]
-    fn hashed_turn_state_with_hash_stores_provided_hash() {
+    fn hashed_turn_state_golden_value() {
+        let got = HashedTurnState::new(sample_turn_state()).state_hash();
+        assert_eq!(
+            got, 0x7006_86d9_8688_95f5,
+            "update expected value if the hash algorithm changed intentionally"
+        );
+    }
+
+    #[test]
+    fn hashed_turn_state_with_unverified_hash_stores_provided_hash() {
         let ts = sample_turn_state();
-        let hts = HashedTurnState::with_hash(ts, 0xDEAD_BEEF);
+        let hts = HashedTurnState::with_unverified_hash(ts, 0xDEAD_BEEF);
         assert_eq!(hts.state_hash(), 0xDEAD_BEEF);
     }
 

--- a/server/protocol/src/types.rs
+++ b/server/protocol/src/types.rs
@@ -26,7 +26,7 @@ pub fn wire_to_engine_direction(d: pyrat_wire::Direction) -> Direction {
         _ => {
             debug_assert!(false, "unknown wire Direction discriminant: {}", d.0);
             Direction::Stay
-        }
+        },
     }
 }
 


### PR DESCRIPTION
## Motivation

The host (`session/codec.rs`) and SDK (`wire.rs`) each had their own copy of the FlatBuffers-to-owned-types extraction code: direction converters, coordinate helpers, `extract_match_config`, `extract_turn_state`, and the owned type definitions themselves. Same logic, same bugs twice if something drifts.

This is the codec chunk of the `pyrat-protocol` migration (types shipped in #189).

## Solution

Extraction logic (wire → owned) now lives in `pyrat_protocol::codec`. Both consumers depend on it instead of maintaining local copies.

### What moved

The extraction functions (`extract_match_config`, `extract_turn_state`, `extract_game_over`, `extract_info`, `extract_option_defs`), coordinate helpers (`vec2_to_coords`, `vec2_opt`), and direction converters (`wire_to_engine_direction`, `engine_to_wire_direction`) are now in `server/protocol/src/codec.rs` and `server/protocol/src/types.rs`.

The SDK's owned types (`MatchConfigData`, `TurnStateData`, `GameOverData`) are gone. `SdkOptionDef` is a type alias for `OwnedOptionDef`. The host's `session/messages.rs` re-exports from `pyrat_protocol` so internal import paths stay stable (scaffolding, removed later).

### What stayed

Serialization (owned → wire) stays in each consumer. It's coupled to their local enum structures (`HostCommand` variants, bot packet builders). Sharing it would force premature convergence on a common message enum.

### Extraction-only boundary

The split is intentional. The module doc in `codec.rs` captures why:

```rust
//! This module covers the **extraction direction only** (wire → owned).
//! Serialization (owned → wire) stays in each consumer because it's coupled
//! to their local enum structure (`HostCommand`, bot builders).
```

### `compute_initial_hash` deduplication

The SDK had a hand-rolled copy of the hash algorithm in `GameState::compute_initial_hash()`. It now delegates to `HashedTurnState::new(ts).state_hash()`, so the algorithm is defined in one place. If `OwnedTurnState` gains a field, the construction fails to compile instead of silently producing a wrong hash.

### Defensive assertions

`debug_assert!` added in three places that would silently produce wrong data on protocol violations:
- `wire_to_engine_direction` wildcard arm (unknown discriminant → Stay)
- `vec2_opt` (missing required Vec2 field → (0,0))
- Direction roundtrip test re-added (was dropped during the move)

## Test Plan

`cargo test -p pyrat-protocol` (14 tests), `cargo test -p pyrat-sdk` (37 + 13 + 1 tests), `cargo check -p pyrat-gui`. Roundtrip extraction tests for all five shared functions plus envelope tests. New `compute_initial_hash_matches_hashed_turn_state` regression test. Direction conversion roundtrip test.