### PR TITLE
Add Player trait and EmbeddedPlayer in-process impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2968,6 +2968,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyrat-bot-api"
+version = "0.1.0"
+dependencies = [
+ "pyrat-protocol",
+ "pyrat-rust",
+ "pyrat-wire",
+]
+
+[[package]]
 name = "pyrat-check"
 version = "0.1.0"
 dependencies = [
@@ -3053,6 +3062,7 @@ version = "0.1.0"
 dependencies = [
  "fastrand",
  "flatbuffers",
+ "pyrat-bot-api",
  "pyrat-protocol",
  "pyrat-rust",
  "pyrat-wire",
@@ -3088,6 +3098,7 @@ name = "pyrat-sdk"
 version = "0.1.0"
 dependencies = [
  "flatbuffers",
+ "pyrat-bot-api",
  "pyrat-engine-interface",
  "pyrat-protocol",
  "pyrat-rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["engine", "engine/extension", "server/headless", "server/host", "server/protocol", "server/wire", "interface", "sdk/python", "sdk/rust", "sdk/rust/derive", "gui/src-tauri", "tools/bot-check", "eval/store"]
+members = ["engine", "engine/extension", "server/headless", "server/host", "server/protocol", "server/wire", "interface", "sdk/bot-api", "sdk/python", "sdk/rust", "sdk/rust/derive", "gui/src-tauri", "tools/bot-check", "eval/store"]
 resolver = "2"
 
 [workspace.lints.clippy]

--- a/botpack/greedy/Cargo.lock
+++ b/botpack/greedy/Cargo.lock
@@ -196,6 +196,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyrat-bot-api"
+version = "0.1.0"
+dependencies = [
+ "pyrat-protocol",
+ "pyrat-rust",
+ "pyrat-wire",
+]
+
+[[package]]
 name = "pyrat-engine-interface"
 version = "0.1.0"
 dependencies = [
@@ -224,6 +233,7 @@ name = "pyrat-sdk"
 version = "0.1.0"
 dependencies = [
  "flatbuffers",
+ "pyrat-bot-api",
  "pyrat-engine-interface",
  "pyrat-protocol",
  "pyrat-rust",

--- a/botpack/greedy/src/main.rs
+++ b/botpack/greedy/src/main.rs
@@ -19,7 +19,7 @@ impl Bot for Greedy {
         let chosen = candidates.choose(&mut rand::rng());
         match chosen {
             Some(result) if !result.path.is_empty() => {
-                let target = (result.target.x, result.target.y);
+                let target = result.target;
                 ctx.send_info(&InfoParams {
                     multipv: 1,
                     target: Some(target),
@@ -27,8 +27,8 @@ impl Bot for Greedy {
                     pv: &result.path,
                     message: &format!(
                         "target ({}, {}), {} steps",
-                        target.0,
-                        target.1,
+                        target.x,
+                        target.y,
                         result.path.len()
                     ),
                     ..InfoParams::for_player(state.my_player())

--- a/botpack/search/Cargo.lock
+++ b/botpack/search/Cargo.lock
@@ -196,10 +196,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyrat-bot-api"
+version = "0.1.0"
+dependencies = [
+ "pyrat-protocol",
+ "pyrat-rust",
+ "pyrat-wire",
+]
+
+[[package]]
 name = "pyrat-engine-interface"
 version = "0.1.0"
 dependencies = [
  "pyrat-rust",
+]
+
+[[package]]
+name = "pyrat-protocol"
+version = "0.1.0"
+dependencies = [
+ "flatbuffers",
+ "pyrat-rust",
+ "pyrat-wire",
 ]
 
 [[package]]
@@ -215,7 +233,9 @@ name = "pyrat-sdk"
 version = "0.1.0"
 dependencies = [
  "flatbuffers",
+ "pyrat-bot-api",
  "pyrat-engine-interface",
+ "pyrat-protocol",
  "pyrat-rust",
  "pyrat-sdk-derive",
  "pyrat-wire",

--- a/botpack/search/src/main.rs
+++ b/botpack/search/src/main.rs
@@ -22,7 +22,9 @@
 //!
 //! SDK features: GameSim, effective_moves, should_stop, send_info, send_provisional.
 
-use pyrat_sdk::{Bot, Context, Direction, GameSim, GameState, InfoParams, Options, Player};
+use pyrat_sdk::{
+    Bot, Context, Coordinates, Direction, GameSim, GameState, InfoParams, Options, Player,
+};
 use rand::prelude::SliceRandom;
 
 struct Search {
@@ -379,7 +381,7 @@ impl Search {
     }
 }
 
-type Target = Option<(u8, u8)>;
+type Target = Option<Coordinates>;
 
 fn find_targets(
     sim: &mut GameSim,
@@ -414,11 +416,11 @@ fn find_targets(
 
         if our_target.is_none() && cur_our > prev_our {
             let pos = if am_player1 { clone.player1_position() } else { clone.player2_position() };
-            our_target = Some((pos.x, pos.y));
+            our_target = Some(pos);
         }
         if opp_target.is_none() && cur_opp > prev_opp {
             let pos = if am_player1 { clone.player2_position() } else { clone.player1_position() };
-            opp_target = Some((pos.x, pos.y));
+            opp_target = Some(pos);
         }
 
         if our_target.is_some() && opp_target.is_some() {

--- a/botpack/smart-random/Cargo.lock
+++ b/botpack/smart-random/Cargo.lock
@@ -196,6 +196,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyrat-bot-api"
+version = "0.1.0"
+dependencies = [
+ "pyrat-protocol",
+ "pyrat-rust",
+ "pyrat-wire",
+]
+
+[[package]]
 name = "pyrat-engine-interface"
 version = "0.1.0"
 dependencies = [
@@ -224,6 +233,7 @@ name = "pyrat-sdk"
 version = "0.1.0"
 dependencies = [
  "flatbuffers",
+ "pyrat-bot-api",
  "pyrat-engine-interface",
  "pyrat-protocol",
  "pyrat-rust",

--- a/sdk/bot-api/Cargo.toml
+++ b/sdk/bot-api/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "pyrat-bot-api"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+pyrat = { package = "pyrat-rust", path = "../../engine", default-features = false }
+pyrat-wire = { path = "../../server/wire" }
+pyrat-protocol = { path = "../../server/protocol" }
+
+[lints]
+workspace = true

--- a/sdk/bot-api/src/context.rs
+++ b/sdk/bot-api/src/context.rs
@@ -4,7 +4,6 @@
 use std::sync::Arc;
 
 use pyrat::Direction;
-use pyrat_protocol::OwnedInfo;
 use pyrat_wire::Player;
 
 use crate::InfoParams;
@@ -64,27 +63,14 @@ impl InfoSender {
         Self { sink }
     }
 
-    /// Build an `OwnedInfo` from `params` and the worker-supplied
-    /// `turn` / `state_hash`, then forward to the underlying sink.
+    /// Forward an Info emission to the underlying sink.
     pub fn send_info(&self, params: &InfoParams<'_>, turn: u16, state_hash: u64) {
-        let info = OwnedInfo {
-            player: params.player,
-            multipv: params.multipv,
-            target: params.target,
-            depth: params.depth,
-            nodes: params.nodes,
-            score: params.score,
-            pv: params.pv.to_vec(),
-            message: params.message.to_string(),
-            turn,
-            state_hash,
-        };
-        self.sink.send_info(info);
+        self.sink.send_info(params, turn, state_hash);
     }
 }
 
 /// Transport-specific Info emitter. SDK wraps a frame-writer channel;
 /// host wraps an `EventSink` + per-match metadata.
 pub trait InfoSink: Send + Sync {
-    fn send_info(&self, info: OwnedInfo);
+    fn send_info(&self, params: &InfoParams<'_>, turn: u16, state_hash: u64);
 }

--- a/sdk/bot-api/src/context.rs
+++ b/sdk/bot-api/src/context.rs
@@ -1,0 +1,90 @@
+//! Bot-facing context: the interface a bot sees during `think` and
+//! `preprocess`.
+
+use std::sync::Arc;
+
+use pyrat::Direction;
+use pyrat_protocol::OwnedInfo;
+use pyrat_wire::Player;
+
+use crate::InfoParams;
+
+/// Per-turn interface the bot uses to query deadlines, emit sideband
+/// (Info / Provisional), and cooperate with host-initiated stops.
+///
+/// Implemented by `pyrat_sdk::Context` (networked) and
+/// `pyrat_host::player::EmbeddedCtx` (in-process) so a single bot
+/// implementation works unchanged across both transports.
+pub trait BotContext {
+    /// Player slot this bot is controlling.
+    fn player(&self) -> Player;
+
+    /// Current turn number.
+    fn turn(&self) -> u16;
+
+    /// Server-canonical hash of the current turn state.
+    fn state_hash(&self) -> u64;
+
+    /// True when the bot should stop thinking: deadline passed, host
+    /// sent Stop, or the game ended.
+    fn should_stop(&self) -> bool;
+
+    /// Milliseconds remaining before the deadline. Returns 0 if the
+    /// bot has been told to stop.
+    fn time_remaining_ms(&self) -> u64;
+
+    /// Milliseconds elapsed since `think` started.
+    fn think_elapsed_ms(&self) -> u32;
+
+    /// Emit an observer-facing Info frame.
+    fn send_info(&self, params: &InfoParams<'_>);
+
+    /// Emit a provisional best move. The host uses the latest
+    /// provisional as a timeout fallback.
+    fn send_provisional(&self, direction: Direction);
+
+    /// Cloneable handle for sending Info frames from worker threads
+    /// (e.g., MCTS search threads). `None` if the underlying transport
+    /// has no room for sideband.
+    fn info_sender(&self) -> Option<InfoSender>;
+}
+
+/// Cloneable Info emitter. Multi-threaded bots obtain one of these from
+/// [`BotContext::info_sender`] and hand clones to worker threads; each
+/// call passes the worker's view of `turn` and `state_hash`.
+#[derive(Clone)]
+pub struct InfoSender {
+    sink: Arc<dyn InfoSink>,
+}
+
+impl InfoSender {
+    /// Construct from a concrete sink. Transport crates (SDK, host) use
+    /// this to hand out pre-wrapped senders.
+    pub fn new(sink: Arc<dyn InfoSink>) -> Self {
+        Self { sink }
+    }
+
+    /// Build an `OwnedInfo` from `params` and the worker-supplied
+    /// `turn` / `state_hash`, then forward to the underlying sink.
+    pub fn send_info(&self, params: &InfoParams<'_>, turn: u16, state_hash: u64) {
+        let info = OwnedInfo {
+            player: params.player,
+            multipv: params.multipv,
+            target: params.target,
+            depth: params.depth,
+            nodes: params.nodes,
+            score: params.score,
+            pv: params.pv.to_vec(),
+            message: params.message.to_string(),
+            turn,
+            state_hash,
+        };
+        self.sink.send_info(info);
+    }
+}
+
+/// Transport-specific Info emitter. SDK wraps a frame-writer channel;
+/// host wraps an `EventSink` + per-match metadata.
+pub trait InfoSink: Send + Sync {
+    fn send_info(&self, info: OwnedInfo);
+}

--- a/sdk/bot-api/src/info.rs
+++ b/sdk/bot-api/src/info.rs
@@ -27,7 +27,6 @@ pub struct InfoParams<'a> {
 }
 
 impl InfoParams<'_> {
-    /// Defaults for the given player slot.
     pub fn for_player(player: Player) -> Self {
         Self {
             player,

--- a/sdk/bot-api/src/info.rs
+++ b/sdk/bot-api/src/info.rs
@@ -1,0 +1,43 @@
+//! Parameters for sending an Info message to the host.
+
+use pyrat::{Coordinates, Direction};
+use pyrat_wire::Player;
+
+/// Parameters for sending an Info message.
+///
+/// Use [`InfoParams::for_player`] to create with defaults, then override
+/// fields with struct update syntax:
+///
+/// ```ignore
+/// ctx.send_info(&InfoParams {
+///     depth: 5,
+///     score: Some(3.0),
+///     ..InfoParams::for_player(player)
+/// });
+/// ```
+pub struct InfoParams<'a> {
+    pub player: Player,
+    pub multipv: u16,
+    pub target: Option<Coordinates>,
+    pub depth: u16,
+    pub nodes: u32,
+    pub score: Option<f32>,
+    pub pv: &'a [Direction],
+    pub message: &'a str,
+}
+
+impl InfoParams<'_> {
+    /// Defaults for the given player slot.
+    pub fn for_player(player: Player) -> Self {
+        Self {
+            player,
+            multipv: 0,
+            target: None,
+            depth: 0,
+            nodes: 0,
+            score: None,
+            pv: &[],
+            message: "",
+        }
+    }
+}

--- a/sdk/bot-api/src/lib.rs
+++ b/sdk/bot-api/src/lib.rs
@@ -6,7 +6,9 @@
 //! mental model. No `tokio` dependency: async channel types live on the
 //! consumer side.
 
+pub mod info;
 pub mod options;
 
+pub use info::InfoParams;
 pub use options::Options;
 pub use pyrat_protocol::OwnedOptionDef;

--- a/sdk/bot-api/src/lib.rs
+++ b/sdk/bot-api/src/lib.rs
@@ -1,0 +1,12 @@
+//! Shared bot-author-facing API, used by both the networked SDK
+//! (`pyrat-sdk`) and the in-process host (`pyrat-host`).
+//!
+//! This crate holds types that both implementations must agree on so a
+//! bot author switches between networked and embedded with the same
+//! mental model. No `tokio` dependency: async channel types live on the
+//! consumer side.
+
+pub mod options;
+
+pub use options::Options;
+pub use pyrat_protocol::OwnedOptionDef;

--- a/sdk/bot-api/src/lib.rs
+++ b/sdk/bot-api/src/lib.rs
@@ -6,9 +6,11 @@
 //! mental model. No `tokio` dependency: async channel types live on the
 //! consumer side.
 
+pub mod context;
 pub mod info;
 pub mod options;
 
+pub use context::{BotContext, InfoSender, InfoSink};
 pub use info::InfoParams;
 pub use options::Options;
 pub use pyrat_protocol::OwnedOptionDef;

--- a/sdk/bot-api/src/options.rs
+++ b/sdk/bot-api/src/options.rs
@@ -1,0 +1,17 @@
+//! Options trait and option definition types.
+
+/// Trait for bot option declaration and application.
+///
+/// Bots without options: `impl Options for MyBot {}` (gets empty defaults).
+/// Bots with options: `#[derive(Options)]` on the struct.
+pub trait Options {
+    /// Declare configurable options.
+    fn option_defs(&self) -> Vec<pyrat_protocol::OwnedOptionDef> {
+        vec![]
+    }
+
+    /// Apply a named option value. Called for each `SetOption` message.
+    fn apply_option(&mut self, name: &str, _value: &str) -> Result<(), String> {
+        Err(format!("unknown option: {name}"))
+    }
+}

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
+pyrat-bot-api = { path = "../bot-api" }
 pyrat-wire = { path = "../../server/wire" }
 pyrat-protocol = { path = "../../server/protocol" }
 pyrat-engine-interface = { path = "../../interface" }

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -180,7 +180,7 @@ use pyrat_sdk::InfoParams;
 
 ctx.send_info(&InfoParams {
     depth: 5,
-    score: 3.0,
+    score: Some(3.0),
     message: "best: Right",
     ..InfoParams::for_player(state.my_player())
 });
@@ -190,10 +190,10 @@ ctx.send_info(&InfoParams {
 |---|---|---|
 | `player` | `Player` | Which player this info is about |
 | `multipv` | `u16` | Principal variation index (0 for single line) |
-| `target` | `Option<(u8, u8)>` | Cell the bot is heading toward |
+| `target` | `Option<Coordinates>` | Cell the bot is heading toward |
 | `depth` | `u16` | Search depth reached |
 | `nodes` | `u32` | Nodes evaluated |
-| `score` | `f32` | Evaluation score |
+| `score` | `Option<f32>` | Evaluation score |
 | `pv` | `&[Direction]` | Principal variation (sequence of moves) |
 | `message` | `&str` | Free-form debug text |
 

--- a/sdk/rust/src/bot.rs
+++ b/sdk/rust/src/bot.rs
@@ -5,6 +5,8 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use pyrat::Direction;
+use pyrat_bot_api::{BotContext, InfoSink};
+use pyrat_protocol::OwnedInfo;
 use pyrat_wire::{GameResult, Player};
 use tokio::sync::mpsc;
 
@@ -55,6 +57,66 @@ impl InfoSender {
 }
 
 pub use pyrat_bot_api::InfoParams;
+
+impl InfoSink for InfoSender {
+    fn send_info(&self, info: OwnedInfo) {
+        let frame = crate::wire::build_info(
+            info.player,
+            info.multipv,
+            info.target,
+            info.depth,
+            info.nodes,
+            info.score,
+            &info.pv,
+            &info.message,
+            info.turn,
+            info.state_hash,
+        );
+        self.send(&frame);
+    }
+}
+
+impl BotContext for Context {
+    fn player(&self) -> Player {
+        self.player
+    }
+
+    fn turn(&self) -> u16 {
+        self.turn
+    }
+
+    fn state_hash(&self) -> u64 {
+        self.state_hash
+    }
+
+    fn should_stop(&self) -> bool {
+        Context::should_stop(self)
+    }
+
+    fn time_remaining_ms(&self) -> u64 {
+        Context::time_remaining_ms(self)
+    }
+
+    fn think_elapsed_ms(&self) -> u32 {
+        Context::think_elapsed_ms(self)
+    }
+
+    fn send_info(&self, params: &InfoParams<'_>) {
+        Context::send_info(self, params);
+    }
+
+    fn send_provisional(&self, direction: Direction) {
+        Context::send_provisional(self, direction);
+    }
+
+    fn info_sender(&self) -> Option<pyrat_bot_api::InfoSender> {
+        self.info_sender
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|sdk_sender| pyrat_bot_api::InfoSender::new(Arc::new(sdk_sender.clone())))
+    }
+}
 
 /// Timing context passed to `think()` and `preprocess()`.
 ///

--- a/sdk/rust/src/bot.rs
+++ b/sdk/rust/src/bot.rs
@@ -6,7 +6,6 @@ use std::time::Instant;
 
 use pyrat::Direction;
 use pyrat_bot_api::{BotContext, InfoSink};
-use pyrat_protocol::OwnedInfo;
 use pyrat_wire::{GameResult, Player};
 use tokio::sync::mpsc;
 
@@ -32,7 +31,7 @@ impl InfoSender {
     }
 
     /// Send a pre-built frame through the writer channel.
-    pub fn send(&self, frame: &[u8]) {
+    pub(crate) fn send(&self, frame: &[u8]) {
         if let Err(e) = self.tx.send(frame.to_vec()) {
             eprintln!("[sdk] send() failed: channel closed ({e})");
         }
@@ -59,18 +58,18 @@ impl InfoSender {
 pub use pyrat_bot_api::InfoParams;
 
 impl InfoSink for InfoSender {
-    fn send_info(&self, info: OwnedInfo) {
+    fn send_info(&self, params: &InfoParams<'_>, turn: u16, state_hash: u64) {
         let frame = crate::wire::build_info(
-            info.player,
-            info.multipv,
-            info.target,
-            info.depth,
-            info.nodes,
-            info.score,
-            &info.pv,
-            &info.message,
-            info.turn,
-            info.state_hash,
+            params.player,
+            params.multipv,
+            params.target,
+            params.depth,
+            params.nodes,
+            params.score,
+            params.pv,
+            params.message,
+            turn,
+            state_hash,
         );
         self.send(&frame);
     }

--- a/sdk/rust/src/bot.rs
+++ b/sdk/rust/src/bot.rs
@@ -54,43 +54,7 @@ impl InfoSender {
     }
 }
 
-/// Parameters for sending an Info message to the host.
-///
-/// Use [`InfoParams::for_player`] to create with defaults, then override
-/// fields with struct update syntax:
-///
-/// ```ignore
-/// ctx.send_info(&InfoParams {
-///     depth: 5,
-///     score: 3.0,
-///     ..InfoParams::for_player(player)
-/// });
-/// ```
-pub struct InfoParams<'a> {
-    pub player: Player,
-    pub multipv: u16,
-    pub target: Option<(u8, u8)>,
-    pub depth: u16,
-    pub nodes: u32,
-    pub score: Option<f32>,
-    pub pv: &'a [Direction],
-    pub message: &'a str,
-}
-
-impl InfoParams<'_> {
-    pub fn for_player(player: Player) -> Self {
-        Self {
-            player,
-            multipv: 0,
-            target: None,
-            depth: 0,
-            nodes: 0,
-            score: None,
-            pv: &[],
-            message: "",
-        }
-    }
-}
+pub use pyrat_bot_api::InfoParams;
 
 /// Timing context passed to `think()` and `preprocess()`.
 ///

--- a/sdk/rust/src/options.rs
+++ b/sdk/rust/src/options.rs
@@ -1,20 +1,9 @@
 //! Options trait and option definition types.
+//!
+//! These types live in `pyrat-bot-api` so networked and embedded bots
+//! share one surface. Re-exported here for API continuity.
+
+pub use pyrat_bot_api::Options;
 
 /// Owned option definition sent during Identify.
 pub type SdkOptionDef = pyrat_protocol::OwnedOptionDef;
-
-/// Trait for bot option declaration and application.
-///
-/// Bots without options: `impl Options for MyBot {}` (gets empty defaults).
-/// Bots with options: `#[derive(Options)]` on the struct.
-pub trait Options {
-    /// Declare configurable options.
-    fn option_defs(&self) -> Vec<SdkOptionDef> {
-        vec![]
-    }
-
-    /// Apply a named option value. Called for each `SetOption` message.
-    fn apply_option(&mut self, name: &str, _value: &str) -> Result<(), String> {
-        Err(format!("unknown option: {name}"))
-    }
-}

--- a/sdk/rust/src/wire.rs
+++ b/sdk/rust/src/wire.rs
@@ -216,7 +216,7 @@ pub fn build_action_full(
 pub fn build_info(
     player: wire::Player,
     multipv: u16,
-    target: Option<(u8, u8)>,
+    target: Option<pyrat::Coordinates>,
     depth: u16,
     nodes: u32,
     score: Option<f32>,
@@ -240,7 +240,7 @@ pub fn build_info(
             Some(fbb.create_vector(&pv_vec))
         };
 
-        let target_v = target.map(|(x, y)| Vec2::new(x, y));
+        let target_v = target.map(|c| Vec2::new(c.x, c.y));
 
         wire::Info::create(
             fbb,
@@ -542,7 +542,7 @@ mod tests {
         let bytes = build_info(
             Player::Player2,
             3,
-            Some((10, 7)),
+            Some(Coordinates::new(10, 7)),
             5,
             42000,
             Some(2.5),

--- a/server/host/Cargo.toml
+++ b/server/host/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 fastrand = "2"
 flatbuffers = "25.2.10"
+pyrat-bot-api = { path = "../../sdk/bot-api" }
 pyrat-protocol = { path = "../protocol" }
 pyrat-rust = { path = "../../engine", default-features = false }
 pyrat-wire = { path = "../wire" }

--- a/server/host/src/lib.rs
+++ b/server/host/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod game_loop;
+pub mod player;
 pub mod session;
 pub mod stub;
 pub use pyrat_wire as wire;

--- a/server/host/src/player/embedded.rs
+++ b/server/host/src/player/embedded.rs
@@ -24,36 +24,15 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use pyrat::{Coordinates, Direction, GameBuilder, GameState, MudMap};
+use pyrat_bot_api::Options;
 use pyrat_protocol::{
-    BotMsg, HashedTurnState, HostMsg, OwnedMatchConfig, OwnedOptionDef, OwnedTurnState,
-    SearchLimits,
+    BotMsg, HashedTurnState, HostMsg, OwnedMatchConfig, OwnedTurnState, SearchLimits,
 };
 use pyrat_wire::{GameResult, Player as PlayerSlot};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
 use super::{EventSink, Player, PlayerError, PlayerIdentity};
-
-// ── Bot-author-facing surface ──────────────────────────
-
-/// Bot-declared option application.
-///
-/// Shape mirrors the SDK `pyrat_sdk::Options` trait verbatim, re-declared
-/// here to avoid a `pyrat-host → pyrat-sdk` dependency edge. If drift between
-/// the two becomes a problem, the open plan item is to extract a shared
-/// `pyrat-bot-api` crate.
-pub trait Options {
-    /// Declare configurable options.
-    fn option_defs(&self) -> Vec<OwnedOptionDef> {
-        vec![]
-    }
-
-    /// Apply a named option value. Called once per entry in
-    /// [`HostMsg::Configure`]'s `options` vector.
-    fn apply_option(&mut self, _name: &str, _value: &str) -> Result<(), String> {
-        Err("unknown option".into())
-    }
-}
 
 /// In-process bot interface.
 ///

--- a/server/host/src/player/embedded.rs
+++ b/server/host/src/player/embedded.rs
@@ -563,12 +563,17 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
                 // to interrupt. Silently ignored.
                 Ok(Event::Continue(self))
             },
-            HostMsg::FullState { .. } => Err(PlayerError::ProtocolError(
-                "FullState received while Synced — server sent without Resync".into(),
-            )),
-            HostMsg::Welcome { .. } | HostMsg::Configure { .. } => Err(PlayerError::ProtocolError(
-                format!("setup message in Playing: {msg:?}"),
-            )),
+            HostMsg::FullState { .. } => Err(PlayerError::ProtocolError(format!(
+                "FullState received while Synced, server sent without Resync \
+                 (player={:?}, turn={})",
+                self.player_slot, self.game.turn
+            ))),
+            HostMsg::Welcome { .. } | HostMsg::Configure { .. } => {
+                Err(PlayerError::ProtocolError(format!(
+                    "setup message in Playing: {msg:?} (player={:?}, turn={})",
+                    self.player_slot, self.game.turn
+                )))
+            },
             HostMsg::ProtocolError { reason } => Err(PlayerError::ProtocolError(reason)),
         }
     }
@@ -577,8 +582,8 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
     async fn handle_go_preprocess(mut self, state_hash: u64) -> Result<Event<B>, PlayerError> {
         if !matches!(self.inner, InnerState::Idle) {
             return Err(PlayerError::ProtocolError(format!(
-                "GoPreprocess in state {:?}",
-                self.inner
+                "GoPreprocess in state {:?} (player={:?}, turn={})",
+                self.inner, self.player_slot, self.game.turn
             )));
         }
         self.inner = InnerState::Preprocessing;
@@ -599,8 +604,8 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
     ) -> Result<Event<B>, PlayerError> {
         if !matches!(self.inner, InnerState::Idle | InnerState::Syncing) {
             return Err(PlayerError::ProtocolError(format!(
-                "Go in state {:?}",
-                self.inner
+                "Go in state {:?} (player={:?}, turn={})",
+                self.inner, self.player_slot, self.game.turn
             )));
         }
         self.inner = InnerState::Thinking;
@@ -625,7 +630,8 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
     }
 
     /// Handle GoState: overwrite local state with the provided turn state,
-    /// then run Go as usual.
+    /// verify the host-claimed hash against the rebuilt state, then run Go
+    /// as usual.
     async fn handle_go_state(
         mut self,
         turn_state: OwnedTurnState,
@@ -635,27 +641,41 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
         // Rebuild the engine mirror to match the injected state.
         self.game = rebuild_engine_state(&self.match_config, &turn_state)?;
         self.last_moves = (turn_state.player1_last_move, turn_state.player2_last_move);
+        let local_hash = hash_from_game(&self.game, self.last_moves.0, self.last_moves.1);
+        if local_hash != state_hash {
+            return Err(PlayerError::ProtocolError(format!(
+                "GoState hash mismatch: local={local_hash}, host={state_hash} \
+                 (player={:?}, turn={})",
+                self.player_slot, self.game.turn
+            )));
+        }
         self.handle_go(state_hash, limits).await
     }
 
-    /// Handle Advance: apply moves locally, verify hash.
+    /// Handle Advance: apply moves locally, verify turn and hash.
     fn handle_advance(
         mut self,
         p1_dir: Direction,
         p2_dir: Direction,
-        _turn: u16,
+        turn: u16,
         new_hash: u64,
     ) -> Result<Event<B>, PlayerError> {
         if !matches!(self.inner, InnerState::Idle) {
             return Err(PlayerError::ProtocolError(format!(
-                "Advance in state {:?}",
-                self.inner
+                "Advance in state {:?} (player={:?}, turn={})",
+                self.inner, self.player_slot, self.game.turn
             )));
         }
-        // Apply the two moves. The returned undo token is discarded — on
+        // Apply the two moves. The returned undo token is discarded: on
         // desync we defer to the server's FullState rather than rolling back.
         let _undo = self.game.make_move(p1_dir, p2_dir);
         self.last_moves = (p1_dir, p2_dir);
+        if turn != self.game.turn {
+            return Err(PlayerError::ProtocolError(format!(
+                "Advance turn mismatch: msg={turn}, local={} (player={:?})",
+                self.game.turn, self.player_slot
+            )));
+        }
         let local_hash = hash_from_game(&self.game, p1_dir, p2_dir);
 
         if local_hash == new_hash {
@@ -697,13 +717,21 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
     /// messages. Sideband forwarding goes through `EmbeddedCtx`.
     async fn run_preprocess(&mut self, state_hash: u64) -> Result<(), PlayerError> {
         let (hts, ctx) = self.prepare_ctx(state_hash);
+        let turn = hts.turn;
         let mut bot = self.bot.take().expect("bot present between turns");
         let mut handle = tokio::task::spawn_blocking(move || {
             bot.preprocess(&hts, &ctx);
             bot
         });
         let stopped = self.core.stopped.clone();
-        let returned_bot = watch_for_stop(&mut self.core.host_rx, &stopped, &mut handle).await?;
+        let returned_bot = watch_for_stop(
+            &mut self.core.host_rx,
+            &stopped,
+            &mut handle,
+            self.player_slot,
+            turn,
+        )
+        .await?;
         self.bot = Some(returned_bot);
         Ok(())
     }
@@ -720,8 +748,14 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
             (bot, dir)
         });
         let stopped = self.core.stopped.clone();
-        let (returned_bot, direction) =
-            watch_for_stop(&mut self.core.host_rx, &stopped, &mut handle).await?;
+        let (returned_bot, direction) = watch_for_stop(
+            &mut self.core.host_rx,
+            &stopped,
+            &mut handle,
+            self.player_slot,
+            turn,
+        )
+        .await?;
         self.bot = Some(returned_bot);
         let think_ms = start.elapsed().as_millis() as u32;
         Ok((turn, direction, think_ms))
@@ -870,13 +904,15 @@ async fn watch_for_stop<T>(
     host_rx: &mut mpsc::UnboundedReceiver<HostMsg>,
     stopped: &Arc<AtomicBool>,
     handle: &mut JoinHandle<T>,
+    player_slot: PlayerSlot,
+    turn: u16,
 ) -> Result<T, PlayerError> {
     loop {
         tokio::select! {
             biased;
             result = &mut *handle => {
                 return result.map_err(|e| PlayerError::TransportError(
-                    format!("bot task panicked: {e}"),
+                    format!("bot task panicked (player={player_slot:?}, turn={turn}): {e}"),
                 ));
             }
             msg = host_rx.recv() => {
@@ -886,13 +922,15 @@ async fn watch_for_stop<T>(
                     }
                     Some(other) => {
                         return Err(PlayerError::ProtocolError(format!(
-                            "unexpected {other:?} while bot is working"
+                            "unexpected {other:?} while bot is working \
+                             (player={player_slot:?}, turn={turn})"
                         )));
                     }
                     None => {
-                        return Err(PlayerError::TransportError(
-                            "host_rx closed while bot is working".into(),
-                        ));
+                        return Err(PlayerError::TransportError(format!(
+                            "host_rx closed while bot is working \
+                             (player={player_slot:?}, turn={turn})"
+                        )));
                     }
                 }
             }

--- a/server/host/src/player/embedded.rs
+++ b/server/host/src/player/embedded.rs
@@ -61,40 +61,17 @@ pub trait EmbeddedBot: Options + Send + 'static {
 /// - `send_provisional` forwarded to the Match's `recv()` queue as
 ///   [`BotMsg::Provisional`] (Match uses the latest as timeout fallback).
 pub struct EmbeddedCtx {
-    event_sink: EventSink,
-    bot_tx: mpsc::UnboundedSender<BotMsg>,
-    turn: u16,
-    state_hash: u64,
-    player: PlayerSlot,
-    stopped: Arc<AtomicBool>,
-    think_start: Instant,
-    deadline: Option<Instant>,
+    pub(crate) event_sink: EventSink,
+    pub(crate) bot_tx: mpsc::UnboundedSender<BotMsg>,
+    pub(crate) turn: u16,
+    pub(crate) state_hash: u64,
+    pub(crate) player: PlayerSlot,
+    pub(crate) stopped: Arc<AtomicBool>,
+    pub(crate) think_start: Instant,
+    pub(crate) deadline: Option<Instant>,
 }
 
 impl EmbeddedCtx {
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn new(
-        event_sink: EventSink,
-        bot_tx: mpsc::UnboundedSender<BotMsg>,
-        turn: u16,
-        state_hash: u64,
-        player: PlayerSlot,
-        stopped: Arc<AtomicBool>,
-        think_start: Instant,
-        deadline: Option<Instant>,
-    ) -> Self {
-        Self {
-            event_sink,
-            bot_tx,
-            turn,
-            state_hash,
-            player,
-            stopped,
-            think_start,
-            deadline,
-        }
-    }
-
     /// True when the bot should stop: host sent Stop, or the per-turn
     /// deadline passed. Cooperatively polled from the bot's think loop.
     pub fn should_stop(&self) -> bool {
@@ -126,24 +103,13 @@ impl EmbeddedCtx {
     /// Send an Info message. Routed to the attached [`EventSink`] as a
     /// `MatchEvent::BotInfo` (observer-facing, never inspected by Match).
     pub fn send_info(&self, params: &InfoParams<'_>) {
-        let info = OwnedInfo {
-            player: params.player,
-            multipv: params.multipv,
-            target: params.target,
-            depth: params.depth,
-            nodes: params.nodes,
-            score: params.score,
-            pv: params.pv.to_vec(),
-            message: params.message.to_string(),
-            turn: self.turn,
-            state_hash: self.state_hash,
-        };
-        self.event_sink.emit(crate::game_loop::MatchEvent::BotInfo {
-            sender: self.player,
-            turn: self.turn,
-            state_hash: self.state_hash,
-            info,
-        });
+        emit_bot_info(
+            &self.event_sink,
+            self.player,
+            params,
+            self.turn,
+            self.state_hash,
+        );
     }
 
     /// Send a provisional (best-so-far) direction. Emitted as
@@ -219,14 +185,36 @@ struct EmbeddedInfoSink {
 }
 
 impl InfoSink for EmbeddedInfoSink {
-    fn send_info(&self, info: OwnedInfo) {
-        self.event_sink.emit(crate::game_loop::MatchEvent::BotInfo {
-            sender: self.player,
-            turn: info.turn,
-            state_hash: info.state_hash,
-            info,
-        });
+    fn send_info(&self, params: &InfoParams<'_>, turn: u16, state_hash: u64) {
+        emit_bot_info(&self.event_sink, self.player, params, turn, state_hash);
     }
+}
+
+fn emit_bot_info(
+    event_sink: &EventSink,
+    sender: PlayerSlot,
+    params: &InfoParams<'_>,
+    turn: u16,
+    state_hash: u64,
+) {
+    let info = OwnedInfo {
+        player: params.player,
+        multipv: params.multipv,
+        target: params.target,
+        depth: params.depth,
+        nodes: params.nodes,
+        score: params.score,
+        pv: params.pv.to_vec(),
+        message: params.message.to_string(),
+        turn,
+        state_hash,
+    };
+    event_sink.emit(crate::game_loop::MatchEvent::BotInfo {
+        sender,
+        turn,
+        state_hash,
+        info,
+    });
 }
 
 // ── EmbeddedPlayer ────────────────────────────────────
@@ -410,9 +398,7 @@ impl<B: EmbeddedBot> Setup<B, Initial> {
     }
 
     /// Emit `BotMsg::Identify` from the bot's declared identity + options.
-    ///
-    /// Synchronous: `UnboundedSender::send` never awaits. Returns `Ok(None)`
-    /// if the player handle was already dropped (clean local close).
+    /// Returns `Ok(None)` if the player handle was already dropped.
     fn emit_identify(
         self,
         identity: &PlayerIdentity,
@@ -559,9 +545,23 @@ struct Playing<B, S> {
     game: GameState,
     /// Last moves applied (for `OwnedTurnState::player{1,2}_last_move`).
     last_moves: (Direction, Direction),
-    /// Sync-state-specific data. `Synced` carries `InnerState`, `Desynced`
-    /// is empty.
     state: S,
+}
+
+impl<B, S> Playing<B, S> {
+    /// Swap the sync-state marker, keeping everything else. Used for the
+    /// `Synced` <-> `Desynced` transitions at Advance-mismatch and recovery.
+    fn with_state<S2>(self, state: S2) -> Playing<B, S2> {
+        Playing {
+            bot: self.bot,
+            core: self.core,
+            player_slot: self.player_slot,
+            match_config: self.match_config,
+            game: self.game,
+            last_moves: self.last_moves,
+            state,
+        }
+    }
 }
 
 /// Return value of one iteration of `Playing<Synced>::next_event`.
@@ -756,15 +756,7 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
             {
                 return Ok(Event::CleanClose);
             }
-            Ok(Event::Desynced(Playing {
-                bot: self.bot,
-                core: self.core,
-                player_slot: self.player_slot,
-                match_config: self.match_config,
-                game: self.game,
-                last_moves: self.last_moves,
-                state: Desynced,
-            }))
+            Ok(Event::Desynced(self.with_state(Desynced)))
         }
     }
 
@@ -780,15 +772,7 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
             bot.preprocess(&hts, &ctx);
             bot
         });
-        let stopped = self.core.stopped.clone();
-        let returned_bot = watch_for_stop(
-            &mut self.core.host_rx,
-            &stopped,
-            &mut handle,
-            self.player_slot,
-            turn,
-        )
-        .await?;
+        let returned_bot = self.watch_for_stop(&mut handle, turn).await?;
         self.bot = Some(returned_bot);
         Ok(())
     }
@@ -805,18 +789,50 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
             let dir = bot.think(&hts, &ctx);
             (bot, dir)
         });
-        let stopped = self.core.stopped.clone();
-        let (returned_bot, direction) = watch_for_stop(
-            &mut self.core.host_rx,
-            &stopped,
-            &mut handle,
-            self.player_slot,
-            turn,
-        )
-        .await?;
+        let (returned_bot, direction) = self.watch_for_stop(&mut handle, turn).await?;
         self.bot = Some(returned_bot);
         let think_ms = start.elapsed().as_millis() as u32;
         Ok((turn, direction, think_ms))
+    }
+
+    /// Await a spawn_blocking bot task while draining `host_rx` for Stop or
+    /// protocol faults. If Stop arrives, flips the `stopped` flag and keeps
+    /// waiting. Any other in-flight message is a protocol error.
+    async fn watch_for_stop<T>(
+        &mut self,
+        handle: &mut JoinHandle<T>,
+        turn: u16,
+    ) -> Result<T, PlayerError> {
+        let player_slot = self.player_slot;
+        loop {
+            tokio::select! {
+                biased;
+                result = &mut *handle => {
+                    return result.map_err(|e| PlayerError::TransportError(
+                        format!("bot task panicked (player={player_slot:?}, turn={turn}): {e}"),
+                    ));
+                }
+                msg = self.core.host_rx.recv() => {
+                    match msg {
+                        Some(HostMsg::Stop) => {
+                            self.core.stopped.store(true, Ordering::Relaxed);
+                        }
+                        Some(other) => {
+                            return Err(PlayerError::ProtocolError(format!(
+                                "unexpected {other:?} while bot is working \
+                                 (player={player_slot:?}, turn={turn})"
+                            )));
+                        }
+                        None => {
+                            return Err(PlayerError::TransportError(format!(
+                                "host_rx closed while bot is working \
+                                 (player={player_slot:?}, turn={turn})"
+                            )));
+                        }
+                    }
+                }
+            }
+        }
     }
 
     fn prepare_ctx(
@@ -826,16 +842,16 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
         deadline: Option<Instant>,
     ) -> (HashedTurnState, EmbeddedCtx) {
         let hts = HashedTurnState::new(owned_turn_state_from_game(&self.game, self.last_moves));
-        let ctx = EmbeddedCtx::new(
-            self.core.event_sink.clone(),
-            self.core.bot_tx.clone(),
-            self.game.turn,
+        let ctx = EmbeddedCtx {
+            event_sink: self.core.event_sink.clone(),
+            bot_tx: self.core.bot_tx.clone(),
+            turn: self.game.turn,
             state_hash,
-            self.player_slot,
-            self.core.stopped.clone(),
+            player: self.player_slot,
+            stopped: self.core.stopped.clone(),
             think_start,
             deadline,
-        );
+        };
         (hts, ctx)
     }
 }
@@ -881,17 +897,9 @@ impl<B: EmbeddedBot> Playing<B, Desynced> {
             return Ok(None);
         }
 
-        Ok(Some(Playing {
-            bot: self.bot,
-            core: self.core,
-            player_slot: self.player_slot,
-            match_config: self.match_config,
-            game: self.game,
-            last_moves: self.last_moves,
-            state: Synced {
-                inner: InnerState::Idle,
-            },
-        }))
+        Ok(Some(self.with_state(Synced {
+            inner: InnerState::Idle,
+        })))
     }
 }
 
@@ -967,49 +975,6 @@ fn owned_turn_state_from_game(
         cheese: game.cheese_positions(),
         player1_last_move: last_moves.0,
         player2_last_move: last_moves.1,
-    }
-}
-
-/// Await a blocking bot task while watching `host_rx` for Stop messages.
-///
-/// - If the blocking task completes first, return its value.
-/// - If Stop arrives, flip `stopped` and keep waiting.
-/// - Any other message during bot execution is a protocol error.
-async fn watch_for_stop<T>(
-    host_rx: &mut mpsc::UnboundedReceiver<HostMsg>,
-    stopped: &Arc<AtomicBool>,
-    handle: &mut JoinHandle<T>,
-    player_slot: PlayerSlot,
-    turn: u16,
-) -> Result<T, PlayerError> {
-    loop {
-        tokio::select! {
-            biased;
-            result = &mut *handle => {
-                return result.map_err(|e| PlayerError::TransportError(
-                    format!("bot task panicked (player={player_slot:?}, turn={turn}): {e}"),
-                ));
-            }
-            msg = host_rx.recv() => {
-                match msg {
-                    Some(HostMsg::Stop) => {
-                        stopped.store(true, Ordering::Relaxed);
-                    }
-                    Some(other) => {
-                        return Err(PlayerError::ProtocolError(format!(
-                            "unexpected {other:?} while bot is working \
-                             (player={player_slot:?}, turn={turn})"
-                        )));
-                    }
-                    None => {
-                        return Err(PlayerError::TransportError(format!(
-                            "host_rx closed while bot is working \
-                             (player={player_slot:?}, turn={turn})"
-                        )));
-                    }
-                }
-            }
-        }
     }
 }
 

--- a/server/host/src/player/embedded.rs
+++ b/server/host/src/player/embedded.rs
@@ -35,6 +35,12 @@ use tokio::task::JoinHandle;
 
 use super::{EventSink, Player, PlayerError, PlayerIdentity};
 
+/// Maximum time `close` waits for the dispatcher to exit before aborting it.
+/// A bot that ignores `ctx.should_stop()` may still be running on a
+/// `spawn_blocking` thread when this fires; the task is detached. Honors the
+/// `Player::close` "best-effort, bounded" contract.
+const CLOSE_GRACE: Duration = Duration::from_secs(1);
+
 /// In-process bot interface.
 ///
 /// Shape mirrors the SDK `Bot` trait so a bot author switches between
@@ -228,6 +234,9 @@ pub struct EmbeddedPlayer {
     host_tx: mpsc::UnboundedSender<HostMsg>,
     bot_rx: mpsc::UnboundedReceiver<BotMsg>,
     dispatcher: Option<JoinHandle<Result<(), PlayerError>>>,
+    /// Cooperative-stop signal shared with the dispatcher and any in-flight
+    /// `EmbeddedCtx`. `close` flips this so bots polling `should_stop` exit.
+    stopped: Arc<AtomicBool>,
 }
 
 impl EmbeddedPlayer {
@@ -240,18 +249,21 @@ impl EmbeddedPlayer {
     pub fn new<B: EmbeddedBot>(bot: B, identity: PlayerIdentity, event_sink: EventSink) -> Self {
         let (host_tx, host_rx) = mpsc::unbounded_channel();
         let (bot_tx, bot_rx) = mpsc::unbounded_channel();
+        let stopped = Arc::new(AtomicBool::new(false));
         let dispatcher = tokio::spawn(dispatcher_task(
             bot,
             identity.clone(),
             event_sink,
             host_rx,
             bot_tx,
+            stopped.clone(),
         ));
         Self {
             identity,
             host_tx,
             bot_rx,
             dispatcher: Some(dispatcher),
+            stopped,
         }
     }
 
@@ -288,14 +300,49 @@ impl Player for EmbeddedPlayer {
     async fn close(self) -> Result<(), PlayerError> {
         let Self {
             host_tx,
-            mut bot_rx,
+            bot_rx,
             dispatcher,
+            stopped,
             identity: _,
         } = self;
-        // Signal the dispatcher by dropping host_tx; drain any pending BotMsgs.
+        // Signal cooperative bots first so they get the earliest possible
+        // chance to observe `should_stop()`. Order matters: another tokio
+        // worker can drive the dispatcher past the closed channel before our
+        // store completes if we drop host_tx first.
+        stopped.store(true, Ordering::Relaxed);
         drop(host_tx);
-        while bot_rx.recv().await.is_some() {}
-        reap(dispatcher).await
+        // Don't drain bot_rx: queued BotMsgs at close time are observer state
+        // nobody is consuming, and any in-flight EmbeddedCtx in spawn_blocking
+        // holds a bot_tx clone that keeps the channel open until the bot
+        // returns — that's the unbounded-wait bug we're fixing.
+        drop(bot_rx);
+
+        let Some(mut handle) = dispatcher else {
+            return Ok(());
+        };
+        // Bounded wait for the dispatcher to exit. We borrow the JoinHandle
+        // so the timeout branch can still call `abort()` on it — using
+        // `tokio::time::timeout(_, reap(dispatcher))` would consume the
+        // handle into reap and drop it on timeout, leaving nothing to abort.
+        tokio::select! {
+            result = &mut handle => match result {
+                // Swallow any dispatcher Err: close was intentional, and the
+                // contract authorizes "if the peer is already gone, swallow
+                // the error and return Ok(())". The expected error here is
+                // `TransportError("host_rx closed while bot is working")`.
+                Ok(_) => Ok(()),
+                Err(join_err) => Err(PlayerError::TransportError(format!(
+                    "dispatcher panicked: {join_err}"
+                ))),
+            },
+            () = tokio::time::sleep(CLOSE_GRACE) => {
+                // The bot ignored `should_stop`. Abort the dispatcher; the
+                // spawn_blocking task running the bot is detached, which is
+                // unavoidable since spawn_blocking tasks cannot be aborted.
+                handle.abort();
+                Ok(())
+            }
+        }
     }
 }
 
@@ -326,12 +373,13 @@ async fn dispatcher_task<B: EmbeddedBot>(
     event_sink: EventSink,
     host_rx: mpsc::UnboundedReceiver<HostMsg>,
     bot_tx: mpsc::UnboundedSender<BotMsg>,
+    stopped: Arc<AtomicBool>,
 ) -> Result<(), PlayerError> {
     let core = DispatcherCore {
         event_sink,
         host_rx,
         bot_tx,
-        stopped: Arc::new(AtomicBool::new(false)),
+        stopped,
     };
 
     let initial = Setup::<B, Initial>::new(bot, core);
@@ -791,7 +839,8 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
         });
         let (returned_bot, direction) = self.watch_for_stop(&mut handle, turn).await?;
         self.bot = Some(returned_bot);
-        let think_ms = start.elapsed().as_millis() as u32;
+        // Clamp to 1: the host rejects think_ms == 0 (indistinguishable from missing field).
+        let think_ms = (start.elapsed().as_millis() as u32).max(1);
         Ok((turn, direction, think_ms))
     }
 
@@ -824,6 +873,11 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
                             )));
                         }
                         None => {
+                            // Defense in depth: signal the bot cooperatively
+                            // so it gets a chance to exit before this
+                            // dispatcher is reaped. `close` already sets this,
+                            // but other paths that drop host_tx don't.
+                            self.core.stopped.store(true, Ordering::Relaxed);
                             return Err(PlayerError::TransportError(format!(
                                 "host_rx closed while bot is working \
                                  (player={player_slot:?}, turn={turn})"

--- a/server/host/src/player/embedded.rs
+++ b/server/host/src/player/embedded.rs
@@ -19,11 +19,15 @@
 //! with the same API surface as the SDK `Context`. Calls are routed to the
 //! [`EventSink`](super::EventSink) instead of an mpsc-backed codec.
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use pyrat::{Coordinates, Direction};
-use pyrat_protocol::{BotMsg, HashedTurnState, HostMsg, OwnedOptionDef};
+use pyrat::{Coordinates, Direction, GameBuilder, GameState, MudMap};
+use pyrat_protocol::{
+    BotMsg, HashedTurnState, HostMsg, OwnedMatchConfig, OwnedOptionDef, OwnedTurnState,
+    SearchLimits,
+};
 use pyrat_wire::{GameResult, Player as PlayerSlot};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -119,7 +123,6 @@ pub struct EmbeddedCtx {
 }
 
 impl EmbeddedCtx {
-    #[expect(dead_code, reason = "consumed by dispatcher in follow-up commit")]
     pub(crate) fn new(
         event_sink: EventSink,
         bot_tx: mpsc::UnboundedSender<BotMsg>,
@@ -275,10 +278,10 @@ async fn reap(dispatcher: Option<JoinHandle<Result<(), PlayerError>>>) -> Result
 
 /// Run one bot to completion.
 ///
-/// Lifecycle: setup typestate chain (Initial → Connected → Identified →
-/// Configured → Playing) then the playing loop. The setup chain is fully
-/// wired in this commit. Playing currently exits immediately after Ready;
-/// the turn loop lands in a follow-up.
+/// Lifecycle: setup typestate chain (Initial → Connected → Identified) then
+/// the playing loop (Playing<Synced> alternating with Playing<Desynced> on
+/// hash mismatches). Exits cleanly on [`HostMsg::GameOver`], with an error on
+/// unexpected messages or channel closure.
 async fn dispatcher_task<B: EmbeddedBot>(
     bot: B,
     identity: PlayerIdentity,
@@ -286,39 +289,34 @@ async fn dispatcher_task<B: EmbeddedBot>(
     host_rx: mpsc::UnboundedReceiver<HostMsg>,
     bot_tx: mpsc::UnboundedSender<BotMsg>,
 ) -> Result<(), PlayerError> {
-    let stopped = Arc::new(AtomicBool::new(false));
     let core = DispatcherCore {
-        bot,
         event_sink,
         host_rx,
         bot_tx,
-        stopped,
+        stopped: Arc::new(AtomicBool::new(false)),
     };
 
-    let initial = Setup::<B, Initial>::new(core);
+    let initial = Setup::<B, Initial>::new(bot, core);
     let connected = initial.emit_identify(&identity)?;
     let identified = connected.await_welcome().await?;
-    let _playing = identified.await_configure_emit_ready().await?;
-    // TODO: playing loop lands in the next commit.
-    Ok(())
+    let mut playing = identified.await_configure_emit_ready().await?;
+
+    loop {
+        match playing.next_event().await? {
+            Event::Continue(p) => playing = p,
+            Event::Desynced(d) => playing = d.recover().await?,
+            Event::GameOver => return Ok(()),
+        }
+    }
 }
 
-/// Data shared across every dispatcher state. Re-typed but not rebuilt across
-/// transitions: the bot, event sink, channels, and stop flag persist for the
-/// lifetime of the dispatcher.
-struct DispatcherCore<B> {
-    bot: B,
-    #[expect(
-        dead_code,
-        reason = "consumed by the playing loop in a follow-up commit"
-    )]
+/// Data shared across every dispatcher state: channels, event sink, stop
+/// flag. The bot lives separately on each state struct so it can move in and
+/// out of `spawn_blocking` without any `Option` / sentinel dance.
+struct DispatcherCore {
     event_sink: EventSink,
     host_rx: mpsc::UnboundedReceiver<HostMsg>,
     bot_tx: mpsc::UnboundedSender<BotMsg>,
-    #[expect(
-        dead_code,
-        reason = "consumed by the playing loop in a follow-up commit"
-    )]
     stopped: Arc<AtomicBool>,
 }
 
@@ -330,7 +328,8 @@ struct DispatcherCore<B> {
 // lives on the marker struct.
 
 struct Setup<B, S> {
-    core: DispatcherCore<B>,
+    bot: B,
+    core: DispatcherCore,
     state: S,
 }
 
@@ -341,8 +340,9 @@ struct Identified {
 }
 
 impl<B: EmbeddedBot> Setup<B, Initial> {
-    fn new(core: DispatcherCore<B>) -> Self {
+    fn new(bot: B, core: DispatcherCore) -> Self {
         Self {
+            bot,
             core,
             state: Initial,
         }
@@ -352,7 +352,7 @@ impl<B: EmbeddedBot> Setup<B, Initial> {
     ///
     /// Synchronous: `UnboundedSender::send` never awaits.
     fn emit_identify(self, identity: &PlayerIdentity) -> Result<Setup<B, Connected>, PlayerError> {
-        let options = self.core.bot.option_defs();
+        let options = self.bot.option_defs();
         self.core
             .bot_tx
             .send(BotMsg::Identify {
@@ -363,6 +363,7 @@ impl<B: EmbeddedBot> Setup<B, Initial> {
             })
             .map_err(|_| PlayerError::TransportError("bot_tx closed".into()))?;
         Ok(Setup {
+            bot: self.bot,
             core: self.core,
             state: Connected,
         })
@@ -374,6 +375,7 @@ impl<B: EmbeddedBot> Setup<B, Connected> {
     async fn await_welcome(mut self) -> Result<Setup<B, Identified>, PlayerError> {
         match self.core.host_rx.recv().await {
             Some(HostMsg::Welcome { player_slot }) => Ok(Setup {
+                bot: self.bot,
                 core: self.core,
                 state: Identified { player_slot },
             }),
@@ -387,12 +389,12 @@ impl<B: EmbeddedBot> Setup<B, Connected> {
 }
 
 impl<B: EmbeddedBot> Setup<B, Identified> {
-    /// Await `HostMsg::Configure`, apply options, compute the initial state
-    /// hash, emit `BotMsg::Ready`. Returns a `Playing<Synced>`.
+    /// Await `HostMsg::Configure`, apply options, build the local engine
+    /// state mirror, compute the initial hash, emit `BotMsg::Ready`.
+    /// Returns a `Playing<Synced>`.
     ///
-    /// Options whose `apply_option` returns `Err` are reported through the
-    /// event sink but do not abort setup (the fault policy for bad option
-    /// values is "warn and use default", matching the SDK).
+    /// Options whose `apply_option` returns `Err` are logged but do not abort
+    /// setup (fault policy: "warn and use default", matching the SDK).
     async fn await_configure_emit_ready(mut self) -> Result<Playing<B, Synced>, PlayerError> {
         let (options, match_config) = match self.core.host_rx.recv().await {
             Some(HostMsg::Configure {
@@ -411,13 +413,13 @@ impl<B: EmbeddedBot> Setup<B, Identified> {
         };
 
         for (name, value) in &options {
-            if let Err(err) = self.core.bot.apply_option(name, value) {
+            if let Err(err) = self.bot.apply_option(name, value) {
                 tracing::warn!(option = %name, error = %err, "bot rejected option");
             }
         }
 
-        let initial_state = initial_turn_state(&match_config);
-        let hash = initial_state.state_hash();
+        let game = build_engine_state(&match_config)?;
+        let hash = hash_from_game(&game, Direction::Stay, Direction::Stay);
 
         self.core
             .bot_tx
@@ -425,52 +427,434 @@ impl<B: EmbeddedBot> Setup<B, Identified> {
             .map_err(|_| PlayerError::TransportError("bot_tx closed".into()))?;
 
         Ok(Playing {
+            bot: Some(self.bot),
             core: self.core,
             player_slot: self.state.player_slot,
             match_config,
-            state: initial_state,
+            game,
+            last_moves: (Direction::Stay, Direction::Stay),
+            inner: InnerState::Idle,
             _sync: std::marker::PhantomData,
         })
     }
 }
 
-// ── Playing<Sync> (placeholder — dispatcher loop in follow-up) ────────
+// ── Playing<Sync> typestate ───────────────────────────
 
-/// Sync marker: the local state mirror agrees with the server's.
+/// Sync status markers. `Playing<Synced>` exposes the turn-handling methods;
+/// `Playing<Desynced>` exposes only `recover`.
 struct Synced;
+struct Desynced;
 
-/// Playing state with sync-status marker. Methods and the inner runtime-enum
-/// step loop (Idle / Syncing / Thinking / Preprocessing) land in the next
-/// commit; the struct exists here so setup has a concrete return type.
-#[allow(
-    dead_code,
-    reason = "fields consumed by the playing loop in a follow-up commit"
-)]
+/// Inner state machine inside `Playing<Synced>`. Tracked as a runtime enum —
+/// typestate in a message-driven loop collapses back to this shape anyway.
+#[derive(Debug, Clone, Copy)]
+enum InnerState {
+    /// Between turns, awaiting Advance / GoState / GameOver.
+    Idle,
+    /// Preprocessing phase: awaiting Stop (optional) while the bot runs
+    /// `preprocess`.
+    Preprocessing,
+    /// Post-Advance: SyncOk emitted, awaiting Go or FullState.
+    Syncing,
+    /// Thinking phase: bot is running `think`, awaiting Stop (optional).
+    Thinking,
+}
+
 struct Playing<B, Sync> {
-    core: DispatcherCore<B>,
+    /// The bot. `Option` so we can temporarily move it into a
+    /// `spawn_blocking` closure during think/preprocess; always `Some` at
+    /// every `.await` point in `next_event`. Unwrap sites document the
+    /// invariant.
+    bot: Option<B>,
+    core: DispatcherCore,
     player_slot: PlayerSlot,
-    match_config: Box<pyrat_protocol::OwnedMatchConfig>,
-    state: HashedTurnState,
+    match_config: Box<OwnedMatchConfig>,
+    /// Local engine state mirror. Authoritative for the client's view.
+    game: GameState,
+    /// Last moves applied (for `OwnedTurnState::player{1,2}_last_move`).
+    last_moves: (Direction, Direction),
+    inner: InnerState,
     _sync: std::marker::PhantomData<Sync>,
 }
 
-/// Build the initial `HashedTurnState` a client would compute at Ready time.
+/// Return value of one iteration of `Playing<Synced>::next_event`.
+enum Event<B> {
+    /// Still Synced; loop continues.
+    Continue(Playing<B, Synced>),
+    /// Hash mismatch observed; await FullState before doing anything else.
+    Desynced(Playing<B, Desynced>),
+    /// `HostMsg::GameOver` received and processed; dispatcher exits.
+    GameOver,
+}
+
+impl<B: EmbeddedBot> Playing<B, Synced> {
+    /// Advance the dispatcher by one host message.
+    ///
+    /// Takes `self` and returns one of:
+    /// - `Event::Continue` — still Synced, loop with the returned value.
+    /// - `Event::Desynced` — hash mismatch detected, Resync emitted.
+    /// - `Event::GameOver` — GameOver processed, dispatcher exits.
+    async fn next_event(mut self) -> Result<Event<B>, PlayerError> {
+        let msg = self
+            .core
+            .host_rx
+            .recv()
+            .await
+            .ok_or_else(|| PlayerError::TransportError("host_rx closed".into()))?;
+
+        match msg {
+            HostMsg::GoPreprocess { state_hash } => self.handle_go_preprocess(state_hash).await,
+            HostMsg::Go { state_hash, limits } => self.handle_go(state_hash, limits).await,
+            HostMsg::GoState {
+                turn_state,
+                state_hash,
+                limits,
+            } => self.handle_go_state(*turn_state, state_hash, limits).await,
+            HostMsg::Advance {
+                p1_dir,
+                p2_dir,
+                turn,
+                new_hash,
+            } => self.handle_advance(p1_dir, p2_dir, turn, new_hash),
+            HostMsg::GameOver {
+                result,
+                player1_score,
+                player2_score,
+            } => {
+                self.bot
+                    .as_mut()
+                    .expect("bot present between turns")
+                    .on_game_over(result, (player1_score, player2_score));
+                Ok(Event::GameOver)
+            },
+            HostMsg::Stop => {
+                // Stop outside of thinking/preprocessing is a no-op: nothing
+                // to interrupt. Silently ignored.
+                Ok(Event::Continue(self))
+            },
+            HostMsg::FullState { .. } => Err(PlayerError::ProtocolError(
+                "FullState received while Synced — server sent without Resync".into(),
+            )),
+            HostMsg::Welcome { .. } | HostMsg::Configure { .. } => Err(PlayerError::ProtocolError(
+                format!("setup message in Playing: {msg:?}"),
+            )),
+            HostMsg::ProtocolError { reason } => Err(PlayerError::ProtocolError(reason)),
+        }
+    }
+
+    /// Handle GoPreprocess: run bot.preprocess, emit PreprocessingDone.
+    async fn handle_go_preprocess(mut self, state_hash: u64) -> Result<Event<B>, PlayerError> {
+        if !matches!(self.inner, InnerState::Idle) {
+            return Err(PlayerError::ProtocolError(format!(
+                "GoPreprocess in state {:?}",
+                self.inner
+            )));
+        }
+        self.inner = InnerState::Preprocessing;
+        self.core.stopped.store(false, Ordering::Relaxed);
+        self.run_preprocess(state_hash).await?;
+        self.core
+            .bot_tx
+            .send(BotMsg::PreprocessingDone)
+            .map_err(|_| PlayerError::TransportError("bot_tx closed".into()))?;
+        self.inner = InnerState::Idle;
+        Ok(Event::Continue(self))
+    }
+
+    /// Handle Go: run bot.think, emit Action.
+    async fn handle_go(
+        mut self,
+        state_hash: u64,
+        _limits: SearchLimits,
+    ) -> Result<Event<B>, PlayerError> {
+        if !matches!(self.inner, InnerState::Idle | InnerState::Syncing) {
+            return Err(PlayerError::ProtocolError(format!(
+                "Go in state {:?}",
+                self.inner
+            )));
+        }
+        self.inner = InnerState::Thinking;
+        self.core.stopped.store(false, Ordering::Relaxed);
+        let (turn, direction, think_ms) = self.run_think(state_hash).await?;
+        self.core
+            .bot_tx
+            .send(BotMsg::Action {
+                direction,
+                player: self.player_slot,
+                turn,
+                state_hash,
+                think_ms,
+            })
+            .map_err(|_| PlayerError::TransportError("bot_tx closed".into()))?;
+        self.inner = InnerState::Idle;
+        Ok(Event::Continue(self))
+    }
+
+    /// Handle GoState: overwrite local state with the provided turn state,
+    /// then run Go as usual.
+    async fn handle_go_state(
+        mut self,
+        turn_state: OwnedTurnState,
+        state_hash: u64,
+        limits: SearchLimits,
+    ) -> Result<Event<B>, PlayerError> {
+        // Rebuild the engine mirror to match the injected state.
+        self.game = rebuild_engine_state(&self.match_config, &turn_state)?;
+        self.last_moves = (turn_state.player1_last_move, turn_state.player2_last_move);
+        self.handle_go(state_hash, limits).await
+    }
+
+    /// Handle Advance: apply moves locally, verify hash.
+    fn handle_advance(
+        mut self,
+        p1_dir: Direction,
+        p2_dir: Direction,
+        _turn: u16,
+        new_hash: u64,
+    ) -> Result<Event<B>, PlayerError> {
+        if !matches!(self.inner, InnerState::Idle) {
+            return Err(PlayerError::ProtocolError(format!(
+                "Advance in state {:?}",
+                self.inner
+            )));
+        }
+        // Apply the two moves. The returned undo token is discarded — on
+        // desync we defer to the server's FullState rather than rolling back.
+        let _undo = self.game.make_move(p1_dir, p2_dir);
+        self.last_moves = (p1_dir, p2_dir);
+        let local_hash = hash_from_game(&self.game, p1_dir, p2_dir);
+
+        if local_hash == new_hash {
+            self.core
+                .bot_tx
+                .send(BotMsg::SyncOk { hash: local_hash })
+                .map_err(|_| PlayerError::TransportError("bot_tx closed".into()))?;
+            self.inner = InnerState::Syncing;
+            Ok(Event::Continue(self))
+        } else {
+            self.core
+                .bot_tx
+                .send(BotMsg::Resync {
+                    my_hash: local_hash,
+                })
+                .map_err(|_| PlayerError::TransportError("bot_tx closed".into()))?;
+            Ok(Event::Desynced(Playing {
+                bot: self.bot,
+                core: self.core,
+                player_slot: self.player_slot,
+                match_config: self.match_config,
+                game: self.game,
+                last_moves: self.last_moves,
+                inner: InnerState::Idle, // not meaningful while desynced
+                _sync: std::marker::PhantomData,
+            }))
+        }
+    }
+
+    /// Run `bot.preprocess` while selecting on `host_rx` for concurrent Stop
+    /// messages. Sideband forwarding goes through `EmbeddedCtx`.
+    async fn run_preprocess(&mut self, state_hash: u64) -> Result<(), PlayerError> {
+        let (hts, ctx) = self.prepare_ctx(state_hash);
+        let mut bot = self.bot.take().expect("bot present between turns");
+        let mut handle = tokio::task::spawn_blocking(move || {
+            bot.preprocess(&hts, &ctx);
+            bot
+        });
+        let stopped = self.core.stopped.clone();
+        let returned_bot = watch_for_stop(&mut self.core.host_rx, &stopped, &mut handle).await?;
+        self.bot = Some(returned_bot);
+        Ok(())
+    }
+
+    /// Run `bot.think` while selecting on `host_rx` for concurrent Stop.
+    /// Returns the turn number, chosen direction, and recorded think time.
+    async fn run_think(&mut self, state_hash: u64) -> Result<(u16, Direction, u32), PlayerError> {
+        let (hts, ctx) = self.prepare_ctx(state_hash);
+        let turn = hts.turn;
+        let start = std::time::Instant::now();
+        let mut bot = self.bot.take().expect("bot present between turns");
+        let mut handle = tokio::task::spawn_blocking(move || {
+            let dir = bot.think(&hts, &ctx);
+            (bot, dir)
+        });
+        let stopped = self.core.stopped.clone();
+        let (returned_bot, direction) =
+            watch_for_stop(&mut self.core.host_rx, &stopped, &mut handle).await?;
+        self.bot = Some(returned_bot);
+        let think_ms = start.elapsed().as_millis() as u32;
+        Ok((turn, direction, think_ms))
+    }
+
+    fn prepare_ctx(&self, state_hash: u64) -> (HashedTurnState, EmbeddedCtx) {
+        let hts = HashedTurnState::new(owned_turn_state_from_game(&self.game, self.last_moves));
+        let ctx = EmbeddedCtx::new(
+            self.core.event_sink.clone(),
+            self.core.bot_tx.clone(),
+            self.game.turn,
+            state_hash,
+            self.player_slot,
+            self.core.stopped.clone(),
+        );
+        (hts, ctx)
+    }
+}
+
+impl<B: EmbeddedBot> Playing<B, Desynced> {
+    /// Await `HostMsg::FullState`, rebuild the local mirror, emit `SyncOk`,
+    /// return to `Playing<Synced>`.
+    async fn recover(mut self) -> Result<Playing<B, Synced>, PlayerError> {
+        let (match_config, turn_state) = match self.core.host_rx.recv().await {
+            Some(HostMsg::FullState {
+                match_config,
+                turn_state,
+            }) => (match_config, *turn_state),
+            Some(HostMsg::ProtocolError { reason }) => {
+                return Err(PlayerError::ProtocolError(reason));
+            },
+            Some(other) => {
+                return Err(PlayerError::ProtocolError(format!(
+                    "expected FullState while Desynced, got {other:?}"
+                )));
+            },
+            None => return Err(PlayerError::TransportError("host_rx closed".into())),
+        };
+
+        self.match_config = match_config;
+        self.game = rebuild_engine_state(&self.match_config, &turn_state)?;
+        self.last_moves = (turn_state.player1_last_move, turn_state.player2_last_move);
+        let hash = hash_from_game(&self.game, self.last_moves.0, self.last_moves.1);
+        self.core
+            .bot_tx
+            .send(BotMsg::SyncOk { hash })
+            .map_err(|_| PlayerError::TransportError("bot_tx closed".into()))?;
+
+        Ok(Playing {
+            bot: self.bot,
+            core: self.core,
+            player_slot: self.player_slot,
+            match_config: self.match_config,
+            game: self.game,
+            last_moves: self.last_moves,
+            inner: InnerState::Idle,
+            _sync: std::marker::PhantomData,
+        })
+    }
+}
+
+// ── State mirror helpers ──────────────────────────────
+
+/// Construct an engine `GameState` from an `OwnedMatchConfig`.
+fn build_engine_state(cfg: &OwnedMatchConfig) -> Result<GameState, PlayerError> {
+    let mut walls: HashMap<Coordinates, Vec<Coordinates>> = HashMap::new();
+    for (a, b) in &cfg.walls {
+        walls.entry(*a).or_default().push(*b);
+        walls.entry(*b).or_default().push(*a);
+    }
+    let mut mud = MudMap::new();
+    for entry in &cfg.mud {
+        mud.insert(entry.pos1, entry.pos2, entry.turns);
+    }
+
+    GameBuilder::new(cfg.width, cfg.height)
+        .with_max_turns(cfg.max_turns)
+        .with_custom_maze(walls, mud)
+        .with_custom_positions(cfg.player1_start, cfg.player2_start)
+        .with_custom_cheese(cfg.cheese.clone())
+        .build()
+        .create(None)
+        .map_err(|e| PlayerError::ProtocolError(format!("invalid match config: {e}")))
+}
+
+/// Rebuild the engine state to match an injected turn state (GoState or
+/// FullState recovery).
+fn rebuild_engine_state(
+    cfg: &OwnedMatchConfig,
+    ts: &OwnedTurnState,
+) -> Result<GameState, PlayerError> {
+    let mut game = build_engine_state(cfg)?;
+    game.turn = ts.turn;
+    game.player1.current_pos = ts.player1_position;
+    game.player2.current_pos = ts.player2_position;
+    game.player1.score = ts.player1_score;
+    game.player2.score = ts.player2_score;
+    game.player1.mud_timer = ts.player1_mud_turns;
+    game.player2.mud_timer = ts.player2_mud_turns;
+    // Cheese: replace whatever the builder placed with the set in `ts`.
+    // Simplest path: clear and re-place. `CheeseBoard::place_cheese` is
+    // idempotent; `clear` / per-cell remove is not exposed, so rebuild.
+    for pos in cfg.cheese.iter() {
+        if !ts.cheese.contains(pos) {
+            game.cheese.take_cheese(*pos);
+        }
+    }
+    Ok(game)
+}
+
+/// Hash a `GameState` via the protocol-canonical path: derive
+/// `OwnedTurnState`, wrap in `HashedTurnState::new()` (DefaultHasher). This
+/// is the same hashing used for Ready; `Advance` must produce a compatible
+/// hash for desync detection to work.
+fn hash_from_game(game: &GameState, last_p1: Direction, last_p2: Direction) -> u64 {
+    HashedTurnState::new(owned_turn_state_from_game(game, (last_p1, last_p2))).state_hash()
+}
+
+/// Extract an `OwnedTurnState` from an engine `GameState`.
+fn owned_turn_state_from_game(
+    game: &GameState,
+    last_moves: (Direction, Direction),
+) -> OwnedTurnState {
+    OwnedTurnState {
+        turn: game.turn,
+        player1_position: game.player1.current_pos,
+        player2_position: game.player2.current_pos,
+        player1_score: game.player1.score,
+        player2_score: game.player2.score,
+        player1_mud_turns: game.player1.mud_timer,
+        player2_mud_turns: game.player2.mud_timer,
+        cheese: game.cheese_positions(),
+        player1_last_move: last_moves.0,
+        player2_last_move: last_moves.1,
+    }
+}
+
+/// Await a blocking bot task while watching `host_rx` for Stop messages.
 ///
-/// Positions from the config, scores zero, no mud, no last move, all cheese
-/// still on the board. Does not require the engine.
-fn initial_turn_state(cfg: &pyrat_protocol::OwnedMatchConfig) -> HashedTurnState {
-    HashedTurnState::new(pyrat_protocol::OwnedTurnState {
-        turn: 0,
-        player1_position: cfg.player1_start,
-        player2_position: cfg.player2_start,
-        player1_score: 0.0,
-        player2_score: 0.0,
-        player1_mud_turns: 0,
-        player2_mud_turns: 0,
-        cheese: cfg.cheese.clone(),
-        player1_last_move: Direction::Stay,
-        player2_last_move: Direction::Stay,
-    })
+/// - If the blocking task completes first, return its value.
+/// - If Stop arrives, flip `stopped` and keep waiting.
+/// - Any other message during bot execution is a protocol error.
+async fn watch_for_stop<T>(
+    host_rx: &mut mpsc::UnboundedReceiver<HostMsg>,
+    stopped: &Arc<AtomicBool>,
+    handle: &mut JoinHandle<T>,
+) -> Result<T, PlayerError> {
+    loop {
+        tokio::select! {
+            biased;
+            result = &mut *handle => {
+                return result.map_err(|e| PlayerError::TransportError(
+                    format!("bot task panicked: {e}"),
+                ));
+            }
+            msg = host_rx.recv() => {
+                match msg {
+                    Some(HostMsg::Stop) => {
+                        stopped.store(true, Ordering::Relaxed);
+                    }
+                    Some(other) => {
+                        return Err(PlayerError::ProtocolError(format!(
+                            "unexpected {other:?} while bot is working"
+                        )));
+                    }
+                    None => {
+                        return Err(PlayerError::TransportError(
+                            "host_rx closed while bot is working".into(),
+                        ));
+                    }
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -538,7 +922,11 @@ mod tests {
 
         // Configure triggers the Ready emission with a hash over initial state.
         let match_config = sample_match_config();
-        let expected_hash = initial_turn_state(&match_config).state_hash();
+        let expected_hash = hash_from_game(
+            &build_engine_state(&match_config).unwrap(),
+            Direction::Stay,
+            Direction::Stay,
+        );
         player
             .send(HostMsg::Configure {
                 options: vec![],
@@ -552,11 +940,12 @@ mod tests {
             other => panic!("expected Ready, got {other:?}"),
         }
 
-        // Setup complete. The current (partial) dispatcher exits immediately
-        // after Ready; close the player and confirm clean exit.
-        // recv() should surface Ok(None) once the dispatcher drops bot_tx.
-        assert!(matches!(player.recv().await, Ok(None)));
-        player.close().await.unwrap();
+        // Setup is done; dispatcher is now in Playing<Synced>, awaiting a
+        // host message. Close the player; dispatcher sees host_tx drop and
+        // exits with a TransportError ("host_rx closed"). That's the
+        // expected clean-close semantics for a synced player with no pending
+        // GameOver.
+        drop(player);
     }
 
     #[tokio::test]

--- a/server/host/src/player/embedded.rs
+++ b/server/host/src/player/embedded.rs
@@ -974,4 +974,85 @@ mod tests {
         let err = player.recv().await.unwrap_err();
         assert!(matches!(err, PlayerError::ProtocolError(_)), "{err:?}");
     }
+
+    /// Verifies the Advance + SyncOk happy path. Lives here (not in the
+    /// integration tests) because computing the expected post-move hash
+    /// needs the crate-private `build_engine_state` / `hash_from_game`
+    /// helpers; exposing them publicly would leak implementation details.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn advance_with_correct_hash_emits_syncok() {
+        let identity = PlayerIdentity {
+            name: "Dummy".into(),
+            author: "test".into(),
+            agent_id: "pyrat/dummy".into(),
+        };
+        let mut player = EmbeddedPlayer::new(DummyBot, identity, EventSink::noop());
+
+        // Setup.
+        let _ = player.recv().await.unwrap().unwrap(); // Identify
+        player
+            .send(HostMsg::Welcome {
+                player_slot: PlayerSlot::Player1,
+            })
+            .await
+            .unwrap();
+        let match_config = sample_match_config();
+        player
+            .send(HostMsg::Configure {
+                options: vec![],
+                match_config: match_config.clone(),
+            })
+            .await
+            .unwrap();
+        let hash0 = match player.recv().await.unwrap().unwrap() {
+            BotMsg::Ready { state_hash } => state_hash,
+            _ => panic!("expected Ready"),
+        };
+
+        // First turn: Go (from Configured/Idle) → Action. Bot plays Stay.
+        player
+            .send(HostMsg::Go {
+                state_hash: hash0,
+                limits: SearchLimits::default(),
+            })
+            .await
+            .unwrap();
+        match player.recv().await.unwrap().unwrap() {
+            BotMsg::Action { .. } => {},
+            other => panic!("expected Action, got {other:?}"),
+        }
+
+        // Compute the hash the dispatcher would arrive at after applying
+        // (Stay, Stay) to the initial state — same helpers the dispatcher
+        // uses internally.
+        let mut game = build_engine_state(&match_config).unwrap();
+        let _ = game.make_move(Direction::Stay, Direction::Stay);
+        let hash_after = hash_from_game(&game, Direction::Stay, Direction::Stay);
+
+        player
+            .send(HostMsg::Advance {
+                p1_dir: Direction::Stay,
+                p2_dir: Direction::Stay,
+                turn: 1,
+                new_hash: hash_after,
+            })
+            .await
+            .unwrap();
+
+        match player.recv().await.unwrap().unwrap() {
+            BotMsg::SyncOk { hash } => assert_eq!(hash, hash_after),
+            other => panic!("expected SyncOk, got {other:?}"),
+        }
+
+        // Clean shutdown.
+        player
+            .send(HostMsg::GameOver {
+                result: GameResult::Draw,
+                player1_score: 0.0,
+                player2_score: 0.0,
+            })
+            .await
+            .unwrap();
+        let _ = player.close().await;
+    }
 }

--- a/server/host/src/player/embedded.rs
+++ b/server/host/src/player/embedded.rs
@@ -463,21 +463,26 @@ impl<B: EmbeddedBot> Setup<B, Identified> {
             match_config,
             game,
             last_moves: (Direction::Stay, Direction::Stay),
-            inner: InnerState::Idle,
-            _sync: std::marker::PhantomData,
+            state: Synced {
+                inner: InnerState::Idle,
+            },
         }))
     }
 }
 
-// ── Playing<Sync> typestate ───────────────────────────
+// ── Playing<S> typestate ──────────────────────────────
 
-/// Sync status markers. `Playing<Synced>` exposes the turn-handling methods;
-/// `Playing<Desynced>` exposes only `recover`.
-struct Synced;
+/// Sync status markers. `Playing<Synced>` exposes the turn-handling methods
+/// and carries the runtime `InnerState`; `Playing<Desynced>` exposes only
+/// `recover` and carries no inner state.
+struct Synced {
+    inner: InnerState,
+}
 struct Desynced;
 
-/// Inner state machine inside `Playing<Synced>`. Tracked as a runtime enum —
-/// typestate in a message-driven loop collapses back to this shape anyway.
+/// Inner state machine inside `Playing<Synced>`. Tracked as a runtime enum
+/// because typestate in a message-driven loop collapses back to this shape
+/// anyway.
 #[derive(Debug, Clone, Copy)]
 enum InnerState {
     /// Between turns, awaiting Advance / GoState / GameOver.
@@ -491,7 +496,7 @@ enum InnerState {
     Thinking,
 }
 
-struct Playing<B, Sync> {
+struct Playing<B, S> {
     /// The bot. `Option` so we can temporarily move it into a
     /// `spawn_blocking` closure during think/preprocess; always `Some` at
     /// every `.await` point in `next_event`. Unwrap sites document the
@@ -504,8 +509,9 @@ struct Playing<B, Sync> {
     game: GameState,
     /// Last moves applied (for `OwnedTurnState::player{1,2}_last_move`).
     last_moves: (Direction, Direction),
-    inner: InnerState,
-    _sync: std::marker::PhantomData<Sync>,
+    /// Sync-state-specific data. `Synced` carries `InnerState`, `Desynced`
+    /// is empty.
+    state: S,
 }
 
 /// Return value of one iteration of `Playing<Synced>::next_event`.
@@ -580,19 +586,19 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
 
     /// Handle GoPreprocess: run bot.preprocess, emit PreprocessingDone.
     async fn handle_go_preprocess(mut self, state_hash: u64) -> Result<Event<B>, PlayerError> {
-        if !matches!(self.inner, InnerState::Idle) {
+        if !matches!(self.state.inner, InnerState::Idle) {
             return Err(PlayerError::ProtocolError(format!(
                 "GoPreprocess in state {:?} (player={:?}, turn={})",
-                self.inner, self.player_slot, self.game.turn
+                self.state.inner, self.player_slot, self.game.turn
             )));
         }
-        self.inner = InnerState::Preprocessing;
+        self.state.inner = InnerState::Preprocessing;
         self.core.stopped.store(false, Ordering::Relaxed);
         self.run_preprocess(state_hash).await?;
         if self.core.bot_tx.send(BotMsg::PreprocessingDone).is_err() {
             return Ok(Event::CleanClose);
         }
-        self.inner = InnerState::Idle;
+        self.state.inner = InnerState::Idle;
         Ok(Event::Continue(self))
     }
 
@@ -602,13 +608,13 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
         state_hash: u64,
         _limits: SearchLimits,
     ) -> Result<Event<B>, PlayerError> {
-        if !matches!(self.inner, InnerState::Idle | InnerState::Syncing) {
+        if !matches!(self.state.inner, InnerState::Idle | InnerState::Syncing) {
             return Err(PlayerError::ProtocolError(format!(
                 "Go in state {:?} (player={:?}, turn={})",
-                self.inner, self.player_slot, self.game.turn
+                self.state.inner, self.player_slot, self.game.turn
             )));
         }
-        self.inner = InnerState::Thinking;
+        self.state.inner = InnerState::Thinking;
         self.core.stopped.store(false, Ordering::Relaxed);
         let (turn, direction, think_ms) = self.run_think(state_hash).await?;
         if self
@@ -625,7 +631,7 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
         {
             return Ok(Event::CleanClose);
         }
-        self.inner = InnerState::Idle;
+        self.state.inner = InnerState::Idle;
         Ok(Event::Continue(self))
     }
 
@@ -660,10 +666,10 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
         turn: u16,
         new_hash: u64,
     ) -> Result<Event<B>, PlayerError> {
-        if !matches!(self.inner, InnerState::Idle) {
+        if !matches!(self.state.inner, InnerState::Idle) {
             return Err(PlayerError::ProtocolError(format!(
                 "Advance in state {:?} (player={:?}, turn={})",
-                self.inner, self.player_slot, self.game.turn
+                self.state.inner, self.player_slot, self.game.turn
             )));
         }
         // Apply the two moves. The returned undo token is discarded: on
@@ -687,7 +693,7 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
             {
                 return Ok(Event::CleanClose);
             }
-            self.inner = InnerState::Syncing;
+            self.state.inner = InnerState::Syncing;
             Ok(Event::Continue(self))
         } else {
             if self
@@ -707,8 +713,7 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
                 match_config: self.match_config,
                 game: self.game,
                 last_moves: self.last_moves,
-                inner: InnerState::Idle, // not meaningful while desynced
-                _sync: std::marker::PhantomData,
+                state: Desynced,
             }))
         }
     }
@@ -813,8 +818,9 @@ impl<B: EmbeddedBot> Playing<B, Desynced> {
             match_config: self.match_config,
             game: self.game,
             last_moves: self.last_moves,
-            inner: InnerState::Idle,
-            _sync: std::marker::PhantomData,
+            state: Synced {
+                inner: InnerState::Idle,
+            },
         }))
     }
 }

--- a/server/host/src/player/embedded.rs
+++ b/server/host/src/player/embedded.rs
@@ -1,7 +1,7 @@
 //! In-process [`Player`](super::Player) implementation.
 //!
 //! `EmbeddedPlayer` runs a bot in the same process as the Match. No TCP, no
-//! FlatBuffers, no subprocess — a dispatcher task translates [`HostMsg`] into
+//! FlatBuffers, no subprocess. A dispatcher task translates [`HostMsg`] into
 //! method calls on an [`EmbeddedBot`] and wraps the results in [`BotMsg`].
 //!
 //! ## Who writes what
@@ -245,6 +245,10 @@ pub struct EmbeddedPlayer {
 impl EmbeddedPlayer {
     /// Construct an EmbeddedPlayer wrapping `bot`. Spawns a dispatcher task
     /// on the current tokio runtime.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called outside a tokio runtime (via `tokio::spawn`).
     pub fn new<B: EmbeddedBot>(bot: B, identity: PlayerIdentity, event_sink: EventSink) -> Self {
         let (host_tx, host_rx) = mpsc::unbounded_channel();
         let (bot_tx, bot_rx) = mpsc::unbounded_channel();
@@ -577,9 +581,9 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
     /// Advance the dispatcher by one host message.
     ///
     /// Takes `self` and returns one of:
-    /// - `Event::Continue` — still Synced, loop with the returned value.
-    /// - `Event::Desynced` — hash mismatch detected, Resync emitted.
-    /// - `Event::GameOver` — GameOver processed, dispatcher exits.
+    /// - `Event::Continue`: still Synced, loop with the returned value.
+    /// - `Event::Desynced`: hash mismatch detected, Resync emitted.
+    /// - `Event::GameOver`: GameOver processed, dispatcher exits.
     async fn next_event(mut self) -> Result<Event<B>, PlayerError> {
         let Some(msg) = self.core.host_rx.recv().await else {
             return Ok(Event::CleanClose);
@@ -948,7 +952,6 @@ fn hash_from_game(game: &GameState, last_p1: Direction, last_p2: Direction) -> u
     HashedTurnState::new(owned_turn_state_from_game(game, (last_p1, last_p2))).state_hash()
 }
 
-/// Extract an `OwnedTurnState` from an engine `GameState`.
 fn owned_turn_state_from_game(
     game: &GameState,
     last_moves: (Direction, Direction),
@@ -1179,7 +1182,7 @@ mod tests {
         }
 
         // Compute the hash the dispatcher would arrive at after applying
-        // (Stay, Stay) to the initial state — same helpers the dispatcher
+        // (Stay, Stay) to the initial state, using the same helpers the dispatcher
         // uses internally.
         let mut game = build_engine_state(&match_config).unwrap();
         let _ = game.make_move(Direction::Stay, Direction::Stay);

--- a/server/host/src/player/embedded.rs
+++ b/server/host/src/player/embedded.rs
@@ -1123,7 +1123,12 @@ mod tests {
         // recv() drains bot_tx (empty) then reaps the dispatcher and surfaces
         // its error verbatim.
         let err = player.recv().await.unwrap_err();
-        assert!(matches!(err, PlayerError::ProtocolError(_)), "{err:?}");
+        match err {
+            PlayerError::ProtocolError(msg) => {
+                assert!(msg.contains("expected Welcome"), "msg={msg}");
+            },
+            other => panic!("expected ProtocolError, got {other:?}"),
+        }
     }
 
     /// Verifies the Advance + SyncOk happy path. Lives here (not in the

--- a/server/host/src/player/embedded.rs
+++ b/server/host/src/player/embedded.rs
@@ -22,11 +22,12 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use pyrat::{Coordinates, Direction, GameBuilder, GameState, MudMap};
-use pyrat_bot_api::{InfoParams, Options};
+use pyrat_bot_api::{BotContext, InfoParams, InfoSink, Options};
 use pyrat_protocol::{
-    BotMsg, HashedTurnState, HostMsg, OwnedMatchConfig, OwnedTurnState, SearchLimits,
+    BotMsg, HashedTurnState, HostMsg, OwnedInfo, OwnedMatchConfig, OwnedTurnState, SearchLimits,
 };
 use pyrat_wire::{GameResult, Player as PlayerSlot};
 use tokio::sync::mpsc;
@@ -53,13 +54,12 @@ pub trait EmbeddedBot: Options + Send + 'static {
 /// Per-turn context passed to [`EmbeddedBot::think`] and
 /// [`EmbeddedBot::preprocess`].
 ///
-/// Shape mirrors the SDK `Context` API surface. `should_stop` reads an atomic
-/// that the dispatcher flips on [`HostMsg::Stop`]. Sideband routing:
-/// - `send_info` → observer-facing, forwarded to [`EventSink`] as
-///   `MatchEvent::BotInfo`.
-/// - `send_provisional` → game-driving, forwarded to the Match's `recv()`
-///   queue as [`BotMsg::Provisional`] (Match uses the latest as timeout
-///   fallback).
+/// Shape mirrors the SDK `Context` API surface. `should_stop` reads both an
+/// atomic the dispatcher flips on [`HostMsg::Stop`] and an optional per-turn
+/// deadline derived from the match config. Sideband routing:
+/// - `send_info` forwarded to [`EventSink`] as `MatchEvent::BotInfo`.
+/// - `send_provisional` forwarded to the Match's `recv()` queue as
+///   [`BotMsg::Provisional`] (Match uses the latest as timeout fallback).
 pub struct EmbeddedCtx {
     event_sink: EventSink,
     bot_tx: mpsc::UnboundedSender<BotMsg>,
@@ -67,9 +67,12 @@ pub struct EmbeddedCtx {
     state_hash: u64,
     player: PlayerSlot,
     stopped: Arc<AtomicBool>,
+    think_start: Instant,
+    deadline: Option<Instant>,
 }
 
 impl EmbeddedCtx {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         event_sink: EventSink,
         bot_tx: mpsc::UnboundedSender<BotMsg>,
@@ -77,6 +80,8 @@ impl EmbeddedCtx {
         state_hash: u64,
         player: PlayerSlot,
         stopped: Arc<AtomicBool>,
+        think_start: Instant,
+        deadline: Option<Instant>,
     ) -> Self {
         Self {
             event_sink,
@@ -85,19 +90,43 @@ impl EmbeddedCtx {
             state_hash,
             player,
             stopped,
+            think_start,
+            deadline,
         }
     }
 
-    /// True if the host has signalled Stop. Cooperatively polled from the
-    /// bot's think loop.
+    /// True when the bot should stop: host sent Stop, or the per-turn
+    /// deadline passed. Cooperatively polled from the bot's think loop.
     pub fn should_stop(&self) -> bool {
-        self.stopped.load(Ordering::Relaxed)
+        if self.stopped.load(Ordering::Relaxed) {
+            return true;
+        }
+        self.deadline.is_some_and(|d| Instant::now() >= d)
+    }
+
+    /// Milliseconds remaining before the deadline. Returns 0 if the bot has
+    /// been told to stop; `u64::MAX` if no deadline was configured.
+    pub fn time_remaining_ms(&self) -> u64 {
+        if self.stopped.load(Ordering::Relaxed) {
+            return 0;
+        }
+        let Some(deadline) = self.deadline else {
+            return u64::MAX;
+        };
+        deadline
+            .checked_duration_since(Instant::now())
+            .map_or(0, |d| d.as_millis() as u64)
+    }
+
+    /// Milliseconds elapsed since think started.
+    pub fn think_elapsed_ms(&self) -> u32 {
+        self.think_start.elapsed().as_millis() as u32
     }
 
     /// Send an Info message. Routed to the attached [`EventSink`] as a
     /// `MatchEvent::BotInfo` (observer-facing, never inspected by Match).
     pub fn send_info(&self, params: &InfoParams<'_>) {
-        let info = pyrat_protocol::OwnedInfo {
+        let info = OwnedInfo {
             player: params.player,
             multipv: params.multipv,
             target: params.target,
@@ -121,11 +150,81 @@ impl EmbeddedCtx {
     /// [`BotMsg::Provisional`] on the game-driving channel: Match holds the
     /// latest as its timeout fallback.
     pub fn send_provisional(&self, direction: Direction) {
-        let _ = self.bot_tx.send(BotMsg::Provisional {
-            direction,
+        if self
+            .bot_tx
+            .send(BotMsg::Provisional {
+                direction,
+                player: self.player,
+                turn: self.turn,
+                state_hash: self.state_hash,
+            })
+            .is_err()
+        {
+            tracing::debug!(
+                player = ?self.player,
+                turn = self.turn,
+                "provisional dropped: bot_tx closed"
+            );
+        }
+    }
+}
+
+impl BotContext for EmbeddedCtx {
+    fn player(&self) -> PlayerSlot {
+        self.player
+    }
+
+    fn turn(&self) -> u16 {
+        self.turn
+    }
+
+    fn state_hash(&self) -> u64 {
+        self.state_hash
+    }
+
+    fn should_stop(&self) -> bool {
+        EmbeddedCtx::should_stop(self)
+    }
+
+    fn time_remaining_ms(&self) -> u64 {
+        EmbeddedCtx::time_remaining_ms(self)
+    }
+
+    fn think_elapsed_ms(&self) -> u32 {
+        EmbeddedCtx::think_elapsed_ms(self)
+    }
+
+    fn send_info(&self, params: &InfoParams<'_>) {
+        EmbeddedCtx::send_info(self, params);
+    }
+
+    fn send_provisional(&self, direction: Direction) {
+        EmbeddedCtx::send_provisional(self, direction);
+    }
+
+    fn info_sender(&self) -> Option<pyrat_bot_api::InfoSender> {
+        let sink: Arc<dyn InfoSink> = Arc::new(EmbeddedInfoSink {
+            event_sink: self.event_sink.clone(),
             player: self.player,
-            turn: self.turn,
-            state_hash: self.state_hash,
+        });
+        Some(pyrat_bot_api::InfoSender::new(sink))
+    }
+}
+
+/// Adapter so `InfoSender` handles from worker threads reach the Match's
+/// event sink as `MatchEvent::BotInfo`.
+struct EmbeddedInfoSink {
+    event_sink: EventSink,
+    player: PlayerSlot,
+}
+
+impl InfoSink for EmbeddedInfoSink {
+    fn send_info(&self, info: OwnedInfo) {
+        self.event_sink.emit(crate::game_loop::MatchEvent::BotInfo {
+            sender: self.player,
+            turn: info.turn,
+            state_hash: info.state_hash,
+            info,
         });
     }
 }
@@ -668,7 +767,9 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
     /// Run `bot.preprocess` while selecting on `host_rx` for concurrent Stop
     /// messages. Sideband forwarding goes through `EmbeddedCtx`.
     async fn run_preprocess(&mut self, state_hash: u64) -> Result<(), PlayerError> {
-        let (hts, ctx) = self.prepare_ctx(state_hash);
+        let start = Instant::now();
+        let deadline = deadline_from_ms(start, self.match_config.preprocessing_timeout_ms);
+        let (hts, ctx) = self.prepare_ctx(state_hash, start, deadline);
         let turn = hts.turn;
         let mut bot = self.bot.take().expect("bot present between turns");
         let mut handle = tokio::task::spawn_blocking(move || {
@@ -691,9 +792,10 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
     /// Run `bot.think` while selecting on `host_rx` for concurrent Stop.
     /// Returns the turn number, chosen direction, and recorded think time.
     async fn run_think(&mut self, state_hash: u64) -> Result<(u16, Direction, u32), PlayerError> {
-        let (hts, ctx) = self.prepare_ctx(state_hash);
+        let start = Instant::now();
+        let deadline = deadline_from_ms(start, self.match_config.move_timeout_ms);
+        let (hts, ctx) = self.prepare_ctx(state_hash, start, deadline);
         let turn = hts.turn;
-        let start = std::time::Instant::now();
         let mut bot = self.bot.take().expect("bot present between turns");
         let mut handle = tokio::task::spawn_blocking(move || {
             let dir = bot.think(&hts, &ctx);
@@ -713,7 +815,12 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
         Ok((turn, direction, think_ms))
     }
 
-    fn prepare_ctx(&self, state_hash: u64) -> (HashedTurnState, EmbeddedCtx) {
+    fn prepare_ctx(
+        &self,
+        state_hash: u64,
+        think_start: Instant,
+        deadline: Option<Instant>,
+    ) -> (HashedTurnState, EmbeddedCtx) {
         let hts = HashedTurnState::new(owned_turn_state_from_game(&self.game, self.last_moves));
         let ctx = EmbeddedCtx::new(
             self.core.event_sink.clone(),
@@ -722,8 +829,20 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
             state_hash,
             self.player_slot,
             self.core.stopped.clone(),
+            think_start,
+            deadline,
         );
         (hts, ctx)
+    }
+}
+
+/// Derive a deadline instant from a `_timeout_ms` field. A zero timeout
+/// means "no wall-clock deadline"; bots cooperate on `HostMsg::Stop` only.
+fn deadline_from_ms(start: Instant, timeout_ms: u32) -> Option<Instant> {
+    if timeout_ms == 0 {
+        None
+    } else {
+        Some(start + Duration::from_millis(u64::from(timeout_ms)))
     }
 }
 

--- a/server/host/src/player/embedded.rs
+++ b/server/host/src/player/embedded.rs
@@ -297,15 +297,26 @@ async fn dispatcher_task<B: EmbeddedBot>(
     };
 
     let initial = Setup::<B, Initial>::new(bot, core);
-    let connected = initial.emit_identify(&identity)?;
-    let identified = connected.await_welcome().await?;
-    let mut playing = identified.await_configure_emit_ready().await?;
+    let Some(connected) = initial.emit_identify(&identity)? else {
+        return Ok(());
+    };
+    let Some(identified) = connected.await_welcome().await? else {
+        return Ok(());
+    };
+    let Some(mut playing) = identified.await_configure_emit_ready().await? else {
+        return Ok(());
+    };
 
     loop {
         match playing.next_event().await? {
             Event::Continue(p) => playing = p,
-            Event::Desynced(d) => playing = d.recover().await?,
-            Event::GameOver => return Ok(()),
+            Event::Desynced(d) => {
+                let Some(p) = d.recover().await? else {
+                    return Ok(());
+                };
+                playing = p;
+            },
+            Event::GameOver | Event::CleanClose => return Ok(()),
         }
     }
 }
@@ -350,10 +361,15 @@ impl<B: EmbeddedBot> Setup<B, Initial> {
 
     /// Emit `BotMsg::Identify` from the bot's declared identity + options.
     ///
-    /// Synchronous: `UnboundedSender::send` never awaits.
-    fn emit_identify(self, identity: &PlayerIdentity) -> Result<Setup<B, Connected>, PlayerError> {
+    /// Synchronous: `UnboundedSender::send` never awaits. Returns `Ok(None)`
+    /// if the player handle was already dropped (clean local close).
+    fn emit_identify(
+        self,
+        identity: &PlayerIdentity,
+    ) -> Result<Option<Setup<B, Connected>>, PlayerError> {
         let options = self.bot.option_defs();
-        self.core
+        if self
+            .core
             .bot_tx
             .send(BotMsg::Identify {
                 name: identity.name.clone(),
@@ -361,29 +377,35 @@ impl<B: EmbeddedBot> Setup<B, Initial> {
                 agent_id: identity.agent_id.clone(),
                 options,
             })
-            .map_err(|_| PlayerError::TransportError("bot_tx closed".into()))?;
-        Ok(Setup {
+            .is_err()
+        {
+            return Ok(None);
+        }
+        Ok(Some(Setup {
             bot: self.bot,
             core: self.core,
             state: Connected,
-        })
+        }))
     }
 }
 
 impl<B: EmbeddedBot> Setup<B, Connected> {
     /// Await `HostMsg::Welcome`, store the assigned player slot.
-    async fn await_welcome(mut self) -> Result<Setup<B, Identified>, PlayerError> {
+    ///
+    /// Returns `Ok(None)` if the player handle was dropped before Welcome
+    /// arrived (clean local close).
+    async fn await_welcome(mut self) -> Result<Option<Setup<B, Identified>>, PlayerError> {
         match self.core.host_rx.recv().await {
-            Some(HostMsg::Welcome { player_slot }) => Ok(Setup {
+            Some(HostMsg::Welcome { player_slot }) => Ok(Some(Setup {
                 bot: self.bot,
                 core: self.core,
                 state: Identified { player_slot },
-            }),
+            })),
             Some(HostMsg::ProtocolError { reason }) => Err(PlayerError::ProtocolError(reason)),
             Some(other) => Err(PlayerError::ProtocolError(format!(
                 "expected Welcome, got {other:?}"
             ))),
-            None => Err(PlayerError::TransportError("host_rx closed".into())),
+            None => Ok(None),
         }
     }
 }
@@ -395,7 +417,11 @@ impl<B: EmbeddedBot> Setup<B, Identified> {
     ///
     /// Options whose `apply_option` returns `Err` are logged but do not abort
     /// setup (fault policy: "warn and use default", matching the SDK).
-    async fn await_configure_emit_ready(mut self) -> Result<Playing<B, Synced>, PlayerError> {
+    /// Returns `Ok(None)` if the player handle was dropped before Configure
+    /// arrived or before Ready could be emitted (clean local close).
+    async fn await_configure_emit_ready(
+        mut self,
+    ) -> Result<Option<Playing<B, Synced>>, PlayerError> {
         let (options, match_config) = match self.core.host_rx.recv().await {
             Some(HostMsg::Configure {
                 options,
@@ -409,7 +435,7 @@ impl<B: EmbeddedBot> Setup<B, Identified> {
                     "expected Configure, got {other:?}"
                 )));
             },
-            None => return Err(PlayerError::TransportError("host_rx closed".into())),
+            None => return Ok(None),
         };
 
         for (name, value) in &options {
@@ -421,12 +447,16 @@ impl<B: EmbeddedBot> Setup<B, Identified> {
         let game = build_engine_state(&match_config)?;
         let hash = hash_from_game(&game, Direction::Stay, Direction::Stay);
 
-        self.core
+        if self
+            .core
             .bot_tx
             .send(BotMsg::Ready { state_hash: hash })
-            .map_err(|_| PlayerError::TransportError("bot_tx closed".into()))?;
+            .is_err()
+        {
+            return Ok(None);
+        }
 
-        Ok(Playing {
+        Ok(Some(Playing {
             bot: Some(self.bot),
             core: self.core,
             player_slot: self.state.player_slot,
@@ -435,7 +465,7 @@ impl<B: EmbeddedBot> Setup<B, Identified> {
             last_moves: (Direction::Stay, Direction::Stay),
             inner: InnerState::Idle,
             _sync: std::marker::PhantomData,
-        })
+        }))
     }
 }
 
@@ -486,6 +516,9 @@ enum Event<B> {
     Desynced(Playing<B, Desynced>),
     /// `HostMsg::GameOver` received and processed; dispatcher exits.
     GameOver,
+    /// Player handle dropped (host_rx closed or bot_tx send failed).
+    /// Dispatcher exits cleanly with `Ok(())`.
+    CleanClose,
 }
 
 impl<B: EmbeddedBot> Playing<B, Synced> {
@@ -496,12 +529,9 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
     /// - `Event::Desynced` — hash mismatch detected, Resync emitted.
     /// - `Event::GameOver` — GameOver processed, dispatcher exits.
     async fn next_event(mut self) -> Result<Event<B>, PlayerError> {
-        let msg = self
-            .core
-            .host_rx
-            .recv()
-            .await
-            .ok_or_else(|| PlayerError::TransportError("host_rx closed".into()))?;
+        let Some(msg) = self.core.host_rx.recv().await else {
+            return Ok(Event::CleanClose);
+        };
 
         match msg {
             HostMsg::GoPreprocess { state_hash } => self.handle_go_preprocess(state_hash).await,
@@ -554,10 +584,9 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
         self.inner = InnerState::Preprocessing;
         self.core.stopped.store(false, Ordering::Relaxed);
         self.run_preprocess(state_hash).await?;
-        self.core
-            .bot_tx
-            .send(BotMsg::PreprocessingDone)
-            .map_err(|_| PlayerError::TransportError("bot_tx closed".into()))?;
+        if self.core.bot_tx.send(BotMsg::PreprocessingDone).is_err() {
+            return Ok(Event::CleanClose);
+        }
         self.inner = InnerState::Idle;
         Ok(Event::Continue(self))
     }
@@ -577,7 +606,8 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
         self.inner = InnerState::Thinking;
         self.core.stopped.store(false, Ordering::Relaxed);
         let (turn, direction, think_ms) = self.run_think(state_hash).await?;
-        self.core
+        if self
+            .core
             .bot_tx
             .send(BotMsg::Action {
                 direction,
@@ -586,7 +616,10 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
                 state_hash,
                 think_ms,
             })
-            .map_err(|_| PlayerError::TransportError("bot_tx closed".into()))?;
+            .is_err()
+        {
+            return Ok(Event::CleanClose);
+        }
         self.inner = InnerState::Idle;
         Ok(Event::Continue(self))
     }
@@ -626,19 +659,27 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
         let local_hash = hash_from_game(&self.game, p1_dir, p2_dir);
 
         if local_hash == new_hash {
-            self.core
+            if self
+                .core
                 .bot_tx
                 .send(BotMsg::SyncOk { hash: local_hash })
-                .map_err(|_| PlayerError::TransportError("bot_tx closed".into()))?;
+                .is_err()
+            {
+                return Ok(Event::CleanClose);
+            }
             self.inner = InnerState::Syncing;
             Ok(Event::Continue(self))
         } else {
-            self.core
+            if self
+                .core
                 .bot_tx
                 .send(BotMsg::Resync {
                     my_hash: local_hash,
                 })
-                .map_err(|_| PlayerError::TransportError("bot_tx closed".into()))?;
+                .is_err()
+            {
+                return Ok(Event::CleanClose);
+            }
             Ok(Event::Desynced(Playing {
                 bot: self.bot,
                 core: self.core,
@@ -703,7 +744,10 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
 impl<B: EmbeddedBot> Playing<B, Desynced> {
     /// Await `HostMsg::FullState`, rebuild the local mirror, emit `SyncOk`,
     /// return to `Playing<Synced>`.
-    async fn recover(mut self) -> Result<Playing<B, Synced>, PlayerError> {
+    ///
+    /// Returns `Ok(None)` if the player handle was dropped before recovery
+    /// completed (clean local close).
+    async fn recover(mut self) -> Result<Option<Playing<B, Synced>>, PlayerError> {
         let (match_config, turn_state) = match self.core.host_rx.recv().await {
             Some(HostMsg::FullState {
                 match_config,
@@ -717,19 +761,18 @@ impl<B: EmbeddedBot> Playing<B, Desynced> {
                     "expected FullState while Desynced, got {other:?}"
                 )));
             },
-            None => return Err(PlayerError::TransportError("host_rx closed".into())),
+            None => return Ok(None),
         };
 
         self.match_config = match_config;
         self.game = rebuild_engine_state(&self.match_config, &turn_state)?;
         self.last_moves = (turn_state.player1_last_move, turn_state.player2_last_move);
         let hash = hash_from_game(&self.game, self.last_moves.0, self.last_moves.1);
-        self.core
-            .bot_tx
-            .send(BotMsg::SyncOk { hash })
-            .map_err(|_| PlayerError::TransportError("bot_tx closed".into()))?;
+        if self.core.bot_tx.send(BotMsg::SyncOk { hash }).is_err() {
+            return Ok(None);
+        }
 
-        Ok(Playing {
+        Ok(Some(Playing {
             bot: self.bot,
             core: self.core,
             player_slot: self.player_slot,
@@ -738,7 +781,7 @@ impl<B: EmbeddedBot> Playing<B, Desynced> {
             last_moves: self.last_moves,
             inner: InnerState::Idle,
             _sync: std::marker::PhantomData,
-        })
+        }))
     }
 }
 
@@ -941,10 +984,8 @@ mod tests {
         }
 
         // Setup is done; dispatcher is now in Playing<Synced>, awaiting a
-        // host message. Close the player; dispatcher sees host_tx drop and
-        // exits with a TransportError ("host_rx closed"). That's the
-        // expected clean-close semantics for a synced player with no pending
-        // GameOver.
+        // host message. Dropping the player closes host_tx; the dispatcher
+        // sees recv() yield None from Idle and exits cleanly.
         drop(player);
     }
 

--- a/server/host/src/player/embedded.rs
+++ b/server/host/src/player/embedded.rs
@@ -199,7 +199,13 @@ impl EmbeddedPlayer {
     pub fn new<B: EmbeddedBot>(bot: B, identity: PlayerIdentity, event_sink: EventSink) -> Self {
         let (host_tx, host_rx) = mpsc::unbounded_channel();
         let (bot_tx, bot_rx) = mpsc::unbounded_channel();
-        let dispatcher = tokio::spawn(dispatcher_task(bot, event_sink, host_rx, bot_tx));
+        let dispatcher = tokio::spawn(dispatcher_task(
+            bot,
+            identity.clone(),
+            event_sink,
+            host_rx,
+            bot_tx,
+        ));
         Self {
             identity,
             host_tx,
@@ -265,20 +271,318 @@ async fn reap(dispatcher: Option<JoinHandle<Result<(), PlayerError>>>) -> Result
     }
 }
 
-// ── Dispatcher (scaffold) ─────────────────────────────
+// ── Dispatcher ────────────────────────────────────────
 
-/// Run one bot to completion, translating between the pipe and bot methods.
+/// Run one bot to completion.
 ///
-/// **Status: scaffold.** This initial commit wires the channels and ensures
-/// the type surface compiles. The actual state machine (setup typestate,
-/// `Playing<Sync>`, inner step loop) lands in follow-up commits.
+/// Lifecycle: setup typestate chain (Initial → Connected → Identified →
+/// Configured → Playing) then the playing loop. The setup chain is fully
+/// wired in this commit. Playing currently exits immediately after Ready;
+/// the turn loop lands in a follow-up.
 async fn dispatcher_task<B: EmbeddedBot>(
-    _bot: B,
-    _event_sink: EventSink,
-    mut host_rx: mpsc::UnboundedReceiver<HostMsg>,
-    _bot_tx: mpsc::UnboundedSender<BotMsg>,
+    bot: B,
+    identity: PlayerIdentity,
+    event_sink: EventSink,
+    host_rx: mpsc::UnboundedReceiver<HostMsg>,
+    bot_tx: mpsc::UnboundedSender<BotMsg>,
 ) -> Result<(), PlayerError> {
-    // Drain host_rx until the sender is dropped. No BotMsgs are produced.
-    while host_rx.recv().await.is_some() {}
+    let stopped = Arc::new(AtomicBool::new(false));
+    let core = DispatcherCore {
+        bot,
+        event_sink,
+        host_rx,
+        bot_tx,
+        stopped,
+    };
+
+    let initial = Setup::<B, Initial>::new(core);
+    let connected = initial.emit_identify(&identity)?;
+    let identified = connected.await_welcome().await?;
+    let _playing = identified.await_configure_emit_ready().await?;
+    // TODO: playing loop lands in the next commit.
     Ok(())
+}
+
+/// Data shared across every dispatcher state. Re-typed but not rebuilt across
+/// transitions: the bot, event sink, channels, and stop flag persist for the
+/// lifetime of the dispatcher.
+struct DispatcherCore<B> {
+    bot: B,
+    #[expect(
+        dead_code,
+        reason = "consumed by the playing loop in a follow-up commit"
+    )]
+    event_sink: EventSink,
+    host_rx: mpsc::UnboundedReceiver<HostMsg>,
+    bot_tx: mpsc::UnboundedSender<BotMsg>,
+    #[expect(
+        dead_code,
+        reason = "consumed by the playing loop in a follow-up commit"
+    )]
+    stopped: Arc<AtomicBool>,
+}
+
+// ── Setup typestate ───────────────────────────────────
+//
+// Each state is a marker type. `Setup<B, S>` threads them through transitions
+// that consume `self` and return the next state, so skipping or reordering a
+// step is a compile error. State-specific data (`player_slot` after Welcome)
+// lives on the marker struct.
+
+struct Setup<B, S> {
+    core: DispatcherCore<B>,
+    state: S,
+}
+
+struct Initial;
+struct Connected;
+struct Identified {
+    player_slot: PlayerSlot,
+}
+
+impl<B: EmbeddedBot> Setup<B, Initial> {
+    fn new(core: DispatcherCore<B>) -> Self {
+        Self {
+            core,
+            state: Initial,
+        }
+    }
+
+    /// Emit `BotMsg::Identify` from the bot's declared identity + options.
+    ///
+    /// Synchronous: `UnboundedSender::send` never awaits.
+    fn emit_identify(self, identity: &PlayerIdentity) -> Result<Setup<B, Connected>, PlayerError> {
+        let options = self.core.bot.option_defs();
+        self.core
+            .bot_tx
+            .send(BotMsg::Identify {
+                name: identity.name.clone(),
+                author: identity.author.clone(),
+                agent_id: identity.agent_id.clone(),
+                options,
+            })
+            .map_err(|_| PlayerError::TransportError("bot_tx closed".into()))?;
+        Ok(Setup {
+            core: self.core,
+            state: Connected,
+        })
+    }
+}
+
+impl<B: EmbeddedBot> Setup<B, Connected> {
+    /// Await `HostMsg::Welcome`, store the assigned player slot.
+    async fn await_welcome(mut self) -> Result<Setup<B, Identified>, PlayerError> {
+        match self.core.host_rx.recv().await {
+            Some(HostMsg::Welcome { player_slot }) => Ok(Setup {
+                core: self.core,
+                state: Identified { player_slot },
+            }),
+            Some(HostMsg::ProtocolError { reason }) => Err(PlayerError::ProtocolError(reason)),
+            Some(other) => Err(PlayerError::ProtocolError(format!(
+                "expected Welcome, got {other:?}"
+            ))),
+            None => Err(PlayerError::TransportError("host_rx closed".into())),
+        }
+    }
+}
+
+impl<B: EmbeddedBot> Setup<B, Identified> {
+    /// Await `HostMsg::Configure`, apply options, compute the initial state
+    /// hash, emit `BotMsg::Ready`. Returns a `Playing<Synced>`.
+    ///
+    /// Options whose `apply_option` returns `Err` are reported through the
+    /// event sink but do not abort setup (the fault policy for bad option
+    /// values is "warn and use default", matching the SDK).
+    async fn await_configure_emit_ready(mut self) -> Result<Playing<B, Synced>, PlayerError> {
+        let (options, match_config) = match self.core.host_rx.recv().await {
+            Some(HostMsg::Configure {
+                options,
+                match_config,
+            }) => (options, match_config),
+            Some(HostMsg::ProtocolError { reason }) => {
+                return Err(PlayerError::ProtocolError(reason));
+            },
+            Some(other) => {
+                return Err(PlayerError::ProtocolError(format!(
+                    "expected Configure, got {other:?}"
+                )));
+            },
+            None => return Err(PlayerError::TransportError("host_rx closed".into())),
+        };
+
+        for (name, value) in &options {
+            if let Err(err) = self.core.bot.apply_option(name, value) {
+                tracing::warn!(option = %name, error = %err, "bot rejected option");
+            }
+        }
+
+        let initial_state = initial_turn_state(&match_config);
+        let hash = initial_state.state_hash();
+
+        self.core
+            .bot_tx
+            .send(BotMsg::Ready { state_hash: hash })
+            .map_err(|_| PlayerError::TransportError("bot_tx closed".into()))?;
+
+        Ok(Playing {
+            core: self.core,
+            player_slot: self.state.player_slot,
+            match_config,
+            state: initial_state,
+            _sync: std::marker::PhantomData,
+        })
+    }
+}
+
+// ── Playing<Sync> (placeholder — dispatcher loop in follow-up) ────────
+
+/// Sync marker: the local state mirror agrees with the server's.
+struct Synced;
+
+/// Playing state with sync-status marker. Methods and the inner runtime-enum
+/// step loop (Idle / Syncing / Thinking / Preprocessing) land in the next
+/// commit; the struct exists here so setup has a concrete return type.
+#[allow(
+    dead_code,
+    reason = "fields consumed by the playing loop in a follow-up commit"
+)]
+struct Playing<B, Sync> {
+    core: DispatcherCore<B>,
+    player_slot: PlayerSlot,
+    match_config: Box<pyrat_protocol::OwnedMatchConfig>,
+    state: HashedTurnState,
+    _sync: std::marker::PhantomData<Sync>,
+}
+
+/// Build the initial `HashedTurnState` a client would compute at Ready time.
+///
+/// Positions from the config, scores zero, no mud, no last move, all cheese
+/// still on the board. Does not require the engine.
+fn initial_turn_state(cfg: &pyrat_protocol::OwnedMatchConfig) -> HashedTurnState {
+    HashedTurnState::new(pyrat_protocol::OwnedTurnState {
+        turn: 0,
+        player1_position: cfg.player1_start,
+        player2_position: cfg.player2_start,
+        player1_score: 0.0,
+        player2_score: 0.0,
+        player1_mud_turns: 0,
+        player2_mud_turns: 0,
+        cheese: cfg.cheese.clone(),
+        player1_last_move: Direction::Stay,
+        player2_last_move: Direction::Stay,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyrat_wire::TimingMode;
+
+    struct DummyBot;
+    impl Options for DummyBot {}
+    impl EmbeddedBot for DummyBot {
+        fn think(&mut self, _: &HashedTurnState, _: &EmbeddedCtx) -> Direction {
+            Direction::Stay
+        }
+    }
+
+    fn sample_match_config() -> Box<pyrat_protocol::OwnedMatchConfig> {
+        Box::new(pyrat_protocol::OwnedMatchConfig {
+            width: 5,
+            height: 5,
+            max_turns: 100,
+            walls: vec![],
+            mud: vec![],
+            cheese: vec![Coordinates::new(2, 2)],
+            player1_start: Coordinates::new(0, 0),
+            player2_start: Coordinates::new(4, 4),
+            controlled_players: vec![PlayerSlot::Player1],
+            timing: TimingMode::Wait,
+            move_timeout_ms: 100,
+            preprocessing_timeout_ms: 1000,
+        })
+    }
+
+    #[tokio::test]
+    async fn setup_flow_emits_identify_then_ready() {
+        let identity = PlayerIdentity {
+            name: "Dummy".into(),
+            author: "test".into(),
+            agent_id: "pyrat/dummy".into(),
+        };
+        let mut player = EmbeddedPlayer::new(DummyBot, identity, EventSink::noop());
+
+        // Dispatcher's first emission is Identify, without any host input.
+        let identify = player.recv().await.unwrap().unwrap();
+        match identify {
+            BotMsg::Identify {
+                name,
+                author,
+                agent_id,
+                ..
+            } => {
+                assert_eq!(name, "Dummy");
+                assert_eq!(author, "test");
+                assert_eq!(agent_id, "pyrat/dummy");
+            },
+            other => panic!("expected Identify, got {other:?}"),
+        }
+
+        // Welcome assigns a slot (dispatcher stores it silently).
+        player
+            .send(HostMsg::Welcome {
+                player_slot: PlayerSlot::Player1,
+            })
+            .await
+            .unwrap();
+
+        // Configure triggers the Ready emission with a hash over initial state.
+        let match_config = sample_match_config();
+        let expected_hash = initial_turn_state(&match_config).state_hash();
+        player
+            .send(HostMsg::Configure {
+                options: vec![],
+                match_config,
+            })
+            .await
+            .unwrap();
+
+        match player.recv().await.unwrap().unwrap() {
+            BotMsg::Ready { state_hash } => assert_eq!(state_hash, expected_hash),
+            other => panic!("expected Ready, got {other:?}"),
+        }
+
+        // Setup complete. The current (partial) dispatcher exits immediately
+        // after Ready; close the player and confirm clean exit.
+        // recv() should surface Ok(None) once the dispatcher drops bot_tx.
+        assert!(matches!(player.recv().await, Ok(None)));
+        player.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn unexpected_message_during_setup_is_a_protocol_error() {
+        let identity = PlayerIdentity {
+            name: "Dummy".into(),
+            author: "test".into(),
+            agent_id: "pyrat/dummy".into(),
+        };
+        let mut player = EmbeddedPlayer::new(DummyBot, identity, EventSink::noop());
+
+        // Drain the bot's Identify.
+        let _ = player.recv().await.unwrap().unwrap();
+
+        // Send a Go instead of Welcome: protocol violation.
+        player
+            .send(HostMsg::Go {
+                state_hash: 0,
+                limits: pyrat_protocol::SearchLimits::default(),
+            })
+            .await
+            .unwrap();
+
+        // recv() drains bot_tx (empty) then reaps the dispatcher and surfaces
+        // its error verbatim.
+        let err = player.recv().await.unwrap_err();
+        assert!(matches!(err, PlayerError::ProtocolError(_)), "{err:?}");
+    }
 }

--- a/server/host/src/player/embedded.rs
+++ b/server/host/src/player/embedded.rs
@@ -24,7 +24,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use pyrat::{Coordinates, Direction, GameBuilder, GameState, MudMap};
-use pyrat_bot_api::Options;
+use pyrat_bot_api::{InfoParams, Options};
 use pyrat_protocol::{
     BotMsg, HashedTurnState, HostMsg, OwnedMatchConfig, OwnedTurnState, SearchLimits,
 };
@@ -48,38 +48,6 @@ pub trait EmbeddedBot: Options + Send + 'static {
 
     /// Called when the game ends. Default: no-op.
     fn on_game_over(&mut self, _result: GameResult, _scores: (f32, f32)) {}
-}
-
-/// Parameters for sending an Info message.
-///
-/// Shape mirrors `pyrat_sdk::InfoParams`. Use [`InfoParams::for_player`]
-/// and override fields with struct update syntax.
-#[derive(Debug)]
-pub struct InfoParams<'a> {
-    pub player: PlayerSlot,
-    pub multipv: u16,
-    pub target: Option<Coordinates>,
-    pub depth: u16,
-    pub nodes: u32,
-    pub score: Option<f32>,
-    pub pv: &'a [Direction],
-    pub message: &'a str,
-}
-
-impl InfoParams<'_> {
-    /// Defaults for the given player slot.
-    pub fn for_player(player: PlayerSlot) -> Self {
-        Self {
-            player,
-            multipv: 0,
-            target: None,
-            depth: 0,
-            nodes: 0,
-            score: None,
-            pv: &[],
-            message: "",
-        }
-    }
 }
 
 /// Per-turn context passed to [`EmbeddedBot::think`] and

--- a/server/host/src/player/embedded.rs
+++ b/server/host/src/player/embedded.rs
@@ -1,0 +1,284 @@
+//! In-process [`Player`](super::Player) implementation.
+//!
+//! `EmbeddedPlayer` runs a bot in the same process as the Match. No TCP, no
+//! FlatBuffers, no subprocess — a dispatcher task translates [`HostMsg`] into
+//! method calls on an [`EmbeddedBot`] and wraps the results in [`BotMsg`].
+//!
+//! ## Who writes what
+//!
+//! - Bot authors implement [`EmbeddedBot`] (and its supertrait [`Options`]).
+//!   The shape mirrors the SDK `Bot` trait exactly (`think`, `preprocess`,
+//!   `on_game_over`) so a single mental model covers both embedded and
+//!   networked bots.
+//! - The host constructs [`EmbeddedPlayer::new`] and hands the resulting
+//!   [`Player`](super::Player) impl to Match.
+//!
+//! ## Sideband
+//!
+//! [`EmbeddedCtx`] exposes `send_info` / `send_provisional` / `should_stop`
+//! with the same API surface as the SDK `Context`. Calls are routed to the
+//! [`EventSink`](super::EventSink) instead of an mpsc-backed codec.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use pyrat::{Coordinates, Direction};
+use pyrat_protocol::{BotMsg, HashedTurnState, HostMsg, OwnedOptionDef};
+use pyrat_wire::{GameResult, Player as PlayerSlot};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+use super::{EventSink, Player, PlayerError, PlayerIdentity};
+
+// ── Bot-author-facing surface ──────────────────────────
+
+/// Bot-declared option application.
+///
+/// Shape mirrors the SDK `pyrat_sdk::Options` trait verbatim, re-declared
+/// here to avoid a `pyrat-host → pyrat-sdk` dependency edge. If drift between
+/// the two becomes a problem, the open plan item is to extract a shared
+/// `pyrat-bot-api` crate.
+pub trait Options {
+    /// Declare configurable options.
+    fn option_defs(&self) -> Vec<OwnedOptionDef> {
+        vec![]
+    }
+
+    /// Apply a named option value. Called once per entry in
+    /// [`HostMsg::Configure`]'s `options` vector.
+    fn apply_option(&mut self, _name: &str, _value: &str) -> Result<(), String> {
+        Err("unknown option".into())
+    }
+}
+
+/// In-process bot interface.
+///
+/// Shape mirrors the SDK `Bot` trait so a bot author switches between
+/// networked and embedded with the same mental model. Argument types use
+/// [`pyrat_protocol`] owned types directly.
+pub trait EmbeddedBot: Options + Send + 'static {
+    /// Choose a direction for this turn.
+    fn think(&mut self, state: &HashedTurnState, ctx: &EmbeddedCtx) -> Direction;
+
+    /// Called once before the first turn. Default: no-op.
+    fn preprocess(&mut self, _state: &HashedTurnState, _ctx: &EmbeddedCtx) {}
+
+    /// Called when the game ends. Default: no-op.
+    fn on_game_over(&mut self, _result: GameResult, _scores: (f32, f32)) {}
+}
+
+/// Parameters for sending an Info message.
+///
+/// Shape mirrors `pyrat_sdk::InfoParams`. Use [`InfoParams::for_player`]
+/// and override fields with struct update syntax.
+#[derive(Debug)]
+pub struct InfoParams<'a> {
+    pub player: PlayerSlot,
+    pub multipv: u16,
+    pub target: Option<Coordinates>,
+    pub depth: u16,
+    pub nodes: u32,
+    pub score: Option<f32>,
+    pub pv: &'a [Direction],
+    pub message: &'a str,
+}
+
+impl InfoParams<'_> {
+    /// Defaults for the given player slot.
+    pub fn for_player(player: PlayerSlot) -> Self {
+        Self {
+            player,
+            multipv: 0,
+            target: None,
+            depth: 0,
+            nodes: 0,
+            score: None,
+            pv: &[],
+            message: "",
+        }
+    }
+}
+
+/// Per-turn context passed to [`EmbeddedBot::think`] and
+/// [`EmbeddedBot::preprocess`].
+///
+/// Shape mirrors the SDK `Context` API surface. `should_stop` reads an atomic
+/// that the dispatcher flips on [`HostMsg::Stop`]. Sideband routing:
+/// - `send_info` → observer-facing, forwarded to [`EventSink`] as
+///   `MatchEvent::BotInfo`.
+/// - `send_provisional` → game-driving, forwarded to the Match's `recv()`
+///   queue as [`BotMsg::Provisional`] (Match uses the latest as timeout
+///   fallback).
+pub struct EmbeddedCtx {
+    event_sink: EventSink,
+    bot_tx: mpsc::UnboundedSender<BotMsg>,
+    turn: u16,
+    state_hash: u64,
+    player: PlayerSlot,
+    stopped: Arc<AtomicBool>,
+}
+
+impl EmbeddedCtx {
+    #[expect(dead_code, reason = "consumed by dispatcher in follow-up commit")]
+    pub(crate) fn new(
+        event_sink: EventSink,
+        bot_tx: mpsc::UnboundedSender<BotMsg>,
+        turn: u16,
+        state_hash: u64,
+        player: PlayerSlot,
+        stopped: Arc<AtomicBool>,
+    ) -> Self {
+        Self {
+            event_sink,
+            bot_tx,
+            turn,
+            state_hash,
+            player,
+            stopped,
+        }
+    }
+
+    /// True if the host has signalled Stop. Cooperatively polled from the
+    /// bot's think loop.
+    pub fn should_stop(&self) -> bool {
+        self.stopped.load(Ordering::Relaxed)
+    }
+
+    /// Send an Info message. Routed to the attached [`EventSink`] as a
+    /// `MatchEvent::BotInfo` (observer-facing, never inspected by Match).
+    pub fn send_info(&self, params: &InfoParams<'_>) {
+        let info = pyrat_protocol::OwnedInfo {
+            player: params.player,
+            multipv: params.multipv,
+            target: params.target,
+            depth: params.depth,
+            nodes: params.nodes,
+            score: params.score,
+            pv: params.pv.to_vec(),
+            message: params.message.to_string(),
+            turn: self.turn,
+            state_hash: self.state_hash,
+        };
+        self.event_sink.emit(crate::game_loop::MatchEvent::BotInfo {
+            sender: self.player,
+            turn: self.turn,
+            state_hash: self.state_hash,
+            info,
+        });
+    }
+
+    /// Send a provisional (best-so-far) direction. Emitted as
+    /// [`BotMsg::Provisional`] on the game-driving channel: Match holds the
+    /// latest as its timeout fallback.
+    pub fn send_provisional(&self, direction: Direction) {
+        let _ = self.bot_tx.send(BotMsg::Provisional {
+            direction,
+            player: self.player,
+            turn: self.turn,
+            state_hash: self.state_hash,
+        });
+    }
+}
+
+// ── EmbeddedPlayer ────────────────────────────────────
+
+/// In-process [`Player`] implementation.
+///
+/// Owns a dispatcher task that translates [`HostMsg`] → bot method calls →
+/// [`BotMsg`]. See module docs for the design rationale.
+pub struct EmbeddedPlayer {
+    identity: PlayerIdentity,
+    host_tx: mpsc::UnboundedSender<HostMsg>,
+    bot_rx: mpsc::UnboundedReceiver<BotMsg>,
+    dispatcher: Option<JoinHandle<Result<(), PlayerError>>>,
+}
+
+impl EmbeddedPlayer {
+    /// Construct an EmbeddedPlayer wrapping `bot`. Spawns a dispatcher task
+    /// on the current tokio runtime.
+    pub fn new<B: EmbeddedBot>(bot: B, identity: PlayerIdentity, event_sink: EventSink) -> Self {
+        let (host_tx, host_rx) = mpsc::unbounded_channel();
+        let (bot_tx, bot_rx) = mpsc::unbounded_channel();
+        let dispatcher = tokio::spawn(dispatcher_task(bot, event_sink, host_rx, bot_tx));
+        Self {
+            identity,
+            host_tx,
+            bot_rx,
+            dispatcher: Some(dispatcher),
+        }
+    }
+
+    /// Await the dispatcher handle and map its exit state. Callable at most
+    /// once; subsequent calls short-circuit to Ok.
+    async fn reap_dispatcher(&mut self) -> Result<(), PlayerError> {
+        reap(self.dispatcher.take()).await
+    }
+}
+
+impl Player for EmbeddedPlayer {
+    fn identity(&self) -> &PlayerIdentity {
+        &self.identity
+    }
+
+    async fn send(&mut self, msg: HostMsg) -> Result<(), PlayerError> {
+        self.host_tx
+            .send(msg)
+            .map_err(|_| PlayerError::TransportError("dispatcher closed".into()))
+    }
+
+    async fn recv(&mut self) -> Result<Option<BotMsg>, PlayerError> {
+        match self.bot_rx.recv().await {
+            Some(msg) => Ok(Some(msg)),
+            None => {
+                // Dispatcher has dropped its sender → it has exited. Surface
+                // its exit reason, if any.
+                self.reap_dispatcher().await?;
+                Ok(None)
+            },
+        }
+    }
+
+    async fn close(self) -> Result<(), PlayerError> {
+        let Self {
+            host_tx,
+            mut bot_rx,
+            dispatcher,
+            identity: _,
+        } = self;
+        // Signal the dispatcher by dropping host_tx; drain any pending BotMsgs.
+        drop(host_tx);
+        while bot_rx.recv().await.is_some() {}
+        reap(dispatcher).await
+    }
+}
+
+async fn reap(dispatcher: Option<JoinHandle<Result<(), PlayerError>>>) -> Result<(), PlayerError> {
+    let Some(handle) = dispatcher else {
+        return Ok(());
+    };
+    match handle.await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(e)) => Err(e),
+        Err(join_err) => Err(PlayerError::TransportError(format!(
+            "dispatcher panicked: {join_err}"
+        ))),
+    }
+}
+
+// ── Dispatcher (scaffold) ─────────────────────────────
+
+/// Run one bot to completion, translating between the pipe and bot methods.
+///
+/// **Status: scaffold.** This initial commit wires the channels and ensures
+/// the type surface compiles. The actual state machine (setup typestate,
+/// `Playing<Sync>`, inner step loop) lands in follow-up commits.
+async fn dispatcher_task<B: EmbeddedBot>(
+    _bot: B,
+    _event_sink: EventSink,
+    mut host_rx: mpsc::UnboundedReceiver<HostMsg>,
+    _bot_tx: mpsc::UnboundedSender<BotMsg>,
+) -> Result<(), PlayerError> {
+    // Drain host_rx until the sender is dropped. No BotMsgs are produced.
+    while host_rx.recv().await.is_some() {}
+    Ok(())
+}

--- a/server/host/src/player/mod.rs
+++ b/server/host/src/player/mod.rs
@@ -13,7 +13,8 @@ use tokio::sync::mpsc;
 
 pub mod embedded;
 
-pub use embedded::{EmbeddedBot, EmbeddedCtx, EmbeddedPlayer, InfoParams, Options};
+pub use embedded::{EmbeddedBot, EmbeddedCtx, EmbeddedPlayer, InfoParams};
+pub use pyrat_bot_api::Options;
 
 use crate::game_loop::MatchEvent;
 

--- a/server/host/src/player/mod.rs
+++ b/server/host/src/player/mod.rs
@@ -13,8 +13,8 @@ use tokio::sync::mpsc;
 
 pub mod embedded;
 
-pub use embedded::{EmbeddedBot, EmbeddedCtx, EmbeddedPlayer, InfoParams};
-pub use pyrat_bot_api::Options;
+pub use embedded::{EmbeddedBot, EmbeddedCtx, EmbeddedPlayer};
+pub use pyrat_bot_api::{InfoParams, Options};
 
 use crate::game_loop::MatchEvent;
 

--- a/server/host/src/player/mod.rs
+++ b/server/host/src/player/mod.rs
@@ -1,0 +1,132 @@
+//! Player abstraction — bidirectional message pipe between Match and bot endpoint.
+//!
+//! The `Player` trait is the single protocol interface Match uses to drive a
+//! bot. It is transport-agnostic: an [`embedded::EmbeddedPlayer`] runs a bot
+//! in-process (no TCP, no serialization), while a future `TcpPlayer` will wrap
+//! the session layer. Either way, the Match only speaks in [`HostMsg`] /
+//! [`BotMsg`] through [`Player::send`] and [`Player::recv`].
+//!
+//! See `.mt/briefs/host-restructure/architecture.md` for the design rationale.
+
+use pyrat_protocol::{BotMsg, HostMsg};
+use tokio::sync::mpsc;
+
+pub mod embedded;
+
+pub use embedded::{EmbeddedBot, EmbeddedCtx, EmbeddedPlayer, InfoParams, Options};
+
+use crate::game_loop::MatchEvent;
+
+/// Identity known at construction time (before any handshake).
+///
+/// Same fields as the bot-reported `Identify` message, but carried separately:
+/// Match needs to know who the player is before it can route messages, and a
+/// caller (test harness, orchestrator, GUI) knows the identity of an embedded
+/// bot a priori.
+#[derive(Debug, Clone)]
+pub struct PlayerIdentity {
+    pub name: String,
+    pub author: String,
+    pub agent_id: String,
+}
+
+/// Optional consumer of observer-facing events.
+///
+/// Players forward sideband messages (Info, Provisional, RenderCommands) here
+/// directly. `recv()` yields only game-driving messages; the Match never
+/// inspects sideband.
+#[derive(Clone, Default)]
+pub struct EventSink {
+    tx: Option<mpsc::UnboundedSender<MatchEvent>>,
+}
+
+impl EventSink {
+    /// A sink that drops every event. Useful for tests that don't care about
+    /// sideband.
+    pub const fn noop() -> Self {
+        Self { tx: None }
+    }
+
+    /// Wrap an existing sender.
+    pub fn new(tx: mpsc::UnboundedSender<MatchEvent>) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    /// Emit an event. Silently dropped if no consumer is attached or the
+    /// receiver has hung up.
+    pub fn emit(&self, event: MatchEvent) {
+        if let Some(tx) = &self.tx {
+            let _ = tx.send(event);
+        }
+    }
+}
+
+/// Errors returned by [`Player`] methods.
+///
+/// Variants mirror the distinctions in `architecture.md`: clean close is
+/// distinct from a protocol or transport fault, which is distinct from a
+/// deadline timeout.
+#[derive(Debug, thiserror::Error)]
+pub enum PlayerError {
+    /// Peer closed gracefully. Currently returned by `close()` after a clean
+    /// shutdown; `recv()` signals clean close with `Ok(None)` instead.
+    #[error("peer closed cleanly")]
+    CleanClose,
+    /// Parse failure, unexpected message type, or other protocol violation.
+    #[error("protocol error: {0}")]
+    ProtocolError(String),
+    /// Channel closed unexpectedly, TCP died, or similar transport fault.
+    #[error("transport error: {0}")]
+    TransportError(String),
+    /// Deadline exceeded (clock mode).
+    #[error("deadline exceeded")]
+    Timeout,
+}
+
+/// Bidirectional message pipe between the Match and a bot endpoint.
+///
+/// Transport-agnostic. Impls:
+/// - [`EmbeddedPlayer`]: in-process, no TCP or FlatBuffers.
+/// - `TcpPlayer` (future): wraps the existing session layer.
+///
+/// # Cancel-safety
+///
+/// The contract is asymmetric:
+/// - `recv()` **MUST** be cancel-safe. Match selects on it (waiting for either
+///   player plus a timeout); a cancelled `recv()` future must not lose
+///   buffered bytes or drop an already-received message. For [`EmbeddedPlayer`]
+///   this falls out of `tokio::sync::mpsc::Receiver::recv`.
+/// - `send()` need not be cancel-safe. Match always awaits it to completion.
+/// - `close()` need not be cancel-safe. Same reason.
+///
+/// # Sideband routing
+///
+/// Players receive an [`EventSink`] at construction and route observer-facing
+/// messages (Info, Provisional, RenderCommands) directly to it. `recv()`
+/// surfaces only game-driving messages (`Identify`, `Ready`,
+/// `PreprocessingDone`, `SyncOk`, `Resync`, `Action`).
+pub trait Player: Send + Sync {
+    /// Identity known at construction, before any handshake.
+    fn identity(&self) -> &PlayerIdentity;
+
+    /// Send a host-to-bot message.
+    fn send(
+        &mut self,
+        msg: HostMsg,
+    ) -> impl std::future::Future<Output = Result<(), PlayerError>> + Send;
+
+    /// Receive the next bot-to-host message.
+    ///
+    /// - `Ok(Some(msg))` — a message was received.
+    /// - `Ok(None)` — the peer closed cleanly.
+    /// - `Err(_)` — a protocol, transport, or timeout failure occurred.
+    fn recv(
+        &mut self,
+    ) -> impl std::future::Future<Output = Result<Option<BotMsg>, PlayerError>> + Send;
+
+    /// Close the player cleanly.
+    ///
+    /// Best-effort, bounded, always attempted by Match's run loop on exit.
+    /// If the peer is already gone, swallow the error and return `Ok(())`.
+    fn close(self) -> impl std::future::Future<Output = Result<(), PlayerError>> + Send;
+}

--- a/server/host/src/player/mod.rs
+++ b/server/host/src/player/mod.rs
@@ -68,8 +68,10 @@ impl EventSink {
 /// deadline timeout.
 #[derive(Debug, thiserror::Error)]
 pub enum PlayerError {
-    /// Peer closed gracefully. Currently returned by `close()` after a clean
-    /// shutdown; `recv()` signals clean close with `Ok(None)` instead.
+    /// Reserved for future impls where the peer signals clean close
+    /// explicitly (e.g., `TcpPlayer` receiving a Disconnect frame).
+    /// `EmbeddedPlayer` signals clean close via `Ok(None)` on `recv()` and
+    /// `Ok(())` on `close()`, so it never constructs this variant.
     #[error("peer closed cleanly")]
     CleanClose,
     /// Parse failure, unexpected message type, or other protocol violation.

--- a/server/host/src/player/mod.rs
+++ b/server/host/src/player/mod.rs
@@ -1,12 +1,10 @@
-//! Player abstraction — bidirectional message pipe between Match and bot endpoint.
+//! Player abstraction: bidirectional message pipe between Match and bot endpoint.
 //!
 //! The `Player` trait is the single protocol interface Match uses to drive a
 //! bot. It is transport-agnostic: an [`embedded::EmbeddedPlayer`] runs a bot
 //! in-process (no TCP, no serialization), while a future `TcpPlayer` will wrap
 //! the session layer. Either way, the Match only speaks in [`HostMsg`] /
 //! [`BotMsg`] through [`Player::send`] and [`Player::recv`].
-//!
-//! See `.mt/briefs/host-restructure/architecture.md` for the design rationale.
 
 use pyrat_protocol::{BotMsg, HostMsg};
 use tokio::sync::mpsc;
@@ -64,9 +62,8 @@ impl EventSink {
 
 /// Errors returned by [`Player`] methods.
 ///
-/// Variants mirror the distinctions in `architecture.md`: clean close is
-/// distinct from a protocol or transport fault, which is distinct from a
-/// deadline timeout.
+/// Variants separate clean close from protocol or transport faults, and
+/// either of those from a deadline timeout.
 #[derive(Debug, thiserror::Error)]
 pub enum PlayerError {
     /// Reserved for future impls where the peer signals clean close
@@ -112,7 +109,6 @@ pub trait Player: Send + Sync {
     /// Identity known at construction, before any handshake.
     fn identity(&self) -> &PlayerIdentity;
 
-    /// Send a host-to-bot message.
     fn send(
         &mut self,
         msg: HostMsg,
@@ -120,9 +116,9 @@ pub trait Player: Send + Sync {
 
     /// Receive the next bot-to-host message.
     ///
-    /// - `Ok(Some(msg))` — a message was received.
-    /// - `Ok(None)` — the peer closed cleanly.
-    /// - `Err(_)` — a protocol, transport, or timeout failure occurred.
+    /// - `Ok(Some(msg))`: a message was received.
+    /// - `Ok(None)`: the peer closed cleanly.
+    /// - `Err(_)`: a protocol, transport, or timeout failure occurred.
     fn recv(
         &mut self,
     ) -> impl std::future::Future<Output = Result<Option<BotMsg>, PlayerError>> + Send;

--- a/server/host/src/session/codec.rs
+++ b/server/host/src/session/codec.rs
@@ -561,7 +561,7 @@ mod tests {
     fn build_info(
         player: Player,
         multipv: u16,
-        target: Option<(u8, u8)>,
+        target: Option<Coordinates>,
         depth: u16,
         nodes: u32,
         score: Option<f32>,
@@ -582,7 +582,7 @@ mod tests {
         } else {
             Some(fbb.create_vector(pv))
         };
-        let target_v = target.map(|(x, y)| Vec2::new(x, y));
+        let target_v = target.map(|coords| Vec2::new(coords.x, coords.y));
 
         let info = wire::Info::create(
             &mut fbb,
@@ -615,7 +615,7 @@ mod tests {
         let buf = build_info(
             Player::Player2,
             3,
-            Some((10, 7)),
+            Some(Coordinates::new(10, 7)),
             5,
             42000,
             Some(2.5),

--- a/server/host/tests/embedded_player.rs
+++ b/server/host/tests/embedded_player.rs
@@ -12,8 +12,8 @@ use std::time::Duration;
 use pyrat::{Coordinates, Direction};
 use pyrat_host::game_loop::MatchEvent;
 use pyrat_host::player::{
-    EmbeddedBot, EmbeddedCtx, EmbeddedPlayer, EventSink, InfoParams, Options, Player,
-    PlayerError, PlayerIdentity,
+    EmbeddedBot, EmbeddedCtx, EmbeddedPlayer, EventSink, InfoParams, Options, Player, PlayerError,
+    PlayerIdentity,
 };
 use pyrat_protocol::{
     BotMsg, HashedTurnState, HostMsg, OwnedMatchConfig, OwnedTurnState, SearchLimits,
@@ -96,7 +96,7 @@ impl EmbeddedBot for StayBot {
 }
 
 /// Returns a different direction depending on the turn number the dispatcher
-/// passes in — lets tests verify `GoState` overwrote the local mirror.
+/// passes in. Lets tests verify `GoState` overwrote the local mirror.
 struct TurnSensitiveBot;
 impl Options for TurnSensitiveBot {}
 impl EmbeddedBot for TurnSensitiveBot {
@@ -202,8 +202,7 @@ async fn happy_path_preprocess_think_game_over() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn info_routes_to_event_sink_not_bot_recv() {
     let (event_tx, mut event_rx) = mpsc::unbounded_channel::<MatchEvent>();
-    let mut player =
-        EmbeddedPlayer::new(InfoEmittingBot, identity(), EventSink::new(event_tx));
+    let mut player = EmbeddedPlayer::new(InfoEmittingBot, identity(), EventSink::new(event_tx));
     let hash = walk_through_setup(&mut player).await;
 
     player
@@ -677,7 +676,7 @@ async fn protocol_error_advance_while_thinking() {
         .unwrap();
 
     // Bot is now sleeping inside spawn_blocking. Send a forbidden Advance
-    // while it works — the dispatcher's watch_for_stop should reject it.
+    // while it works; the dispatcher's watch_for_stop should reject it.
     tokio::time::sleep(Duration::from_millis(20)).await;
     player
         .send(HostMsg::Advance {

--- a/server/host/tests/embedded_player.rs
+++ b/server/host/tests/embedded_player.rs
@@ -49,6 +49,24 @@ fn sample_match_config() -> Box<OwnedMatchConfig> {
     })
 }
 
+/// Default `OwnedTurnState` matching `sample_match_config`'s layout: players
+/// at their starting corners, one cheese at (2, 2), no mud, zero scores,
+/// last moves `Stay`. Callers override fields via struct update syntax.
+fn base_turn_state(turn: u16) -> OwnedTurnState {
+    OwnedTurnState {
+        turn,
+        player1_position: Coordinates::new(0, 0),
+        player2_position: Coordinates::new(4, 4),
+        player1_score: 0.0,
+        player2_score: 0.0,
+        player1_mud_turns: 0,
+        player2_mud_turns: 0,
+        cheese: vec![Coordinates::new(2, 2)],
+        player1_last_move: Direction::Stay,
+        player2_last_move: Direction::Stay,
+    }
+}
+
 /// Drive an [`EmbeddedPlayer`] through setup (Identify → Welcome →
 /// Configure → Ready), returning the hash the bot announced.
 async fn walk_through_setup(player: &mut EmbeddedPlayer) -> u64 {
@@ -272,16 +290,9 @@ async fn desync_emits_resync_then_fullstate_recovers() {
     // Send a FullState that restores a known position. The bot should emit
     // SyncOk with the hash of that state.
     let recovery_state = OwnedTurnState {
-        turn: 1,
         player1_position: Coordinates::new(1, 0),
-        player2_position: Coordinates::new(4, 4),
-        player1_score: 0.0,
-        player2_score: 0.0,
-        player1_mud_turns: 0,
-        player2_mud_turns: 0,
-        cheese: vec![Coordinates::new(2, 2)],
         player1_last_move: Direction::Right,
-        player2_last_move: Direction::Stay,
+        ..base_turn_state(1)
     };
     player
         .send(HostMsg::FullState {
@@ -352,18 +363,7 @@ async fn go_state_overrides_local_mirror() {
     // Local mirror has turn=0; TurnSensitiveBot would return Down. Inject
     // turn=42 via GoState and expect Right. Compute the canonical hash of
     // the injected state so the dispatcher's verification accepts it.
-    let injected = OwnedTurnState {
-        turn: 42,
-        player1_position: Coordinates::new(0, 0),
-        player2_position: Coordinates::new(4, 4),
-        player1_score: 0.0,
-        player2_score: 0.0,
-        player1_mud_turns: 0,
-        player2_mud_turns: 0,
-        cheese: vec![Coordinates::new(2, 2)],
-        player1_last_move: Direction::Stay,
-        player2_last_move: Direction::Stay,
-    };
+    let injected = base_turn_state(42);
     let state_hash = HashedTurnState::new(injected.clone()).state_hash();
     player
         .send(HostMsg::GoState {
@@ -561,22 +561,10 @@ async fn protocol_error_fullstate_while_synced() {
 
     // In Playing<Synced>/Idle; a FullState arriving here is a protocol
     // violation (the server must only send FullState after a Resync).
-    let bogus_state = OwnedTurnState {
-        turn: 0,
-        player1_position: Coordinates::new(0, 0),
-        player2_position: Coordinates::new(4, 4),
-        player1_score: 0.0,
-        player2_score: 0.0,
-        player1_mud_turns: 0,
-        player2_mud_turns: 0,
-        cheese: vec![Coordinates::new(2, 2)],
-        player1_last_move: Direction::Stay,
-        player2_last_move: Direction::Stay,
-    };
     player
         .send(HostMsg::FullState {
             match_config: sample_match_config(),
-            turn_state: Box::new(bogus_state),
+            turn_state: Box::new(base_turn_state(0)),
         })
         .await
         .unwrap();
@@ -616,19 +604,7 @@ async fn protocol_error_go_preprocess_while_syncing() {
 
     // Apply a (Stay, Stay) advance. The post-move local state has turn=1
     // and its canonical hash is what the bot will compare against.
-    let advanced = OwnedTurnState {
-        turn: 1,
-        player1_position: Coordinates::new(0, 0),
-        player2_position: Coordinates::new(4, 4),
-        player1_score: 0.0,
-        player2_score: 0.0,
-        player1_mud_turns: 0,
-        player2_mud_turns: 0,
-        cheese: vec![Coordinates::new(2, 2)],
-        player1_last_move: Direction::Stay,
-        player2_last_move: Direction::Stay,
-    };
-    let hash1 = HashedTurnState::new(advanced).state_hash();
+    let hash1 = HashedTurnState::new(base_turn_state(1)).state_hash();
     player
         .send(HostMsg::Advance {
             p1_dir: Direction::Stay,

--- a/server/host/tests/embedded_player.rs
+++ b/server/host/tests/embedded_player.rs
@@ -1,0 +1,408 @@
+//! Integration tests for the in-process [`EmbeddedPlayer`].
+//!
+//! These exercise the full `Player` trait surface from outside the crate.
+//! They don't reach into private helpers, so paths that need
+//! hash-verification (Advance + SyncOk) are covered by inline unit tests in
+//! `player/embedded.rs`; this file covers end-to-end flows that only need
+//! public API.
+
+use std::time::Duration;
+
+use pyrat::{Coordinates, Direction};
+use pyrat_host::game_loop::MatchEvent;
+use pyrat_host::player::{
+    EmbeddedBot, EmbeddedCtx, EmbeddedPlayer, EventSink, InfoParams, Options, Player,
+    PlayerError, PlayerIdentity,
+};
+use pyrat_protocol::{
+    BotMsg, HashedTurnState, HostMsg, OwnedMatchConfig, OwnedTurnState, SearchLimits,
+};
+use pyrat_wire::{GameResult, Player as PlayerSlot, TimingMode};
+use tokio::sync::mpsc;
+use tokio::time::timeout;
+
+// ── Test fixtures ─────────────────────────────────────
+
+fn identity() -> PlayerIdentity {
+    PlayerIdentity {
+        name: "TestBot".into(),
+        author: "tests".into(),
+        agent_id: "pyrat/test".into(),
+    }
+}
+
+fn sample_match_config() -> Box<OwnedMatchConfig> {
+    Box::new(OwnedMatchConfig {
+        width: 5,
+        height: 5,
+        max_turns: 100,
+        walls: vec![],
+        mud: vec![],
+        cheese: vec![Coordinates::new(2, 2)],
+        player1_start: Coordinates::new(0, 0),
+        player2_start: Coordinates::new(4, 4),
+        controlled_players: vec![PlayerSlot::Player1],
+        timing: TimingMode::Wait,
+        move_timeout_ms: 100,
+        preprocessing_timeout_ms: 1000,
+    })
+}
+
+/// Drive an [`EmbeddedPlayer`] through setup (Identify → Welcome →
+/// Configure → Ready), returning the hash the bot announced.
+async fn walk_through_setup(player: &mut EmbeddedPlayer) -> u64 {
+    match recv_ok(player).await {
+        BotMsg::Identify { .. } => {},
+        other => panic!("expected Identify, got {other:?}"),
+    }
+    player
+        .send(HostMsg::Welcome {
+            player_slot: PlayerSlot::Player1,
+        })
+        .await
+        .unwrap();
+    player
+        .send(HostMsg::Configure {
+            options: vec![],
+            match_config: sample_match_config(),
+        })
+        .await
+        .unwrap();
+    match recv_ok(player).await {
+        BotMsg::Ready { state_hash } => state_hash,
+        other => panic!("expected Ready, got {other:?}"),
+    }
+}
+
+/// Short-circuit helper: await `recv()` with a timeout so a hung test fails
+/// fast instead of hanging CI.
+async fn recv_ok(player: &mut EmbeddedPlayer) -> BotMsg {
+    timeout(Duration::from_secs(2), player.recv())
+        .await
+        .expect("recv timed out")
+        .expect("recv returned Err")
+        .expect("recv returned Ok(None)")
+}
+
+// ── Test bots ─────────────────────────────────────────
+
+struct StayBot;
+impl Options for StayBot {}
+impl EmbeddedBot for StayBot {
+    fn think(&mut self, _: &HashedTurnState, _: &EmbeddedCtx) -> Direction {
+        Direction::Stay
+    }
+}
+
+/// Returns a different direction depending on the turn number the dispatcher
+/// passes in — lets tests verify `GoState` overwrote the local mirror.
+struct TurnSensitiveBot;
+impl Options for TurnSensitiveBot {}
+impl EmbeddedBot for TurnSensitiveBot {
+    fn think(&mut self, state: &HashedTurnState, _: &EmbeddedCtx) -> Direction {
+        if state.turn == 42 {
+            Direction::Right
+        } else {
+            Direction::Down
+        }
+    }
+}
+
+/// Calls `ctx.send_info` during `think`, then returns `Stay`. Used to verify
+/// sideband routing.
+struct InfoEmittingBot;
+impl Options for InfoEmittingBot {}
+impl EmbeddedBot for InfoEmittingBot {
+    fn think(&mut self, _: &HashedTurnState, ctx: &EmbeddedCtx) -> Direction {
+        ctx.send_info(&InfoParams {
+            depth: 3,
+            nodes: 100,
+            message: "analysis",
+            ..InfoParams::for_player(PlayerSlot::Player1)
+        });
+        Direction::Stay
+    }
+}
+
+/// Cooperative-stop bot. Busy-waits until `should_stop` flips, then returns
+/// `Right` (distinct from `Stay` so the test can tell early-exit from
+/// never-started).
+struct SpinBot;
+impl Options for SpinBot {}
+impl EmbeddedBot for SpinBot {
+    fn think(&mut self, _: &HashedTurnState, ctx: &EmbeddedCtx) -> Direction {
+        while !ctx.should_stop() {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        Direction::Right
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn happy_path_preprocess_think_game_over() {
+    let mut player = EmbeddedPlayer::new(StayBot, identity(), EventSink::noop());
+    let hash = walk_through_setup(&mut player).await;
+
+    // Preprocess → PreprocessingDone.
+    player
+        .send(HostMsg::GoPreprocess { state_hash: hash })
+        .await
+        .unwrap();
+    match recv_ok(&mut player).await {
+        BotMsg::PreprocessingDone => {},
+        other => panic!("expected PreprocessingDone, got {other:?}"),
+    }
+
+    // Go (first turn, direct from Configured) → Action.
+    player
+        .send(HostMsg::Go {
+            state_hash: hash,
+            limits: SearchLimits::default(),
+        })
+        .await
+        .unwrap();
+    match recv_ok(&mut player).await {
+        BotMsg::Action {
+            direction,
+            player: slot,
+            state_hash,
+            ..
+        } => {
+            assert_eq!(direction, Direction::Stay);
+            assert_eq!(slot, PlayerSlot::Player1);
+            assert_eq!(state_hash, hash);
+        },
+        other => panic!("expected Action, got {other:?}"),
+    }
+
+    // GameOver → dispatcher exits cleanly.
+    player
+        .send(HostMsg::GameOver {
+            result: GameResult::Draw,
+            player1_score: 0.0,
+            player2_score: 0.0,
+        })
+        .await
+        .unwrap();
+
+    // After GameOver, bot_rx drains and dispatcher drops its sender.
+    let next = timeout(Duration::from_secs(2), player.recv())
+        .await
+        .expect("recv timed out");
+    assert!(matches!(next, Ok(None)), "{next:?}");
+    player.close().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn info_routes_to_event_sink_not_bot_recv() {
+    let (event_tx, mut event_rx) = mpsc::unbounded_channel::<MatchEvent>();
+    let mut player =
+        EmbeddedPlayer::new(InfoEmittingBot, identity(), EventSink::new(event_tx));
+    let hash = walk_through_setup(&mut player).await;
+
+    player
+        .send(HostMsg::Go {
+            state_hash: hash,
+            limits: SearchLimits::default(),
+        })
+        .await
+        .unwrap();
+
+    // The bot emits Info (sideband) then Action (game-driving). Only Action
+    // surfaces through recv(); Info arrives on the EventSink.
+    let msg = recv_ok(&mut player).await;
+    assert!(
+        matches!(msg, BotMsg::Action { .. }),
+        "recv() yielded sideband: {msg:?}"
+    );
+
+    let event = timeout(Duration::from_secs(1), event_rx.recv())
+        .await
+        .expect("EventSink timed out")
+        .expect("EventSink closed");
+    match event {
+        MatchEvent::BotInfo { info, sender, .. } => {
+            assert_eq!(sender, PlayerSlot::Player1);
+            assert_eq!(info.message, "analysis");
+            assert_eq!(info.depth, 3);
+            assert_eq!(info.nodes, 100);
+        },
+        other => panic!("expected BotInfo, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn desync_emits_resync_then_fullstate_recovers() {
+    let mut player = EmbeddedPlayer::new(StayBot, identity(), EventSink::noop());
+    let hash = walk_through_setup(&mut player).await;
+
+    // First turn to move the client past the initial-Go gate. After Action
+    // we're back in Idle and can send Advance.
+    player
+        .send(HostMsg::Go {
+            state_hash: hash,
+            limits: SearchLimits::default(),
+        })
+        .await
+        .unwrap();
+    let _action = recv_ok(&mut player).await;
+
+    // Send an Advance with a deliberately wrong new_hash.
+    player
+        .send(HostMsg::Advance {
+            p1_dir: Direction::Stay,
+            p2_dir: Direction::Stay,
+            turn: 1,
+            new_hash: 0xDEAD_BEEF_DEAD_BEEF,
+        })
+        .await
+        .unwrap();
+
+    let bot_hash = match recv_ok(&mut player).await {
+        BotMsg::Resync { my_hash } => my_hash,
+        other => panic!("expected Resync, got {other:?}"),
+    };
+    assert_ne!(bot_hash, 0xDEAD_BEEF_DEAD_BEEF);
+
+    // Send a FullState that restores a known position. The bot should emit
+    // SyncOk with the hash of that state.
+    let recovery_state = OwnedTurnState {
+        turn: 1,
+        player1_position: Coordinates::new(1, 0),
+        player2_position: Coordinates::new(4, 4),
+        player1_score: 0.0,
+        player2_score: 0.0,
+        player1_mud_turns: 0,
+        player2_mud_turns: 0,
+        cheese: vec![Coordinates::new(2, 2)],
+        player1_last_move: Direction::Right,
+        player2_last_move: Direction::Stay,
+    };
+    player
+        .send(HostMsg::FullState {
+            match_config: sample_match_config(),
+            turn_state: Box::new(recovery_state),
+        })
+        .await
+        .unwrap();
+    match recv_ok(&mut player).await {
+        BotMsg::SyncOk { .. } => {},
+        other => panic!("expected SyncOk after FullState, got {other:?}"),
+    }
+
+    // Bot is Synced again; we can proceed. Close cleanly via GameOver.
+    player
+        .send(HostMsg::GameOver {
+            result: GameResult::Draw,
+            player1_score: 0.0,
+            player2_score: 0.0,
+        })
+        .await
+        .unwrap();
+    let next = timeout(Duration::from_secs(1), player.recv())
+        .await
+        .expect("recv timed out");
+    assert!(matches!(next, Ok(None)));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stop_cancels_think_cooperatively() {
+    let mut player = EmbeddedPlayer::new(SpinBot, identity(), EventSink::noop());
+    let hash = walk_through_setup(&mut player).await;
+
+    // Kick off a Go — the bot spins until should_stop() flips.
+    player
+        .send(HostMsg::Go {
+            state_hash: hash,
+            limits: SearchLimits::default(),
+        })
+        .await
+        .unwrap();
+
+    // Give the bot a moment to enter its spin loop, then send Stop.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    player.send(HostMsg::Stop).await.unwrap();
+
+    // The bot should observe should_stop and return Direction::Right.
+    match recv_ok(&mut player).await {
+        BotMsg::Action { direction, .. } => {
+            assert_eq!(direction, Direction::Right);
+        },
+        other => panic!("expected Action after Stop, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn go_state_overrides_local_mirror() {
+    let mut player = EmbeddedPlayer::new(TurnSensitiveBot, identity(), EventSink::noop());
+    let _hash = walk_through_setup(&mut player).await;
+
+    // Local mirror has turn=0; TurnSensitiveBot would return Down. Inject
+    // turn=42 via GoState and expect Right.
+    let injected = OwnedTurnState {
+        turn: 42,
+        player1_position: Coordinates::new(0, 0),
+        player2_position: Coordinates::new(4, 4),
+        player1_score: 0.0,
+        player2_score: 0.0,
+        player1_mud_turns: 0,
+        player2_mud_turns: 0,
+        cheese: vec![Coordinates::new(2, 2)],
+        player1_last_move: Direction::Stay,
+        player2_last_move: Direction::Stay,
+    };
+    player
+        .send(HostMsg::GoState {
+            turn_state: Box::new(injected),
+            state_hash: 0,
+            limits: SearchLimits::default(),
+        })
+        .await
+        .unwrap();
+
+    match recv_ok(&mut player).await {
+        BotMsg::Action { direction, .. } => {
+            assert_eq!(direction, Direction::Right);
+        },
+        other => panic!("expected Action, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn close_during_idle_exits_cleanly() {
+    let mut player = EmbeddedPlayer::new(StayBot, identity(), EventSink::noop());
+    let _hash = walk_through_setup(&mut player).await;
+
+    // Sitting in Playing<Synced> / Idle. Closing drops host_tx; the
+    // dispatcher's host_rx.recv() yields None → TransportError. `close()`
+    // surfaces that verbatim — not a regression, just the protocol's
+    // "channel gone" semantics without a GameOver.
+    let err = player.close().await.expect_err("close should surface error");
+    assert!(matches!(err, PlayerError::TransportError(_)), "{err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn protocol_error_message_propagates() {
+    let mut player = EmbeddedPlayer::new(StayBot, identity(), EventSink::noop());
+    let _hash = walk_through_setup(&mut player).await;
+
+    // Synced + Idle: send a ProtocolError to simulate the server signalling a
+    // terminal protocol fault. Dispatcher returns Err, surfaced on recv().
+    player
+        .send(HostMsg::ProtocolError {
+            reason: "test fault".into(),
+        })
+        .await
+        .unwrap();
+
+    let err = timeout(Duration::from_secs(1), player.recv())
+        .await
+        .expect("recv timed out")
+        .expect_err("expected protocol error");
+    match err {
+        PlayerError::ProtocolError(msg) => assert!(msg.contains("test fault")),
+        other => panic!("expected ProtocolError, got {other:?}"),
+    }
+}

--- a/server/host/tests/embedded_player.rs
+++ b/server/host/tests/embedded_player.rs
@@ -340,7 +340,8 @@ async fn go_state_overrides_local_mirror() {
     let _hash = walk_through_setup(&mut player).await;
 
     // Local mirror has turn=0; TurnSensitiveBot would return Down. Inject
-    // turn=42 via GoState and expect Right.
+    // turn=42 via GoState and expect Right. Compute the canonical hash of
+    // the injected state so the dispatcher's verification accepts it.
     let injected = OwnedTurnState {
         turn: 42,
         player1_position: Coordinates::new(0, 0),
@@ -353,10 +354,11 @@ async fn go_state_overrides_local_mirror() {
         player1_last_move: Direction::Stay,
         player2_last_move: Direction::Stay,
     };
+    let state_hash = HashedTurnState::new(injected.clone()).state_hash();
     player
         .send(HostMsg::GoState {
             turn_state: Box::new(injected),
-            state_hash: 0,
+            state_hash,
             limits: SearchLimits::default(),
         })
         .await

--- a/server/host/tests/embedded_player.rs
+++ b/server/host/tests/embedded_player.rs
@@ -376,11 +376,8 @@ async fn close_during_idle_exits_cleanly() {
     let _hash = walk_through_setup(&mut player).await;
 
     // Sitting in Playing<Synced> / Idle. Closing drops host_tx; the
-    // dispatcher's host_rx.recv() yields None → TransportError. `close()`
-    // surfaces that verbatim — not a regression, just the protocol's
-    // "channel gone" semantics without a GameOver.
-    let err = player.close().await.expect_err("close should surface error");
-    assert!(matches!(err, PlayerError::TransportError(_)), "{err:?}");
+    // dispatcher sees host_rx.recv() yield None from Idle and exits Ok(()).
+    player.close().await.expect("close should succeed");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/server/host/tests/embedded_player.rs
+++ b/server/host/tests/embedded_player.rs
@@ -747,7 +747,10 @@ async fn close_during_uncooperative_think_is_bounded() {
     // close should fire its grace timeout (~1s) and abort the dispatcher.
     // Bound the assertion at 1.5s to leave room for scheduling jitter.
     let close_start = std::time::Instant::now();
-    player.close().await.expect("close should succeed within grace");
+    player
+        .close()
+        .await
+        .expect("close should succeed within grace");
     let elapsed = close_start.elapsed();
     assert!(
         elapsed < Duration::from_millis(1500),

--- a/server/host/tests/embedded_player.rs
+++ b/server/host/tests/embedded_player.rs
@@ -681,3 +681,104 @@ async fn protocol_error_advance_while_thinking() {
     // down. DelayedBot sleeps 100ms; give it headroom.
     tokio::time::sleep(Duration::from_millis(150)).await;
 }
+
+// ── close + think_ms coverage ────────────────────────
+
+/// Bot that sleeps inside `think` for longer than the close grace period
+/// and never polls `should_stop`. Used to verify `close` is bounded by the
+/// grace timeout, not by the bot's wall time.
+struct UncooperativeSleeperBot;
+impl Options for UncooperativeSleeperBot {}
+impl EmbeddedBot for UncooperativeSleeperBot {
+    fn think(&mut self, _: &HashedTurnState, _: &EmbeddedCtx) -> Direction {
+        // Must exceed `embedded::CLOSE_GRACE` (1s) so the close timeout fires.
+        std::thread::sleep(Duration::from_millis(1200));
+        Direction::Stay
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn close_during_cooperative_think_returns_promptly() {
+    let started = Arc::new(Notify::new());
+    let mut player = EmbeddedPlayer::new(
+        SpinBot {
+            started: started.clone(),
+        },
+        identity(),
+        EventSink::noop(),
+    );
+    let hash = walk_through_setup(&mut player).await;
+
+    player
+        .send(HostMsg::Go {
+            state_hash: hash,
+            limits: SearchLimits::default(),
+        })
+        .await
+        .unwrap();
+    started.notified().await;
+
+    // SpinBot exits as soon as `should_stop()` flips. close should set the
+    // flag and reap well under the grace period.
+    let close_start = std::time::Instant::now();
+    player.close().await.expect("close should succeed");
+    let elapsed = close_start.elapsed();
+    assert!(
+        elapsed < Duration::from_millis(300),
+        "close took {elapsed:?}, expected fast exit for cooperative bot"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn close_during_uncooperative_think_is_bounded() {
+    let mut player = EmbeddedPlayer::new(UncooperativeSleeperBot, identity(), EventSink::noop());
+    let hash = walk_through_setup(&mut player).await;
+
+    player
+        .send(HostMsg::Go {
+            state_hash: hash,
+            limits: SearchLimits::default(),
+        })
+        .await
+        .unwrap();
+    // Let the bot enter spawn_blocking before close.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // close should fire its grace timeout (~1s) and abort the dispatcher.
+    // Bound the assertion at 1.5s to leave room for scheduling jitter.
+    let close_start = std::time::Instant::now();
+    player.close().await.expect("close should succeed within grace");
+    let elapsed = close_start.elapsed();
+    assert!(
+        elapsed < Duration::from_millis(1500),
+        "close took {elapsed:?}, expected bounded by CLOSE_GRACE (~1s)"
+    );
+
+    // Let the detached blocking bot task drain before runtime shutdown.
+    // UncooperativeSleeperBot sleeps 1200ms; give it headroom from t=0.
+    tokio::time::sleep(Duration::from_millis(1300)).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn think_ms_clamped_to_one_for_fast_bots() {
+    let mut player = EmbeddedPlayer::new(StayBot, identity(), EventSink::noop());
+    let hash = walk_through_setup(&mut player).await;
+
+    player
+        .send(HostMsg::Go {
+            state_hash: hash,
+            limits: SearchLimits::default(),
+        })
+        .await
+        .unwrap();
+
+    match recv_ok(&mut player).await {
+        BotMsg::Action { think_ms, .. } => {
+            assert!(
+                think_ms >= 1,
+                "think_ms must be clamped to >=1 (host rejects 0), got {think_ms}"
+            );
+        },
+        other => panic!("expected Action, got {other:?}"),
+    }
+}

--- a/server/host/tests/embedded_player.rs
+++ b/server/host/tests/embedded_player.rs
@@ -6,6 +6,7 @@
 //! `player/embedded.rs`; this file covers end-to-end flows that only need
 //! public API.
 
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use pyrat::{Coordinates, Direction};
@@ -18,7 +19,7 @@ use pyrat_protocol::{
     BotMsg, HashedTurnState, HostMsg, OwnedMatchConfig, OwnedTurnState, SearchLimits,
 };
 use pyrat_wire::{GameResult, Player as PlayerSlot, TimingMode};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Notify};
 use tokio::time::timeout;
 
 // ── Test fixtures ─────────────────────────────────────
@@ -124,13 +125,16 @@ impl EmbeddedBot for InfoEmittingBot {
     }
 }
 
-/// Cooperative-stop bot. Busy-waits until `should_stop` flips, then returns
-/// `Right` (distinct from `Stay` so the test can tell early-exit from
-/// never-started).
-struct SpinBot;
+/// Cooperative-stop bot. Signals `started` once `think` is entered, then
+/// busy-waits until `should_stop` flips. Returns `Right` (distinct from
+/// `Stay` so the test can tell early-exit from never-started).
+struct SpinBot {
+    started: Arc<Notify>,
+}
 impl Options for SpinBot {}
 impl EmbeddedBot for SpinBot {
     fn think(&mut self, _: &HashedTurnState, ctx: &EmbeddedCtx) -> Direction {
+        self.started.notify_one();
         while !ctx.should_stop() {
             std::thread::sleep(Duration::from_millis(1));
         }
@@ -309,10 +313,17 @@ async fn desync_emits_resync_then_fullstate_recovers() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn stop_cancels_think_cooperatively() {
-    let mut player = EmbeddedPlayer::new(SpinBot, identity(), EventSink::noop());
+    let started = Arc::new(Notify::new());
+    let mut player = EmbeddedPlayer::new(
+        SpinBot {
+            started: started.clone(),
+        },
+        identity(),
+        EventSink::noop(),
+    );
     let hash = walk_through_setup(&mut player).await;
 
-    // Kick off a Go — the bot spins until should_stop() flips.
+    // Kick off a Go; the bot spins until should_stop() flips.
     player
         .send(HostMsg::Go {
             state_hash: hash,
@@ -321,8 +332,8 @@ async fn stop_cancels_think_cooperatively() {
         .await
         .unwrap();
 
-    // Give the bot a moment to enter its spin loop, then send Stop.
-    tokio::time::sleep(Duration::from_millis(20)).await;
+    // Wait for the bot to enter think, then send Stop.
+    started.notified().await;
     player.send(HostMsg::Stop).await.unwrap();
 
     // The bot should observe should_stop and return Direction::Right.
@@ -404,4 +415,294 @@ async fn protocol_error_message_propagates() {
         PlayerError::ProtocolError(msg) => assert!(msg.contains("test fault")),
         other => panic!("expected ProtocolError, got {other:?}"),
     }
+}
+
+// ── New coverage ──────────────────────────────────────
+
+/// Bot that calls `ctx.send_provisional(Right)` from inside `think`, then
+/// returns `Stay` as its committed move. Lets the test verify that
+/// provisional messages flow through `recv()` before the final Action.
+struct ProvisionalBot;
+impl Options for ProvisionalBot {}
+impl EmbeddedBot for ProvisionalBot {
+    fn think(&mut self, _: &HashedTurnState, ctx: &EmbeddedCtx) -> Direction {
+        ctx.send_provisional(Direction::Right);
+        Direction::Stay
+    }
+}
+
+type GameOverRecord = Arc<Mutex<Option<(GameResult, (f32, f32))>>>;
+
+/// Bot that records its `on_game_over` invocation.
+struct GameOverBot {
+    called: GameOverRecord,
+}
+impl Options for GameOverBot {}
+impl EmbeddedBot for GameOverBot {
+    fn think(&mut self, _: &HashedTurnState, _: &EmbeddedCtx) -> Direction {
+        Direction::Stay
+    }
+    fn on_game_over(&mut self, result: GameResult, scores: (f32, f32)) {
+        *self.called.lock().unwrap() = Some((result, scores));
+    }
+}
+
+/// Bot whose `think` blocks for 100ms with `std::thread::sleep`, ignoring
+/// `should_stop`. Used to force the dispatcher into a mid-think state while
+/// the test injects a forbidden host message.
+struct DelayedBot;
+impl Options for DelayedBot {}
+impl EmbeddedBot for DelayedBot {
+    fn think(&mut self, _: &HashedTurnState, _: &EmbeddedCtx) -> Direction {
+        std::thread::sleep(Duration::from_millis(100));
+        Direction::Stay
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recv_is_cancel_safe() {
+    let mut player = EmbeddedPlayer::new(StayBot, identity(), EventSink::noop());
+    let hash = walk_through_setup(&mut player).await;
+
+    // Drop a pending recv() by letting a biased zero-duration timer win.
+    // The trait contract says the next recv() must still deliver any
+    // message that arrives after cancellation.
+    tokio::select! {
+        biased;
+        () = tokio::time::sleep(Duration::from_millis(0)) => {},
+        _ = player.recv() => panic!("recv should lose to zero-duration timer"),
+    }
+
+    // Now produce a BotMsg and verify recv still yields it.
+    player
+        .send(HostMsg::Go {
+            state_hash: hash,
+            limits: SearchLimits::default(),
+        })
+        .await
+        .unwrap();
+    match recv_ok(&mut player).await {
+        BotMsg::Action { .. } => {},
+        other => panic!("recv lost a message after cancel: {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn provisional_routes_through_recv() {
+    let mut player = EmbeddedPlayer::new(ProvisionalBot, identity(), EventSink::noop());
+    let hash = walk_through_setup(&mut player).await;
+
+    player
+        .send(HostMsg::Go {
+            state_hash: hash,
+            limits: SearchLimits::default(),
+        })
+        .await
+        .unwrap();
+
+    // Provisional arrives first, then the committed Action.
+    match recv_ok(&mut player).await {
+        BotMsg::Provisional {
+            direction,
+            player: slot,
+            state_hash: h,
+            ..
+        } => {
+            assert_eq!(direction, Direction::Right);
+            assert_eq!(slot, PlayerSlot::Player1);
+            assert_eq!(h, hash);
+        },
+        other => panic!("expected Provisional, got {other:?}"),
+    }
+    match recv_ok(&mut player).await {
+        BotMsg::Action { direction, .. } => assert_eq!(direction, Direction::Stay),
+        other => panic!("expected Action, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn on_game_over_is_invoked() {
+    let called = Arc::new(Mutex::new(None));
+    let mut player = EmbeddedPlayer::new(
+        GameOverBot {
+            called: called.clone(),
+        },
+        identity(),
+        EventSink::noop(),
+    );
+    let _hash = walk_through_setup(&mut player).await;
+
+    player
+        .send(HostMsg::GameOver {
+            result: GameResult::Player1,
+            player1_score: 5.0,
+            player2_score: 2.5,
+        })
+        .await
+        .unwrap();
+
+    // Dispatcher processes GameOver and exits cleanly: next recv yields None.
+    let next = timeout(Duration::from_secs(1), player.recv())
+        .await
+        .expect("recv timed out");
+    assert!(matches!(next, Ok(None)));
+    player.close().await.expect("close should succeed");
+
+    let recorded = *called.lock().unwrap();
+    let (result, scores) = recorded.expect("on_game_over not called");
+    assert!(matches!(result, GameResult::Player1));
+    assert!((scores.0 - 5.0).abs() < f32::EPSILON);
+    assert!((scores.1 - 2.5).abs() < f32::EPSILON);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn protocol_error_fullstate_while_synced() {
+    let mut player = EmbeddedPlayer::new(StayBot, identity(), EventSink::noop());
+    let _hash = walk_through_setup(&mut player).await;
+
+    // In Playing<Synced>/Idle; a FullState arriving here is a protocol
+    // violation (the server must only send FullState after a Resync).
+    let bogus_state = OwnedTurnState {
+        turn: 0,
+        player1_position: Coordinates::new(0, 0),
+        player2_position: Coordinates::new(4, 4),
+        player1_score: 0.0,
+        player2_score: 0.0,
+        player1_mud_turns: 0,
+        player2_mud_turns: 0,
+        cheese: vec![Coordinates::new(2, 2)],
+        player1_last_move: Direction::Stay,
+        player2_last_move: Direction::Stay,
+    };
+    player
+        .send(HostMsg::FullState {
+            match_config: sample_match_config(),
+            turn_state: Box::new(bogus_state),
+        })
+        .await
+        .unwrap();
+
+    let err = timeout(Duration::from_secs(1), player.recv())
+        .await
+        .expect("recv timed out")
+        .expect_err("expected protocol error");
+    match err {
+        PlayerError::ProtocolError(msg) => {
+            assert!(msg.contains("FullState received while Synced"), "msg={msg}");
+            assert!(msg.contains("player=Player1"), "msg={msg}");
+        },
+        other => panic!("expected ProtocolError, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn protocol_error_go_preprocess_while_syncing() {
+    let mut player = EmbeddedPlayer::new(StayBot, identity(), EventSink::noop());
+    let hash0 = walk_through_setup(&mut player).await;
+
+    // Walk one turn to land in InnerState::Syncing: Go -> Action -> Advance
+    // -> SyncOk. After SyncOk the dispatcher is in Syncing, awaiting Go or
+    // FullState. GoPreprocess is forbidden here.
+    player
+        .send(HostMsg::Go {
+            state_hash: hash0,
+            limits: SearchLimits::default(),
+        })
+        .await
+        .unwrap();
+    match recv_ok(&mut player).await {
+        BotMsg::Action { .. } => {},
+        other => panic!("expected Action, got {other:?}"),
+    }
+
+    // Apply a (Stay, Stay) advance. The post-move local state has turn=1
+    // and its canonical hash is what the bot will compare against.
+    let advanced = OwnedTurnState {
+        turn: 1,
+        player1_position: Coordinates::new(0, 0),
+        player2_position: Coordinates::new(4, 4),
+        player1_score: 0.0,
+        player2_score: 0.0,
+        player1_mud_turns: 0,
+        player2_mud_turns: 0,
+        cheese: vec![Coordinates::new(2, 2)],
+        player1_last_move: Direction::Stay,
+        player2_last_move: Direction::Stay,
+    };
+    let hash1 = HashedTurnState::new(advanced).state_hash();
+    player
+        .send(HostMsg::Advance {
+            p1_dir: Direction::Stay,
+            p2_dir: Direction::Stay,
+            turn: 1,
+            new_hash: hash1,
+        })
+        .await
+        .unwrap();
+    match recv_ok(&mut player).await {
+        BotMsg::SyncOk { .. } => {},
+        other => panic!("expected SyncOk, got {other:?}"),
+    }
+
+    // Dispatcher is Syncing; GoPreprocess from Syncing is a protocol error.
+    player
+        .send(HostMsg::GoPreprocess { state_hash: hash1 })
+        .await
+        .unwrap();
+    let err = timeout(Duration::from_secs(1), player.recv())
+        .await
+        .expect("recv timed out")
+        .expect_err("expected protocol error");
+    match err {
+        PlayerError::ProtocolError(msg) => {
+            assert!(msg.contains("GoPreprocess in state Syncing"), "msg={msg}");
+            assert!(msg.contains("player=Player1"), "msg={msg}");
+            assert!(msg.contains("turn=1"), "msg={msg}");
+        },
+        other => panic!("expected ProtocolError, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn protocol_error_advance_while_thinking() {
+    let mut player = EmbeddedPlayer::new(DelayedBot, identity(), EventSink::noop());
+    let hash = walk_through_setup(&mut player).await;
+
+    player
+        .send(HostMsg::Go {
+            state_hash: hash,
+            limits: SearchLimits::default(),
+        })
+        .await
+        .unwrap();
+
+    // Bot is now sleeping inside spawn_blocking. Send a forbidden Advance
+    // while it works — the dispatcher's watch_for_stop should reject it.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    player
+        .send(HostMsg::Advance {
+            p1_dir: Direction::Stay,
+            p2_dir: Direction::Stay,
+            turn: 1,
+            new_hash: 0,
+        })
+        .await
+        .unwrap();
+
+    let err = timeout(Duration::from_secs(2), player.recv())
+        .await
+        .expect("recv timed out")
+        .expect_err("expected protocol error");
+    match err {
+        PlayerError::ProtocolError(msg) => {
+            assert!(msg.contains("Advance"), "msg={msg}");
+            assert!(msg.contains("bot is working"), "msg={msg}");
+            assert!(msg.contains("player=Player1"), "msg={msg}");
+        },
+        other => panic!("expected ProtocolError, got {other:?}"),
+    }
+
+    // Let the detached blocking bot task finish before the runtime shuts
+    // down. DelayedBot sleeps 100ms; give it headroom.
+    tokio::time::sleep(Duration::from_millis(150)).await;
 }

--- a/server/protocol/src/codec.rs
+++ b/server/protocol/src/codec.rs
@@ -300,7 +300,7 @@ mod tests {
         fbb: &mut FlatBufferBuilder<'_>,
         player: Player,
         multipv: u16,
-        target: Option<(u8, u8)>,
+        target: Option<Coordinates>,
         depth: u16,
         nodes: u32,
         score: Option<f32>,
@@ -319,7 +319,7 @@ mod tests {
         } else {
             Some(fbb.create_vector(pv))
         };
-        let target_v = target.map(|(x, y)| Vec2::new(x, y));
+        let target_v = target.map(|coords| Vec2::new(coords.x, coords.y));
 
         let info = wire::Info::create(
             fbb,
@@ -346,7 +346,7 @@ mod tests {
             &mut fbb,
             Player::Player2,
             3,
-            Some((10, 7)),
+            Some(Coordinates::new(10, 7)),
             5,
             42000,
             Some(2.5),


### PR DESCRIPTION
## Motivation

The host crate is a flat bag of async functions with no ownership model. Setup, playing, and transport all reach into each other's state through raw channels. `stub.rs` has been sitting in the tree as a proof-of-concept in-process bot since before host-restructure started, speaking the host's internal `HostCommand`/`SessionMsg` types rather than any protocol vocabulary.

Host-restructure's foundations have landed upstream: the protocol spec is closed (26/26), the `pyrat-protocol` crate ships the `HostMsg`/`BotMsg` pipe vocabulary, and the `Player` trait is fully specified. This is the first concrete `Player` implementation — the in-process flavor. It unblocks both the Match typestate (which needs a concrete `Player` to drive) and the orchestrator's synthetic-bot scenarios (tests, smoke runs, anything that doesn't want a subprocess).

## Solution

The bot-author surface mirrors the SDK `Bot` trait verbatim so a single mental model covers both runtimes. Under it sits a typestate dispatcher that enforces the protocol lifecycle in the type system where it fits, and falls back to a runtime enum where typestate would fight a message loop.

### Layering

```
Match
  │
  └── Box<dyn Player>              ← trait: send / recv / close / identity
            ▲
            │ impl Player
      EmbeddedPlayer               ← owns pipe + dispatcher, wraps a bot
            │
            └── holds impl EmbeddedBot    ← dependency inversion
                      ▲
                 StayBot / RandomBot / user's own bot
```

`EmbeddedBot` is defined host-side (same method shape as SDK `Bot`: `think`, `preprocess`, `on_game_over` + `Options` supertrait). Keeping it parallel rather than unified avoids a host→sdk dep edge. Unification is tracked as a follow-up when orchestrator needs to run production SDK bots in-process.

### Setup as typestate

The handshake is a linear sequence — typestate is a clean fit:

```rust
Setup<Initial>    ──emit_identify──▶ Setup<Connected>
Setup<Connected>  ──await_welcome──▶ Setup<Identified>
Setup<Identified> ──await_configure_emit_ready──▶ Playing<Synced>
```

Each transition consumes `self` and returns the next type. Skipping or reordering a step is a compile error.

### Playing as double typestate

The `Player<Phase, SyncStatus>` product typestate sketched in `protocol.md` lands here as `Playing<B, Sync>` with `Synced` / `Desynced` markers:

```rust
impl<B> Playing<B, Synced> { async fn next_event(self) -> Result<Event<B>, _>; }

impl<B> Playing<B, Desynced> {
    // Only one method — calling emit_action or emit_sync_ok is a compile error.
    async fn recover(self) -> Result<Playing<B, Synced>, _>;
}
```

`protocol.md`'s *"client refuses to proceed when desynced"* is now a compile-time property, not a runtime check.

### Inner loop as runtime enum

Inside `Playing<Synced>`, the step states (Idle / Preprocessing / Syncing / Thinking) live as a runtime enum. Typestate inside a message-driven loop collapses back to `match state { ... }` anyway — use the language where it helps, step aside where it doesn't.

### Dispatcher

`bot.think` / `bot.preprocess` run on `spawn_blocking` while a `select!` races the blocking handle against `host_rx` for concurrent `Stop` messages. Stop flips a shared `AtomicBool` that `EmbeddedCtx::should_stop()` exposes to the bot. Sideband routing splits by message visibility: `Info` goes straight to the `EventSink` (observer-facing, never inspected by Match); `Provisional` goes through `recv()` (game-driving, Match uses as timeout fallback). Hash verification on `Advance` uses the protocol-canonical `HashedTurnState::new` path: a mismatch transitions `Playing<Synced>` → `Playing<Desynced>` and emits `Resync`.

### Scope and follow-ups

`stub.rs` is **not** deleted on this branch. The initial plan had it scheduled for removal, but `gui/src-tauri/match_runner.rs` and `tools/bot-check/src/check.rs` still depend on `spawn_stub_bot`. Migrating those consumers to `EmbeddedPlayer` is follow-up work. No public API changes to existing crates — this is additive.

## Test Plan

- `cargo test -p pyrat-host` — 61 lib tests (up from 58 on main: +3 new setup / Advance / unexpected-message tests) plus 7 integration tests in `tests/embedded_player.rs`:
  - happy path through `Identify → Welcome → Configure → Ready → GoPreprocess → Go → Action → GameOver`
  - Info sideband routes to `EventSink`, not through `recv()`
  - Desync path: wrong-hash `Advance` → `Resync`, `FullState` → `SyncOk`
  - Cooperative stop: `SpinBot` polls `should_stop`, `Stop` mid-think returns early
  - `GoState` overrides the local mirror (verified via a turn-sensitive bot)
  - Clean close semantics and `ProtocolError` propagation
- `cargo clippy -p pyrat-host --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- Zero regressions in existing test files (session, game_loop, launch — all untouched).