### PR TITLE
Drop Owned* prefix from pyrat-protocol types

### DIFF
--- a/gui/src-tauri/src/commands.rs
+++ b/gui/src-tauri/src/commands.rs
@@ -183,7 +183,7 @@ pub struct MazeState {
 /// Convert engine GameState to our serializable MazeState.
 pub fn build_maze_state(game: &GameState) -> MazeState {
     use pyrat::{Coordinates, Direction as EngineDirection};
-    use pyrat_host::game_loop::{HashedTurnState, OwnedTurnState};
+    use pyrat_host::game_loop::{HashedTurnState, TurnState};
 
     let walls = game
         .wall_entries()
@@ -211,7 +211,7 @@ pub fn build_maze_state(game: &GameState) -> MazeState {
         .collect();
 
     // Compute state_hash for the initial position (last moves are Stay/Stay).
-    let hts = HashedTurnState::new(OwnedTurnState {
+    let hts = HashedTurnState::new(TurnState {
         turn: game.turns(),
         player1_position: game.player1_position(),
         player2_position: game.player2_position(),

--- a/gui/src-tauri/src/match_runner.rs
+++ b/gui/src-tauri/src/match_runner.rs
@@ -9,9 +9,8 @@ use tracing::{debug, info, warn};
 use pyrat::game::game_logic::GameState;
 use pyrat::{Coordinates, Direction as EngineDirection};
 use pyrat_host::game_loop::{
-    build_owned_match_config, determine_result, run_playing, run_setup, HashedTurnState,
-    MatchEvent, MatchSetup, OwnedInfo, OwnedTurnState, PlayerEntry, PlayingConfig, PlayingState,
-    SetupTiming,
+    build_match_config, determine_result, run_playing, run_setup, HashedTurnState, Info,
+    MatchEvent, MatchSetup, PlayerEntry, PlayingConfig, PlayingState, SetupTiming, TurnState,
 };
 use pyrat_host::session::messages::{HostCommand, SessionId, SessionMsg};
 use pyrat_host::stub::spawn_stub_bot;
@@ -91,7 +90,7 @@ pub async fn run_match(
     // 1. Build match config
     // In step (analysis) mode, use 0 timeout so bots loop on should_stop() indefinitely
     let move_timeout = if cmd_rx.is_some() { 0 } else { 3000 };
-    let match_config = build_owned_match_config(&game, TimingMode::Wait, move_timeout, 10000);
+    let match_config = build_match_config(&game, TimingMode::Wait, move_timeout, 10000);
 
     let mut bot_options: HashMap<String, Vec<(String, String)>> = HashMap::new();
     if !p1.options.is_empty() {
@@ -400,7 +399,7 @@ async fn run_analysis_inner(
 
 /// Build a HashedTurnState from an arbitrary game-tree position (cursor-follows-analysis).
 fn build_turn_state_from_position(pos: AnalysisPosition) -> HashedTurnState {
-    HashedTurnState::new(OwnedTurnState {
+    HashedTurnState::new(TurnState {
         turn: pos.turn,
         player1_position: Coordinates::new(pos.player1.position.x, pos.player1.position.y),
         player2_position: Coordinates::new(pos.player2.position.x, pos.player2.position.y),
@@ -697,7 +696,7 @@ fn build_bot_info_event(
     sender: Player,
     turn: u16,
     state_hash: u64,
-    info: &OwnedInfo,
+    info: &Info,
 ) -> BotInfoEvent {
     BotInfoEvent {
         match_id,

--- a/sdk/bot-api/src/lib.rs
+++ b/sdk/bot-api/src/lib.rs
@@ -13,4 +13,4 @@ pub mod options;
 pub use context::{BotContext, InfoSender, InfoSink};
 pub use info::InfoParams;
 pub use options::Options;
-pub use pyrat_protocol::OwnedOptionDef;
+pub use pyrat_protocol::OptionDef;

--- a/sdk/bot-api/src/options.rs
+++ b/sdk/bot-api/src/options.rs
@@ -6,7 +6,7 @@
 /// Bots with options: `#[derive(Options)]` on the struct.
 pub trait Options {
     /// Declare configurable options.
-    fn option_defs(&self) -> Vec<pyrat_protocol::OwnedOptionDef> {
+    fn option_defs(&self) -> Vec<pyrat_protocol::OptionDef> {
         vec![]
     }
 

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -650,7 +650,7 @@ mod tests {
     /// With the fix: think() sees the game is over and exits immediately.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn turn_state_does_not_clobber_game_over_stopped_flag() {
-        use pyrat_protocol::{HashedTurnState, OwnedGameOver, OwnedMatchConfig, OwnedTurnState};
+        use pyrat_protocol::{GameOver, HashedTurnState, MatchConfig, TurnState};
         use std::sync::atomic::AtomicU32;
 
         // Bot that spins in think(), counting iterations until should_stop().
@@ -671,7 +671,7 @@ mod tests {
         }
 
         // Minimal game state with a short move timeout.
-        let cfg = OwnedMatchConfig {
+        let cfg = MatchConfig {
             width: 3,
             height: 3,
             max_turns: 10,
@@ -702,7 +702,7 @@ mod tests {
         // TurnState followed immediately by GameOver.
         msg_tx
             .send(HostMsg::TurnState(HashedTurnState::with_unverified_hash(
-                OwnedTurnState {
+                TurnState {
                     turn: 2,
                     player1_position: pyrat::Coordinates::new(0, 0),
                     player2_position: pyrat::Coordinates::new(2, 2),
@@ -719,7 +719,7 @@ mod tests {
             .unwrap();
 
         msg_tx
-            .send(HostMsg::GameOver(OwnedGameOver {
+            .send(HostMsg::GameOver(GameOver {
                 result: GameResult::Draw,
                 player1_score: 0.0,
                 player2_score: 0.0,

--- a/sdk/rust/src/options.rs
+++ b/sdk/rust/src/options.rs
@@ -5,5 +5,5 @@
 
 pub use pyrat_bot_api::Options;
 
-/// Owned option definition sent during Identify.
-pub type SdkOptionDef = pyrat_protocol::OwnedOptionDef;
+/// Option definition sent during Identify.
+pub type SdkOptionDef = pyrat_protocol::OptionDef;

--- a/sdk/rust/src/state.rs
+++ b/sdk/rust/src/state.rs
@@ -12,9 +12,9 @@ use pyrat_engine_interface::GameView;
 use pyrat_wire::Player;
 
 use crate::GameSim;
-use pyrat_protocol::{HashedTurnState, OwnedMatchConfig, OwnedTurnState};
+use pyrat_protocol::{HashedTurnState, MatchConfig, TurnState};
 
-/// SDK-facing game state. Built once from `OwnedMatchConfig`, updated each turn.
+/// SDK-facing game state. Built once from `MatchConfig`, updated each turn.
 pub struct GameState {
     view: GameView,
     my_player: Player,
@@ -41,7 +41,7 @@ pub struct GameState {
 
 impl GameState {
     /// Build from match configuration received during setup.
-    pub fn from_config(cfg: &OwnedMatchConfig) -> Result<Self, String> {
+    pub fn from_config(cfg: &MatchConfig) -> Result<Self, String> {
         let walls: Vec<(Coordinates, Coordinates)> = cfg.walls.clone();
         let mud: Vec<(Coordinates, Coordinates, u8)> =
             cfg.mud.iter().map(|m| (m.pos1, m.pos2, m.turns)).collect();
@@ -229,7 +229,7 @@ impl GameState {
     /// Delegates to `HashedTurnState::new` so the hash algorithm is defined in
     /// one place. The SDK uses this to verify agreement with the host.
     pub fn compute_initial_hash(&self) -> u64 {
-        let ts = OwnedTurnState {
+        let ts = TurnState {
             turn: 0,
             player1_position: self.player1_position,
             player2_position: self.player2_position,
@@ -331,11 +331,11 @@ impl GameState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pyrat_protocol::OwnedTurnState;
+    use pyrat_protocol::TurnState;
     use pyrat_wire::TimingMode;
 
-    fn test_config() -> OwnedMatchConfig {
-        OwnedMatchConfig {
+    fn test_config() -> MatchConfig {
+        MatchConfig {
             width: 5,
             height: 5,
             max_turns: 300,
@@ -353,7 +353,7 @@ mod tests {
 
     fn test_turn_state() -> HashedTurnState {
         HashedTurnState::with_unverified_hash(
-            OwnedTurnState {
+            TurnState {
                 turn: 5,
                 player1_position: Coordinates::new(1, 1),
                 player2_position: Coordinates::new(3, 3),
@@ -374,7 +374,7 @@ mod tests {
         let cfg = test_config();
         let state = GameState::from_config(&cfg).unwrap();
 
-        let expected = HashedTurnState::new(OwnedTurnState {
+        let expected = HashedTurnState::new(TurnState {
             turn: 0,
             player1_position: cfg.player1_start,
             player2_position: cfg.player2_start,
@@ -504,7 +504,7 @@ mod tests {
 
         // Simulate mid-game: one cheese collected, player has some score
         state.update(HashedTurnState::with_unverified_hash(
-            OwnedTurnState {
+            TurnState {
                 turn: 10,
                 player1_position: Coordinates::new(2, 2),
                 player2_position: Coordinates::new(0, 0),

--- a/sdk/rust/src/wire.rs
+++ b/sdk/rust/src/wire.rs
@@ -10,7 +10,7 @@ use pyrat_protocol::{
 };
 use pyrat_wire::{self as wire, BotMessage, HostMessage, Vec2};
 
-// ── Owned extraction types ───────────────────────────
+// ── Extracted host messages ──────────────────────────
 
 /// Parsed host message.
 #[derive(Debug)]

--- a/sdk/rust/src/wire.rs
+++ b/sdk/rust/src/wire.rs
@@ -6,7 +6,7 @@
 use flatbuffers::FlatBufferBuilder;
 use pyrat_protocol::{
     engine_to_wire_direction, extract_game_over, extract_match_config, extract_turn_state,
-    wire_to_engine_direction, HashedTurnState, OwnedGameOver, OwnedMatchConfig,
+    wire_to_engine_direction, GameOver, HashedTurnState, MatchConfig,
 };
 use pyrat_wire::{self as wire, BotMessage, HostMessage, Vec2};
 
@@ -17,11 +17,11 @@ use pyrat_wire::{self as wire, BotMessage, HostMessage, Vec2};
 #[allow(dead_code)] // Fields are extracted for completeness; not all are consumed.
 pub enum HostMsg {
     SetOption { name: String, value: String },
-    MatchConfig(OwnedMatchConfig),
+    MatchConfig(MatchConfig),
     StartPreprocessing { state_hash: u64 },
     TurnState(HashedTurnState),
     Timeout { default_move: pyrat::Direction },
-    GameOver(OwnedGameOver),
+    GameOver(GameOver),
     Ping,
     Stop,
 }

--- a/server/headless/src/main.rs
+++ b/server/headless/src/main.rs
@@ -11,7 +11,7 @@ use tracing::{info, info_span, warn, Instrument};
 use pyrat::game::builder::GameConfig;
 
 use pyrat_host::game_loop::{
-    accept_connections, build_owned_match_config, launch_bots, run_playing, run_setup, BotConfig,
+    accept_connections, build_match_config, launch_bots, run_playing, run_setup, BotConfig,
     MatchEvent, MatchResult, MatchSetup, PlayerEntry, PlayingConfig, SetupTiming,
 };
 use pyrat_host::session::messages::SessionMsg;
@@ -229,7 +229,7 @@ async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // 2. Build match config
-    let match_config = build_owned_match_config(
+    let match_config = build_match_config(
         &game,
         TimingMode::Wait,
         cli.move_timeout_ms,

--- a/server/host/src/game_loop/config.rs
+++ b/server/host/src/game_loop/config.rs
@@ -6,7 +6,7 @@ use tokio::sync::mpsc;
 
 use crate::session::messages::HostCommand;
 use crate::session::SessionId;
-use pyrat_protocol::{MudEntry, OwnedMatchConfig};
+use pyrat_protocol::{MatchConfig, MudEntry};
 use pyrat_wire::{Player, TimingMode};
 
 /// Which player a bot controls, identified by agent_id.
@@ -92,22 +92,22 @@ pub struct MatchSetup {
     pub players: Vec<PlayerEntry>,
     /// Game config sent to bots. `controlled_players` left empty;
     /// the setup phase fills it per session.
-    pub match_config: OwnedMatchConfig,
+    pub match_config: MatchConfig,
     /// Options to set per bot, keyed by agent_id.
     pub bot_options: HashMap<String, Vec<(String, String)>>,
     /// Setup phase timeouts.
     pub timing: SetupTiming,
 }
 
-/// Build an `OwnedMatchConfig` from engine state + timing parameters.
+/// Build a `MatchConfig` from engine state + timing parameters.
 ///
 /// `controlled_players` is left empty — the setup phase fills it per session.
-pub fn build_owned_match_config(
+pub fn build_match_config(
     game: &GameState,
     timing: TimingMode,
     move_timeout_ms: u32,
     preprocessing_timeout_ms: u32,
-) -> OwnedMatchConfig {
+) -> MatchConfig {
     let walls = game
         .wall_entries()
         .into_iter()
@@ -125,7 +125,7 @@ pub fn build_owned_match_config(
 
     let cheese = game.cheese_positions();
 
-    OwnedMatchConfig {
+    MatchConfig {
         width: game.width(),
         height: game.height(),
         max_turns: game.max_turns(),
@@ -148,7 +148,7 @@ mod tests {
     use pyrat::{Coordinates, GameBuilder};
 
     #[test]
-    fn build_owned_match_config_round_trips_game_state() {
+    fn build_match_config_round_trips_game_state() {
         let game = GameBuilder::new(3, 3)
             .with_open_maze()
             .with_custom_positions(Coordinates::new(0, 0), Coordinates::new(2, 2))
@@ -157,7 +157,7 @@ mod tests {
             .create(Some(42))
             .unwrap();
 
-        let cfg = build_owned_match_config(&game, TimingMode::Wait, 500, 3000);
+        let cfg = build_match_config(&game, TimingMode::Wait, 500, 3000);
 
         assert_eq!(cfg.width, 3);
         assert_eq!(cfg.height, 3);
@@ -176,10 +176,10 @@ mod tests {
     }
 
     #[test]
-    fn build_owned_match_config_extracts_walls_and_mud() {
+    fn build_match_config_extracts_walls_and_mud() {
         let game = GameConfig::classic(7, 5, 3).create(Some(42)).unwrap();
 
-        let cfg = build_owned_match_config(&game, TimingMode::Wait, 500, 3000);
+        let cfg = build_match_config(&game, TimingMode::Wait, 500, 3000);
 
         assert_eq!(cfg.width, 7);
         assert_eq!(cfg.height, 5);

--- a/server/host/src/game_loop/events.rs
+++ b/server/host/src/game_loop/events.rs
@@ -9,7 +9,7 @@ use tracing::warn;
 
 use crate::session::messages::DisconnectReason;
 use pyrat::Direction;
-use pyrat_protocol::{HashedTurnState, OwnedInfo, OwnedMatchConfig};
+use pyrat_protocol::{HashedTurnState, Info, MatchConfig};
 use pyrat_wire::Player;
 
 use super::playing::MatchResult;
@@ -30,7 +30,7 @@ pub enum MatchEvent {
     /// All bots connected, identified, configured, and preprocessed.
     SetupComplete,
     /// The match is starting — includes the resolved match configuration.
-    MatchStarted { config: OwnedMatchConfig },
+    MatchStarted { config: MatchConfig },
 
     // ── Playing ──────────────────────────────────
     /// A turn was played and the engine stepped.
@@ -46,7 +46,7 @@ pub enum MatchEvent {
         sender: Player,
         turn: u16,
         state_hash: u64,
-        info: OwnedInfo,
+        info: Info,
     },
     /// A bot timed out on an action this turn.
     BotTimeout { player: Player, turn: u16 },

--- a/server/host/src/game_loop/mod.rs
+++ b/server/host/src/game_loop/mod.rs
@@ -8,7 +8,7 @@ mod slots;
 
 pub use crate::session::messages::DisconnectReason;
 pub use config::{
-    build_owned_match_config, BotConfig, MatchSetup, PlayerEntry, PlayingConfig, SessionHandle,
+    build_match_config, BotConfig, MatchSetup, PlayerEntry, PlayingConfig, SessionHandle,
     SetupTiming,
 };
 pub use events::MatchEvent;
@@ -18,7 +18,5 @@ pub use playing::{
     TurnOutcome,
 };
 pub use probe::{probe_bot, ProbeError, ProbeResult};
-pub use pyrat_protocol::{
-    HashedTurnState, OwnedInfo, OwnedMatchConfig, OwnedOptionDef, OwnedTurnState,
-};
+pub use pyrat_protocol::{HashedTurnState, Info, MatchConfig, OptionDef, TurnState};
 pub use setup::{accept_connections, run_setup, SetupError, SetupResult};

--- a/server/host/src/game_loop/playing.rs
+++ b/server/host/src/game_loop/playing.rs
@@ -10,7 +10,7 @@ use pyrat::game::game_logic::GameState;
 use pyrat::Direction;
 
 use crate::session::messages::{HostCommand, SessionId, SessionMsg};
-use pyrat_protocol::{HashedTurnState, OwnedInfo, OwnedTurnState};
+use pyrat_protocol::{HashedTurnState, Info, TurnState};
 use pyrat_wire::{GameResult, Player};
 
 use super::config::{PlayingConfig, SessionHandle};
@@ -267,7 +267,7 @@ fn build_turn_state(game: &GameState, last_p1: Direction, last_p2: Direction) ->
     let p2 = &game.player2;
     let hash = game.state_hash();
     HashedTurnState::with_unverified_hash(
-        OwnedTurnState {
+        TurnState {
             turn: game.turn,
             player1_position: p1.current_pos,
             player2_position: p2.current_pos,
@@ -506,7 +506,7 @@ fn handle_info(
     session_players: &HashMap<SessionId, Vec<Player>>,
     event_tx: Option<&mpsc::UnboundedSender<MatchEvent>>,
     session_id: SessionId,
-    info: OwnedInfo,
+    info: Info,
 ) {
     if let Some(players) = session_players.get(&session_id) {
         if let Some(&sender) = players.first() {
@@ -781,7 +781,7 @@ mod tests {
         game_tx
             .send(SessionMsg::Info {
                 session_id: SessionId(1),
-                info: OwnedInfo {
+                info: Info {
                     player: Player::Player1,
                     multipv: 1,
                     target: None,
@@ -1063,7 +1063,7 @@ mod tests {
         game_tx
             .send(SessionMsg::Info {
                 session_id: SessionId(1),
-                info: OwnedInfo {
+                info: Info {
                     player: Player::Player1,
                     multipv: 1,
                     target: None,
@@ -1145,8 +1145,8 @@ mod tests {
     use pyrat_protocol::HashedTurnState;
 
     /// Helper: baseline state for hash distinctness tests.
-    fn baseline_turn_state() -> OwnedTurnState {
-        OwnedTurnState {
+    fn baseline_turn_state() -> TurnState {
+        TurnState {
             turn: 5,
             player1_position: Coordinates::new(1, 2),
             player2_position: Coordinates::new(3, 4),
@@ -1167,80 +1167,80 @@ mod tests {
         let base_hash = HashedTurnState::new(base.clone()).state_hash();
         assert_ne!(base_hash, 0, "hash should not be zero");
 
-        let cases: Vec<(&str, OwnedTurnState)> = vec![
+        let cases: Vec<(&str, TurnState)> = vec![
             (
                 "turn +1",
-                OwnedTurnState {
+                TurnState {
                     turn: 6,
                     ..base.clone()
                 },
             ),
             (
                 "p1 position",
-                OwnedTurnState {
+                TurnState {
                     player1_position: Coordinates::new(2, 2),
                     ..base.clone()
                 },
             ),
             (
                 "p2 position",
-                OwnedTurnState {
+                TurnState {
                     player2_position: Coordinates::new(3, 5),
                     ..base.clone()
                 },
             ),
             (
                 "p1 score +0.5",
-                OwnedTurnState {
+                TurnState {
                     player1_score: 2.5,
                     ..base.clone()
                 },
             ),
             (
                 "p2 score +0.5",
-                OwnedTurnState {
+                TurnState {
                     player2_score: 2.0,
                     ..base.clone()
                 },
             ),
             (
                 "p1 mud +1",
-                OwnedTurnState {
+                TurnState {
                     player1_mud_turns: 1,
                     ..base.clone()
                 },
             ),
             (
                 "p2 mud +1",
-                OwnedTurnState {
+                TurnState {
                     player2_mud_turns: 1,
                     ..base.clone()
                 },
             ),
             (
                 "one less cheese",
-                OwnedTurnState {
+                TurnState {
                     cheese: vec![Coordinates::new(5, 5)],
                     ..base.clone()
                 },
             ),
             (
                 "cheese offset by 1",
-                OwnedTurnState {
+                TurnState {
                     cheese: vec![Coordinates::new(5, 6), Coordinates::new(10, 7)],
                     ..base.clone()
                 },
             ),
             (
                 "p1 last move",
-                OwnedTurnState {
+                TurnState {
                     player1_last_move: Direction::Right,
                     ..base.clone()
                 },
             ),
             (
                 "p2 last move",
-                OwnedTurnState {
+                TurnState {
                     player2_last_move: Direction::Left,
                     ..base.clone()
                 },
@@ -1265,7 +1265,7 @@ mod tests {
     #[test]
     fn swapped_players_produce_different_hash() {
         let base = baseline_turn_state();
-        let swapped = OwnedTurnState {
+        let swapped = TurnState {
             player1_position: base.player2_position,
             player2_position: base.player1_position,
             player1_score: base.player2_score,

--- a/server/host/src/game_loop/probe.rs
+++ b/server/host/src/game_loop/probe.rs
@@ -5,7 +5,7 @@ use tokio::net::TcpListener;
 use tracing::debug;
 
 use crate::session::{extract_bot_packet, BotPayload};
-use pyrat_protocol::OwnedOptionDef;
+use pyrat_protocol::OptionDef;
 use pyrat_wire::framing::FrameReader;
 
 use super::config::BotConfig;
@@ -19,7 +19,7 @@ pub struct ProbeResult {
     pub name: String,
     pub author: String,
     pub agent_id: String,
-    pub options: Vec<OwnedOptionDef>,
+    pub options: Vec<OptionDef>,
 }
 
 /// What can go wrong when probing a bot.

--- a/server/host/src/game_loop/setup.rs
+++ b/server/host/src/game_loop/setup.rs
@@ -8,7 +8,7 @@ use tracing::{debug, info, info_span, warn, Instrument};
 
 use crate::session::messages::HostCommand;
 use crate::session::{run_session, SessionConfig, SessionId, SessionMsg};
-use pyrat_protocol::{HashedTurnState, OwnedTurnState};
+use pyrat_protocol::{HashedTurnState, TurnState};
 
 use pyrat_wire::Player;
 
@@ -247,7 +247,7 @@ pub async fn run_setup(
     // Compute the initial state hash from match_config. Sent to bots via
     // StartPreprocessing so they can use it on preprocessing Info frames.
     // Must match the hash the GUI stores on the root node.
-    let initial_state_hash = HashedTurnState::new(OwnedTurnState {
+    let initial_state_hash = HashedTurnState::new(TurnState {
         turn: 0,
         player1_position: setup.match_config.player1_start,
         player2_position: setup.match_config.player2_start,

--- a/server/host/src/player/embedded.rs
+++ b/server/host/src/player/embedded.rs
@@ -27,7 +27,7 @@ use std::time::{Duration, Instant};
 use pyrat::{Coordinates, Direction, GameBuilder, GameState, MudMap};
 use pyrat_bot_api::{BotContext, InfoParams, InfoSink, Options};
 use pyrat_protocol::{
-    BotMsg, HashedTurnState, HostMsg, OwnedInfo, OwnedMatchConfig, OwnedTurnState, SearchLimits,
+    BotMsg, HashedTurnState, HostMsg, Info, MatchConfig, SearchLimits, TurnState,
 };
 use pyrat_wire::{GameResult, Player as PlayerSlot};
 use tokio::sync::mpsc;
@@ -203,7 +203,7 @@ fn emit_bot_info(
     turn: u16,
     state_hash: u64,
 ) {
-    let info = OwnedInfo {
+    let info = Info {
         player: params.player,
         multipv: params.multipv,
         target: params.target,
@@ -588,10 +588,10 @@ struct Playing<B, S> {
     bot: Option<B>,
     core: DispatcherCore,
     player_slot: PlayerSlot,
-    match_config: Box<OwnedMatchConfig>,
+    match_config: Box<MatchConfig>,
     /// Local engine state mirror. Authoritative for the client's view.
     game: GameState,
-    /// Last moves applied (for `OwnedTurnState::player{1,2}_last_move`).
+    /// Last moves applied (for `TurnState::player{1,2}_last_move`).
     last_moves: (Direction, Direction),
     state: S,
 }
@@ -738,7 +738,7 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
     /// as usual.
     async fn handle_go_state(
         mut self,
-        turn_state: OwnedTurnState,
+        turn_state: TurnState,
         state_hash: u64,
         limits: SearchLimits,
     ) -> Result<Event<B>, PlayerError> {
@@ -895,7 +895,7 @@ impl<B: EmbeddedBot> Playing<B, Synced> {
         think_start: Instant,
         deadline: Option<Instant>,
     ) -> (HashedTurnState, EmbeddedCtx) {
-        let hts = HashedTurnState::new(owned_turn_state_from_game(&self.game, self.last_moves));
+        let hts = HashedTurnState::new(turn_state_from_game(&self.game, self.last_moves));
         let ctx = EmbeddedCtx {
             event_sink: self.core.event_sink.clone(),
             bot_tx: self.core.bot_tx.clone(),
@@ -959,8 +959,8 @@ impl<B: EmbeddedBot> Playing<B, Desynced> {
 
 // ── State mirror helpers ──────────────────────────────
 
-/// Construct an engine `GameState` from an `OwnedMatchConfig`.
-fn build_engine_state(cfg: &OwnedMatchConfig) -> Result<GameState, PlayerError> {
+/// Construct an engine `GameState` from a `MatchConfig`.
+fn build_engine_state(cfg: &MatchConfig) -> Result<GameState, PlayerError> {
     let mut walls: HashMap<Coordinates, Vec<Coordinates>> = HashMap::new();
     for (a, b) in &cfg.walls {
         walls.entry(*a).or_default().push(*b);
@@ -983,10 +983,7 @@ fn build_engine_state(cfg: &OwnedMatchConfig) -> Result<GameState, PlayerError> 
 
 /// Rebuild the engine state to match an injected turn state (GoState or
 /// FullState recovery).
-fn rebuild_engine_state(
-    cfg: &OwnedMatchConfig,
-    ts: &OwnedTurnState,
-) -> Result<GameState, PlayerError> {
+fn rebuild_engine_state(cfg: &MatchConfig, ts: &TurnState) -> Result<GameState, PlayerError> {
     let mut game = build_engine_state(cfg)?;
     game.turn = ts.turn;
     game.player1.current_pos = ts.player1_position;
@@ -1007,18 +1004,15 @@ fn rebuild_engine_state(
 }
 
 /// Hash a `GameState` via the protocol-canonical path: derive
-/// `OwnedTurnState`, wrap in `HashedTurnState::new()` (DefaultHasher). This
+/// `TurnState`, wrap in `HashedTurnState::new()` (DefaultHasher). This
 /// is the same hashing used for Ready; `Advance` must produce a compatible
 /// hash for desync detection to work.
 fn hash_from_game(game: &GameState, last_p1: Direction, last_p2: Direction) -> u64 {
-    HashedTurnState::new(owned_turn_state_from_game(game, (last_p1, last_p2))).state_hash()
+    HashedTurnState::new(turn_state_from_game(game, (last_p1, last_p2))).state_hash()
 }
 
-fn owned_turn_state_from_game(
-    game: &GameState,
-    last_moves: (Direction, Direction),
-) -> OwnedTurnState {
-    OwnedTurnState {
+fn turn_state_from_game(game: &GameState, last_moves: (Direction, Direction)) -> TurnState {
+    TurnState {
         turn: game.turn,
         player1_position: game.player1.current_pos,
         player2_position: game.player2.current_pos,
@@ -1045,8 +1039,8 @@ mod tests {
         }
     }
 
-    fn sample_match_config() -> Box<pyrat_protocol::OwnedMatchConfig> {
-        Box::new(pyrat_protocol::OwnedMatchConfig {
+    fn sample_match_config() -> Box<pyrat_protocol::MatchConfig> {
+        Box::new(pyrat_protocol::MatchConfig {
             width: 5,
             height: 5,
             max_turns: 100,

--- a/server/host/src/session/codec.rs
+++ b/server/host/src/session/codec.rs
@@ -7,8 +7,7 @@
 use flatbuffers::FlatBufferBuilder;
 
 use pyrat_protocol::{
-    coords_to_vec2, engine_to_wire_direction, extract_info, extract_option_defs, OwnedInfo,
-    OwnedOptionDef,
+    coords_to_vec2, engine_to_wire_direction, extract_info, extract_option_defs, Info, OptionDef,
 };
 
 use crate::session::messages::HostCommand;
@@ -21,7 +20,7 @@ pub enum BotPayload {
     Identify {
         name: String,
         author: String,
-        options: Vec<OwnedOptionDef>,
+        options: Vec<OptionDef>,
         agent_id: String,
     },
     Ready,
@@ -34,7 +33,7 @@ pub enum BotPayload {
         think_ms: u32,
     },
     Pong,
-    Info(OwnedInfo),
+    Info(Info),
     RenderCommands,
 }
 
@@ -247,9 +246,7 @@ pub fn serialize_host_command(fbb: &mut FlatBufferBuilder<'_>, cmd: &HostCommand
 mod tests {
     use super::*;
     use pyrat::Coordinates;
-    use pyrat_protocol::{
-        extract_match_config, HashedTurnState, MudEntry, OwnedMatchConfig, OwnedTurnState,
-    };
+    use pyrat_protocol::{extract_match_config, HashedTurnState, MatchConfig, MudEntry, TurnState};
     use pyrat_wire::{Direction, GameResult, Player, TimingMode};
 
     // Helper: build a BotPacket with Identify
@@ -427,7 +424,7 @@ mod tests {
     #[test]
     fn round_trip_match_config() {
         let mut fbb = FlatBufferBuilder::new();
-        let cfg = OwnedMatchConfig {
+        let cfg = MatchConfig {
             width: 21,
             height: 15,
             max_turns: 300,
@@ -476,7 +473,7 @@ mod tests {
     #[test]
     fn round_trip_turn_state() {
         let mut fbb = FlatBufferBuilder::new();
-        let ts = HashedTurnState::new(OwnedTurnState {
+        let ts = HashedTurnState::new(TurnState {
             turn: 42,
             player1_position: Coordinates::new(10, 7),
             player2_position: Coordinates::new(0, 0),

--- a/server/host/src/session/messages.rs
+++ b/server/host/src/session/messages.rs
@@ -1,6 +1,6 @@
 use tokio::sync::mpsc;
 
-use pyrat_protocol::{HashedTurnState, OwnedInfo, OwnedMatchConfig, OwnedOptionDef};
+use pyrat_protocol::{HashedTurnState, Info, MatchConfig, OptionDef};
 use pyrat_wire::{GameResult, Player};
 
 // ── Session identity ────────────────────────────────
@@ -33,7 +33,7 @@ pub enum SessionMsg {
         session_id: SessionId,
         name: String,
         author: String,
-        options: Vec<OwnedOptionDef>,
+        options: Vec<OptionDef>,
         agent_id: String,
     },
     /// Bot declared itself ready to receive match configuration.
@@ -50,10 +50,7 @@ pub enum SessionMsg {
         think_ms: u32,
     },
     /// Bot sent debug/analysis info (forwarded as-is).
-    Info {
-        session_id: SessionId,
-        info: OwnedInfo,
-    },
+    Info { session_id: SessionId, info: Info },
     /// Session ended (TCP closed, shutdown, or error).
     Disconnected {
         session_id: SessionId,
@@ -85,7 +82,7 @@ pub enum HostCommand {
         name: String,
         value: String,
     },
-    MatchConfig(Box<OwnedMatchConfig>),
+    MatchConfig(Box<MatchConfig>),
     StartPreprocessing {
         state_hash: u64,
     },

--- a/server/host/src/stub.rs
+++ b/server/host/src/stub.rs
@@ -11,7 +11,7 @@ use tracing::debug;
 use crate::session::messages::{HostCommand, SessionMsg};
 use crate::session::SessionId;
 use pyrat::Direction;
-use pyrat_protocol::OwnedInfo;
+use pyrat_protocol::Info;
 use pyrat_wire::Player;
 
 /// The four movement directions (excludes Stay).
@@ -133,7 +133,7 @@ async fn run_stub(
                 let _ = game_tx
                     .send(SessionMsg::Info {
                         session_id,
-                        info: OwnedInfo {
+                        info: Info {
                             player,
                             multipv: 1,
                             target,

--- a/server/host/tests/common/mod.rs
+++ b/server/host/tests/common/mod.rs
@@ -14,7 +14,7 @@ use pyrat_host::session::messages::*;
 use pyrat_host::session::{run_session, SessionConfig, SessionId};
 use pyrat_host::wire::framing::{FrameReader, FrameWriter};
 use pyrat_host::wire::*;
-use pyrat_protocol::OwnedMatchConfig;
+use pyrat_protocol::MatchConfig;
 
 /// Build a framed BotPacket from a closure that builds the inner message.
 pub fn build_bot_frame<F>(msg_type: BotMessage, build_msg: F) -> Vec<u8>
@@ -91,8 +91,8 @@ pub fn action_frame(direction: Direction, player: Player, turn: u16) -> Vec<u8> 
     })
 }
 
-pub fn simple_match_config() -> OwnedMatchConfig {
-    OwnedMatchConfig {
+pub fn simple_match_config() -> MatchConfig {
+    MatchConfig {
         width: 21,
         height: 15,
         max_turns: 300,

--- a/server/host/tests/embedded_player.rs
+++ b/server/host/tests/embedded_player.rs
@@ -15,9 +15,7 @@ use pyrat_host::player::{
     EmbeddedBot, EmbeddedCtx, EmbeddedPlayer, EventSink, InfoParams, Options, Player, PlayerError,
     PlayerIdentity,
 };
-use pyrat_protocol::{
-    BotMsg, HashedTurnState, HostMsg, OwnedMatchConfig, OwnedTurnState, SearchLimits,
-};
+use pyrat_protocol::{BotMsg, HashedTurnState, HostMsg, MatchConfig, SearchLimits, TurnState};
 use pyrat_wire::{GameResult, Player as PlayerSlot, TimingMode};
 use tokio::sync::{mpsc, Notify};
 use tokio::time::timeout;
@@ -32,8 +30,8 @@ fn identity() -> PlayerIdentity {
     }
 }
 
-fn sample_match_config() -> Box<OwnedMatchConfig> {
-    Box::new(OwnedMatchConfig {
+fn sample_match_config() -> Box<MatchConfig> {
+    Box::new(MatchConfig {
         width: 5,
         height: 5,
         max_turns: 100,
@@ -49,11 +47,11 @@ fn sample_match_config() -> Box<OwnedMatchConfig> {
     })
 }
 
-/// Default `OwnedTurnState` matching `sample_match_config`'s layout: players
+/// Default `TurnState` matching `sample_match_config`'s layout: players
 /// at their starting corners, one cheese at (2, 2), no mud, zero scores,
 /// last moves `Stay`. Callers override fields via struct update syntax.
-fn base_turn_state(turn: u16) -> OwnedTurnState {
-    OwnedTurnState {
+fn base_turn_state(turn: u16) -> TurnState {
+    TurnState {
         turn,
         player1_position: Coordinates::new(0, 0),
         player2_position: Coordinates::new(4, 4),
@@ -289,7 +287,7 @@ async fn desync_emits_resync_then_fullstate_recovers() {
 
     // Send a FullState that restores a known position. The bot should emit
     // SyncOk with the hash of that state.
-    let recovery_state = OwnedTurnState {
+    let recovery_state = TurnState {
         player1_position: Coordinates::new(1, 0),
         player1_last_move: Direction::Right,
         ..base_turn_state(1)

--- a/server/host/tests/session_integration.rs
+++ b/server/host/tests/session_integration.rs
@@ -14,7 +14,7 @@ use pyrat_host::session::messages::*;
 use pyrat_host::session::{run_session, SessionConfig};
 use pyrat_host::wire::framing::{FrameReader, FrameWriter};
 use pyrat_host::wire::*;
-use pyrat_protocol::{HashedTurnState, OwnedMatchConfig, OwnedTurnState};
+use pyrat_protocol::{HashedTurnState, MatchConfig, TurnState};
 
 use common::*;
 
@@ -73,7 +73,7 @@ async fn try_recv(rx: &mut mpsc::Receiver<SessionMsg>) -> Option<SessionMsg> {
         .flatten()
 }
 
-fn session_match_config() -> OwnedMatchConfig {
+fn session_match_config() -> MatchConfig {
     let mut cfg = simple_match_config();
     cfg.controlled_players = vec![Player::Player1];
     cfg
@@ -169,7 +169,7 @@ async fn happy_path_full_lifecycle() {
     // 7. Host sends TurnState, bot sends Action
     cmd_tx
         .send(HostCommand::TurnState(Box::new(HashedTurnState::new(
-            OwnedTurnState {
+            TurnState {
                 turn: 1,
                 player1_position: Coordinates::new(20, 14),
                 player2_position: Coordinates::new(0, 0),
@@ -675,7 +675,7 @@ async fn stop_sends_wire_stop_and_session_stays_alive() {
     // Session stays alive — send TurnState after Stop.
     cmd_tx
         .send(HostCommand::TurnState(Box::new(HashedTurnState::new(
-            OwnedTurnState {
+            TurnState {
                 turn: 1,
                 player1_position: Coordinates::new(20, 14),
                 player2_position: Coordinates::new(0, 0),

--- a/server/protocol/src/codec.rs
+++ b/server/protocol/src/codec.rs
@@ -15,8 +15,8 @@ use pyrat::Coordinates;
 use pyrat_wire::{self as wire, Vec2};
 
 use crate::{
-    wire_to_engine_direction, HashedTurnState, MudEntry, OwnedGameOver, OwnedInfo,
-    OwnedMatchConfig, OwnedOptionDef, OwnedTurnState,
+    wire_to_engine_direction, GameOver, HashedTurnState, Info, MatchConfig, MudEntry, OptionDef,
+    TurnState,
 };
 
 // ── Coordinate helpers ──────────────────────────────
@@ -45,9 +45,9 @@ pub fn coords_to_vec2(c: Coordinates) -> Vec2 {
 
 // ── Extraction functions ────────────────────────────
 
-/// Extract an [`OwnedMatchConfig`] from a wire `MatchConfig` table.
-pub fn extract_match_config(mc: &wire::MatchConfig<'_>) -> OwnedMatchConfig {
-    OwnedMatchConfig {
+/// Extract a [`MatchConfig`] from a wire `MatchConfig` table.
+pub fn extract_match_config(mc: &wire::MatchConfig<'_>) -> MatchConfig {
+    MatchConfig {
         width: mc.width(),
         height: mc.height(),
         max_turns: mc.max_turns(),
@@ -104,7 +104,7 @@ pub fn extract_match_config(mc: &wire::MatchConfig<'_>) -> OwnedMatchConfig {
 /// SDK's `compute_initial_hash`); per-turn hashes ride along on the wire
 /// after that.
 pub fn extract_turn_state(ts: &wire::TurnState<'_>) -> HashedTurnState {
-    let owned = OwnedTurnState {
+    let owned = TurnState {
         turn: ts.turn(),
         player1_position: vec2_opt(ts.player1_position()),
         player2_position: vec2_opt(ts.player2_position()),
@@ -122,9 +122,9 @@ pub fn extract_turn_state(ts: &wire::TurnState<'_>) -> HashedTurnState {
     HashedTurnState::with_unverified_hash(owned, ts.state_hash())
 }
 
-/// Extract an [`OwnedInfo`] from a wire `Info` table.
-pub fn extract_info(info: &wire::Info<'_>) -> OwnedInfo {
-    OwnedInfo {
+/// Extract an [`Info`] from a wire `Info` table.
+pub fn extract_info(info: &wire::Info<'_>) -> Info {
+    Info {
         player: info.player(),
         multipv: info.multipv(),
         target: info.target().map(vec2_to_coords),
@@ -141,9 +141,9 @@ pub fn extract_info(info: &wire::Info<'_>) -> OwnedInfo {
     }
 }
 
-/// Extract an [`OwnedGameOver`] from a wire `GameOver` table.
-pub fn extract_game_over(go: &wire::GameOver<'_>) -> OwnedGameOver {
-    OwnedGameOver {
+/// Extract a [`GameOver`] from a wire `GameOver` table.
+pub fn extract_game_over(go: &wire::GameOver<'_>) -> GameOver {
+    GameOver {
         result: go.result(),
         player1_score: go.player1_score(),
         player2_score: go.player2_score(),
@@ -153,11 +153,11 @@ pub fn extract_game_over(go: &wire::GameOver<'_>) -> OwnedGameOver {
 /// Extract option definitions from a FlatBuffers vector of `OptionDef` tables.
 pub fn extract_option_defs(
     opts: flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<wire::OptionDef<'_>>>,
-) -> Vec<OwnedOptionDef> {
+) -> Vec<OptionDef> {
     (0..opts.len())
         .map(|i| {
             let o = opts.get(i);
-            OwnedOptionDef {
+            OptionDef {
                 name: o.name().unwrap_or("").to_owned(),
                 option_type: o.type_(),
                 default_value: o.default_value().unwrap_or("").to_owned(),

--- a/server/protocol/src/messages.rs
+++ b/server/protocol/src/messages.rs
@@ -8,14 +8,15 @@
 //! distinct from the host-internal `HostCommand`/`SessionMsg` channel types,
 //! which will eventually be replaced.
 //!
-//! **Status: spec-only.** Not yet consumed by host or SDK. The current host
-//! uses `HostCommand`/`SessionMsg` internally. These enums will be wired in
-//! when the Player trait is implemented.
+//! Consumed today by `EmbeddedPlayer` (in `pyrat-host`) for the in-process
+//! Player trait implementation. The TCP path still uses the legacy
+//! `HostCommand`/`SessionMsg` types in `pyrat-host`; those will be replaced
+//! when `TcpPlayer` lands.
 
 use pyrat::Direction;
 use pyrat_wire::{GameResult, Player};
 
-use crate::{OwnedInfo, OwnedMatchConfig, OwnedOptionDef, OwnedTurnState};
+use crate::{Info, MatchConfig, OptionDef, TurnState};
 
 // ── Search limits ───────────────────────────────────
 
@@ -57,7 +58,7 @@ pub enum HostMsg {
     /// declared none in Identify.
     Configure {
         options: Vec<(String, String)>,
-        match_config: Box<OwnedMatchConfig>,
+        match_config: Box<MatchConfig>,
     },
 
     /// Playing phase: begin preprocessing.
@@ -100,7 +101,7 @@ pub enum HostMsg {
     /// prior Advance/SyncOk exchange needed. Used for analysis mode (GUI sends
     /// arbitrary position), restart, and reconnection recovery.
     GoState {
-        turn_state: Box<OwnedTurnState>,
+        turn_state: Box<TurnState>,
         state_hash: u64,
         limits: SearchLimits,
     },
@@ -120,8 +121,8 @@ pub enum HostMsg {
     /// is preserved: recovery returns to where the client was, not back to
     /// the start.
     FullState {
-        match_config: Box<OwnedMatchConfig>,
-        turn_state: Box<OwnedTurnState>,
+        match_config: Box<MatchConfig>,
+        turn_state: Box<TurnState>,
     },
 
     /// Any phase: protocol violation, followed by disconnect.
@@ -161,7 +162,7 @@ pub enum BotMsg {
         name: String,
         author: String,
         agent_id: String,
-        options: Vec<OwnedOptionDef>,
+        options: Vec<OptionDef>,
     },
 
     /// Lobby phase: ready with state hash (initial sync).
@@ -225,7 +226,7 @@ pub enum BotMsg {
     /// inspecting contents. Tagged with `state_hash` for correlation with
     /// the game state being analyzed. Valid during both Preprocessing and
     /// Thinking.
-    Info(OwnedInfo),
+    Info(Info),
 
     /// Playing phase: render commands for GUI visualization (sideband).
     ///

--- a/server/protocol/src/types.rs
+++ b/server/protocol/src/types.rs
@@ -1,8 +1,8 @@
-//! Owned protocol types extracted from FlatBuffers messages.
+//! Protocol types extracted from FlatBuffers messages.
 //!
-//! These types are the canonical representations of protocol data. Both the host
-//! and SDK use them. The codec (in the host or SDK) converts between FlatBuffers
-//! wire format and these owned types at the boundary.
+//! These types are the canonical representations of protocol data, shared by
+//! the host and SDK. The [`crate::codec`] module converts between FlatBuffers
+//! wire format and these types at the boundary.
 //!
 //! All position and direction fields use engine types (`Coordinates`, `Direction`).
 //! The codec is the only place that touches wire representations.
@@ -47,7 +47,7 @@ pub fn engine_to_wire_direction(d: Direction) -> pyrat_wire::Direction {
 /// Bots declare these in their Identify message to advertise knobs the host
 /// or GUI can set before the match starts. Mirrors UCI option declarations.
 #[derive(Debug, Clone)]
-pub struct OwnedOptionDef {
+pub struct OptionDef {
     pub name: String,
     pub option_type: OptionType,
     pub default_value: String,
@@ -63,7 +63,7 @@ pub struct OwnedOptionDef {
 /// Tagged with player, turn, and state_hash for correlation. The host
 /// forwards these to the event stream without inspecting them.
 #[derive(Debug, Clone)]
-pub struct OwnedInfo {
+pub struct Info {
     pub player: Player,
     pub multipv: u16,
     pub target: Option<Coordinates>,
@@ -92,7 +92,7 @@ pub struct MudEntry {
 /// Contains the maze layout, player positions, cheese, timing, and
 /// which players this connection controls.
 #[derive(Debug, Clone)]
-pub struct OwnedMatchConfig {
+pub struct MatchConfig {
     pub width: u8,
     pub height: u8,
     pub max_turns: u16,
@@ -111,7 +111,7 @@ pub struct OwnedMatchConfig {
 
 /// Game-over result data sent to bots at the end of a match.
 #[derive(Debug, Clone)]
-pub struct OwnedGameOver {
+pub struct GameOver {
     pub result: GameResult,
     pub player1_score: f32,
     pub player2_score: f32,
@@ -125,7 +125,7 @@ pub struct OwnedGameOver {
 /// which is a derived value. Use [`HashedTurnState`] to pair a turn state with
 /// a fingerprint of its fields.
 #[derive(Debug, Clone)]
-pub struct OwnedTurnState {
+pub struct TurnState {
     pub turn: u16,
     pub player1_position: Coordinates,
     pub player2_position: Coordinates,
@@ -138,7 +138,7 @@ pub struct OwnedTurnState {
     pub player2_last_move: Direction,
 }
 
-/// An [`OwnedTurnState`] paired with a 64-bit fingerprint of its
+/// An [`TurnState`] paired with a 64-bit fingerprint of its
 /// position-defining fields.
 ///
 /// The hash is computed once at construction time. Two states that a bot would
@@ -146,13 +146,13 @@ pub struct OwnedTurnState {
 /// it's a correlation tag, not a trust boundary.
 #[derive(Debug, Clone)]
 pub struct HashedTurnState {
-    inner: OwnedTurnState,
+    inner: TurnState,
     state_hash: u64,
 }
 
 impl HashedTurnState {
     /// Wrap a turn state, computing the hash from its fields.
-    pub fn new(ts: OwnedTurnState) -> Self {
+    pub fn new(ts: TurnState) -> Self {
         let state_hash = Self::compute_hash(&ts);
         Self {
             inner: ts,
@@ -167,7 +167,7 @@ impl HashedTurnState {
     /// wrapper does not verify this. Name chosen to advertise the trust:
     /// mismatches are only caught by the setup-phase hash handshake in
     /// consumers.
-    pub fn with_unverified_hash(ts: OwnedTurnState, state_hash: u64) -> Self {
+    pub fn with_unverified_hash(ts: TurnState, state_hash: u64) -> Self {
         Self {
             inner: ts,
             state_hash,
@@ -182,15 +182,15 @@ impl HashedTurnState {
     /// Consume the wrapper and return the inner turn state.
     ///
     /// Use `state_hash()` before calling this if you need the hash.
-    pub fn into_inner(self) -> OwnedTurnState {
+    pub fn into_inner(self) -> TurnState {
         self.inner
     }
 
     /// Deterministic hash of all game-position fields.
     ///
     /// Two states that a bot would analyze differently must hash differently.
-    /// If you add a field to [`OwnedTurnState`], update this function.
-    fn compute_hash(ts: &OwnedTurnState) -> u64 {
+    /// If you add a field to [`TurnState`], update this function.
+    fn compute_hash(ts: &TurnState) -> u64 {
         let mut h = std::collections::hash_map::DefaultHasher::new();
         ts.turn.hash(&mut h);
         ts.player1_position.hash(&mut h);
@@ -208,9 +208,9 @@ impl HashedTurnState {
 }
 
 impl Deref for HashedTurnState {
-    type Target = OwnedTurnState;
+    type Target = TurnState;
 
-    fn deref(&self) -> &OwnedTurnState {
+    fn deref(&self) -> &TurnState {
         &self.inner
     }
 }
@@ -219,8 +219,8 @@ impl Deref for HashedTurnState {
 mod tests {
     use super::*;
 
-    fn sample_turn_state() -> OwnedTurnState {
-        OwnedTurnState {
+    fn sample_turn_state() -> TurnState {
+        TurnState {
             turn: 42,
             player1_position: Coordinates::new(10, 7),
             player2_position: Coordinates::new(0, 0),

--- a/server/protocol/src/types.rs
+++ b/server/protocol/src/types.rs
@@ -138,7 +138,7 @@ pub struct TurnState {
     pub player2_last_move: Direction,
 }
 
-/// An [`TurnState`] paired with a 64-bit fingerprint of its
+/// A [`TurnState`] paired with a 64-bit fingerprint of its
 /// position-defining fields.
 ///
 /// The hash is computed once at construction time. Two states that a bot would

--- a/tools/bot-check/src/check.rs
+++ b/tools/bot-check/src/check.rs
@@ -7,7 +7,7 @@ use tokio::sync::mpsc;
 
 use pyrat::game::builder::GameConfig;
 use pyrat_host::game_loop::{
-    accept_connections, build_owned_match_config, launch_bots, run_one_turn, run_setup, BotConfig,
+    accept_connections, build_match_config, launch_bots, run_one_turn, run_setup, BotConfig,
     MatchEvent, MatchSetup, PlayerEntry, PlayingConfig, PlayingState, SetupTiming, TurnOutcome,
 };
 use pyrat_host::session::messages::SessionMsg;
@@ -147,7 +147,7 @@ pub async fn run_check(bot_dir: &Path) -> CheckReport {
         },
     };
 
-    let match_config = build_owned_match_config(&game, TimingMode::Wait, 3000, 5000);
+    let match_config = build_match_config(&game, TimingMode::Wait, 3000, 5000);
 
     let listener = match TcpListener::bind("127.0.0.1:0").await {
         Ok(l) => l,


### PR DESCRIPTION
## Motivation

`pyrat-protocol` is now the canonical home for these types. The `Owned*` prefix was load-bearing only while they lived inside `host` alongside FlatBuffers borrowed tables and needed to disambiguate. In their new home it's just noise on the public surface. Bot SDK authors shouldn't have to learn what "owned" means before declaring a `Vec<OwnedOptionDef>`.

This is the closing chunk of the `pyrat-protocol` consolidation tracked across #189, #190, #192.

## Solution

Drop the prefix across the workspace. `MatchConfig`, `TurnState`, `Info`, `GameOver`, `OptionDef` are the canonical names now. `build_owned_match_config` becomes `build_match_config`.

The new names line up symmetrically with the wire side:

```rust
pyrat_wire::MatchConfig<'_>   // FlatBuffers borrowed table
pyrat_protocol::MatchConfig   // owned protocol type
```

Same identifier on both sides of the codec boundary. The one file that imports both (`server/protocol/src/codec.rs`) already aliases the wire crate (`use pyrat_wire as wire`), so the borrowed/owned-pair convention is already in place.

### Doc refresh

`server/protocol/src/messages.rs` previously said "**Status: spec-only.** Not yet consumed by host or SDK." That stopped being true with #192. Updated to:

> Consumed today by `EmbeddedPlayer` (in `pyrat-host`) for the in-process Player trait implementation. The TCP path still uses the legacy `HostCommand`/`SessionMsg` types in `pyrat-host`; those will be replaced when `TcpPlayer` lands.

`types.rs` module doc points at `crate::codec` directly instead of "the codec (in the host or SDK)".

### Deliberately deferred

The SDK's local `wire.rs` keeps its own `HostMsg` enum (current protocol). It collides by name with `pyrat_protocol::HostMsg` (redesigned protocol). Renaming before the architecture-level "Message type naming" decision lands would be churn.

The re-export block in `server/host/src/game_loop/mod.rs` is acknowledged scaffolding, removable when no host-internal callers depend on it.

## Test Plan

- [x] `cargo check` clean across the workspace
- [x] `cargo test` passes (no behavioral changes; the rename touches only identifiers and doc strings)