### PR TITLE
Add pyrat-orchestrator crate skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3089,6 +3089,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyrat-orchestrator"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "pyrat-bot-api",
+ "pyrat-host",
+ "pyrat-protocol",
+ "pyrat-rust",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "pyrat-protocol"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["engine", "engine/extension", "server/headless", "server/host", "server/protocol", "server/wire", "interface", "sdk/bot-api", "sdk/python", "sdk/rust", "sdk/rust/derive", "gui/src-tauri", "tools/bot-check", "eval/store"]
+members = ["engine", "engine/extension", "server/headless", "server/host", "server/protocol", "server/wire", "interface", "sdk/bot-api", "sdk/python", "sdk/rust", "sdk/rust/derive", "gui/src-tauri", "tools/bot-check", "eval/store", "eval/orchestrator"]
 resolver = "2"
 
 [workspace.lints.clippy]

--- a/eval/orchestrator/Cargo.toml
+++ b/eval/orchestrator/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "pyrat-orchestrator"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+pyrat-host = { path = "../../server/host" }
+pyrat-rust = { path = "../../engine", default-features = false }
+tokio = { version = "1", features = ["sync"] }
+tracing = "0.1"
+async-trait = "0.1"
+thiserror = "2"
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
+pyrat-bot-api = { path = "../../sdk/bot-api" }
+pyrat-protocol = { path = "../../server/protocol" }

--- a/eval/orchestrator/src/descriptor.rs
+++ b/eval/orchestrator/src/descriptor.rs
@@ -15,8 +15,8 @@ use crate::id::MatchId;
 /// Identity carried alongside a match through queue, execution, and sinks.
 ///
 /// Implementors:
-/// - [`AdHocDescriptor`] — minimal, used by run-one paths and tests.
-/// - `EvalMatchDescriptor` — defined in `pyrat-eval`, carries tournament/store ids.
+/// - [`AdHocDescriptor`]: minimal, used by run-one paths and tests.
+/// - `EvalMatchDescriptor` (in `pyrat-eval`): carries tournament/store ids.
 pub trait Descriptor: Send + Sync + Clone + 'static {
     fn match_id(&self) -> MatchId;
     fn seed(&self) -> u64;

--- a/eval/orchestrator/src/descriptor.rs
+++ b/eval/orchestrator/src/descriptor.rs
@@ -1,0 +1,72 @@
+//! Per-match identity that flows through the orchestrator and out to sinks.
+//!
+//! The orchestrator is generic over `D: Descriptor` so consumers can carry
+//! domain-specific identity (tournament id, player ids, attempt index) on
+//! every event without the orchestrator inspecting any of it. The trait
+//! demands only what executor bookkeeping needs (`match_id`) plus what
+//! forensic sinks need (`seed` for replay headers).
+
+use std::time::SystemTime;
+
+use serde::{Deserialize, Serialize};
+
+use crate::id::MatchId;
+
+/// Identity carried alongside a match through queue, execution, and sinks.
+///
+/// Implementors:
+/// - [`AdHocDescriptor`] — minimal, used by run-one paths and tests.
+/// - `EvalMatchDescriptor` — defined in `pyrat-eval`, carries tournament/store ids.
+pub trait Descriptor: Send + Sync + Clone + 'static {
+    fn match_id(&self) -> MatchId;
+    fn seed(&self) -> u64;
+}
+
+/// Minimal descriptor for runs that don't carry tournament context.
+///
+/// Used by the CLI's `run-one` subcommand, tests, and any consumer that
+/// just wants to execute matches without persisting them in a pool.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AdHocDescriptor {
+    pub match_id: MatchId,
+    pub seed: u64,
+    pub planned_at: SystemTime,
+}
+
+impl Descriptor for AdHocDescriptor {
+    fn match_id(&self) -> MatchId {
+        self.match_id
+    }
+
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ad_hoc_descriptor_roundtrips() {
+        let desc = AdHocDescriptor {
+            match_id: MatchId(7),
+            seed: 0xDEAD_BEEF,
+            planned_at: SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000),
+        };
+        let s = serde_json::to_string(&desc).unwrap();
+        let back: AdHocDescriptor = serde_json::from_str(&s).unwrap();
+        assert_eq!(desc, back);
+    }
+
+    #[test]
+    fn ad_hoc_descriptor_returns_stored_match_id_and_seed() {
+        let desc = AdHocDescriptor {
+            match_id: MatchId(3),
+            seed: 99,
+            planned_at: SystemTime::UNIX_EPOCH,
+        };
+        assert_eq!(desc.match_id(), MatchId(3));
+        assert_eq!(desc.seed(), 99);
+    }
+}

--- a/eval/orchestrator/src/event.rs
+++ b/eval/orchestrator/src/event.rs
@@ -1,0 +1,58 @@
+//! Public event stream emitted by the orchestrator.
+//!
+//! `OrchestratorEvent<D>` is a runtime type — *not* required to be
+//! `Serialize`. It carries flatbuffers-generated host types (`MatchEvent`,
+//! `MatchResult`, `PlayerIdentity`) that aren't serde-friendly. Persistence
+//! flows through sink callbacks (sinks extract fields and write them);
+//! replay flows through the `ReplayEvent` DTO added in PR 3.
+
+use pyrat_host::match_host::MatchEvent;
+use pyrat_host::player::PlayerIdentity;
+
+use crate::descriptor::Descriptor;
+use crate::id::MatchId;
+use crate::outcome::{MatchFailure, MatchOutcome};
+
+/// One event from the orchestrator's merged stream.
+///
+/// Ordering rules (enforced in PR 3 by `run_match.rs`):
+/// - `MatchQueued` is the first event for a given id.
+/// - `MatchStarted` is published once players are identified.
+/// - `MatchEvent` carries every non-terminal host event tagged with id.
+/// - `MatchFinished` / `MatchFailed` are the only terminal signals; the
+///   host's `MatchEvent::MatchOver` is suppressed (the canonical terminal
+///   value is the `MatchResult` carried inside `MatchFinished.outcome`).
+#[derive(Debug, Clone)]
+pub enum OrchestratorEvent<D: Descriptor> {
+    MatchQueued {
+        id: MatchId,
+        descriptor: D,
+    },
+    MatchStarted {
+        id: MatchId,
+        descriptor: D,
+        players: [PlayerIdentity; 2],
+    },
+    MatchEvent {
+        id: MatchId,
+        event: MatchEvent,
+    },
+    MatchFinished {
+        outcome: MatchOutcome<D>,
+    },
+    MatchFailed {
+        failure: MatchFailure<D>,
+    },
+}
+
+impl<D: Descriptor> OrchestratorEvent<D> {
+    /// `MatchId` carried by every event variant.
+    pub fn match_id(&self) -> MatchId {
+        match self {
+            Self::MatchQueued { id, .. } | Self::MatchStarted { id, .. } => *id,
+            Self::MatchEvent { id, .. } => *id,
+            Self::MatchFinished { outcome } => outcome.descriptor.match_id(),
+            Self::MatchFailed { failure } => failure.descriptor.match_id(),
+        }
+    }
+}

--- a/eval/orchestrator/src/event.rs
+++ b/eval/orchestrator/src/event.rs
@@ -1,10 +1,10 @@
 //! Public event stream emitted by the orchestrator.
 //!
-//! `OrchestratorEvent<D>` is a runtime type — *not* required to be
-//! `Serialize`. It carries flatbuffers-generated host types (`MatchEvent`,
+//! `OrchestratorEvent<D>` is a runtime type. It is *not* required to be
+//! `Serialize`: it carries flatbuffers-generated host types (`MatchEvent`,
 //! `MatchResult`, `PlayerIdentity`) that aren't serde-friendly. Persistence
 //! flows through sink callbacks (sinks extract fields and write them);
-//! replay flows through the `ReplayEvent` DTO added in PR 3.
+//! replay flows through the `ReplayEvent` DTO.
 
 use pyrat_host::match_host::MatchEvent;
 use pyrat_host::player::PlayerIdentity;
@@ -15,7 +15,7 @@ use crate::outcome::{MatchFailure, MatchOutcome};
 
 /// One event from the orchestrator's merged stream.
 ///
-/// Ordering rules (enforced in PR 3 by `run_match.rs`):
+/// Ordering rules enforced by the executor:
 /// - `MatchQueued` is the first event for a given id.
 /// - `MatchStarted` is published once players are identified.
 /// - `MatchEvent` carries every non-terminal host event tagged with id.
@@ -23,6 +23,7 @@ use crate::outcome::{MatchFailure, MatchOutcome};
 ///   host's `MatchEvent::MatchOver` is suppressed (the canonical terminal
 ///   value is the `MatchResult` carried inside `MatchFinished.outcome`).
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum OrchestratorEvent<D: Descriptor> {
     MatchQueued {
         id: MatchId,
@@ -54,5 +55,92 @@ impl<D: Descriptor> OrchestratorEvent<D> {
             Self::MatchFinished { outcome } => outcome.descriptor.match_id(),
             Self::MatchFailed { failure } => failure.descriptor.match_id(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::SystemTime;
+
+    use pyrat_host::match_host::{MatchEvent, MatchResult};
+    use pyrat_host::player::PlayerIdentity;
+    use pyrat_host::wire::{GameResult, Player};
+
+    use super::*;
+    use crate::descriptor::AdHocDescriptor;
+    use crate::outcome::{FailureReason, MatchFailure, MatchOutcome};
+
+    fn descriptor(id: u64) -> AdHocDescriptor {
+        AdHocDescriptor {
+            match_id: MatchId(id),
+            seed: 0,
+            planned_at: SystemTime::UNIX_EPOCH,
+        }
+    }
+
+    fn identity(slot: Player) -> PlayerIdentity {
+        PlayerIdentity {
+            name: "test".into(),
+            author: "test".into(),
+            agent_id: "test".into(),
+            slot,
+        }
+    }
+
+    fn match_result() -> MatchResult {
+        MatchResult {
+            result: GameResult::Draw,
+            player1_score: 0.0,
+            player2_score: 0.0,
+            turns_played: 0,
+        }
+    }
+
+    /// `MatchQueued`/`MatchStarted`/`MatchEvent` return the explicit `id`
+    /// field; `MatchFinished`/`MatchFailed` route through `descriptor.match_id()`.
+    /// Catches branch transposition in the accessor the executor routes on.
+    #[test]
+    fn match_id_returns_correct_id_for_every_variant() {
+        let queued = OrchestratorEvent::<AdHocDescriptor>::MatchQueued {
+            id: MatchId(1),
+            descriptor: descriptor(1),
+        };
+        assert_eq!(queued.match_id(), MatchId(1));
+
+        let started = OrchestratorEvent::<AdHocDescriptor>::MatchStarted {
+            id: MatchId(2),
+            descriptor: descriptor(2),
+            players: [identity(Player::Player1), identity(Player::Player2)],
+        };
+        assert_eq!(started.match_id(), MatchId(2));
+
+        let event = OrchestratorEvent::<AdHocDescriptor>::MatchEvent {
+            id: MatchId(3),
+            event: MatchEvent::PreprocessingStarted,
+        };
+        assert_eq!(event.match_id(), MatchId(3));
+
+        let finished = OrchestratorEvent::MatchFinished {
+            outcome: MatchOutcome {
+                descriptor: descriptor(4),
+                started_at: SystemTime::UNIX_EPOCH,
+                finished_at: SystemTime::UNIX_EPOCH,
+                result: match_result(),
+                players: [identity(Player::Player1), identity(Player::Player2)],
+            },
+        };
+        assert_eq!(finished.match_id(), MatchId(4));
+
+        let failed = OrchestratorEvent::MatchFailed {
+            failure: MatchFailure {
+                descriptor: descriptor(5),
+                started_at: None,
+                failed_at: SystemTime::UNIX_EPOCH,
+                reason: FailureReason::Cancelled,
+                players: None,
+                durable_record: true,
+            },
+        };
+        assert_eq!(failed.match_id(), MatchId(5));
     }
 }

--- a/eval/orchestrator/src/id.rs
+++ b/eval/orchestrator/src/id.rs
@@ -1,0 +1,71 @@
+//! Monotonic match identifier.
+//!
+//! `MatchId` is allocated at submit time and stays stable across broadcast,
+//! sink calls, and replay records. The allocator is explicit (not a global
+//! atomic) so each orchestrator instance — and each test — controls its own
+//! id space.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::{Deserialize, Serialize};
+
+/// Stable identifier for a match within an orchestrator instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct MatchId(pub u64);
+
+impl std::fmt::Display for MatchId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "match#{}", self.0)
+    }
+}
+
+/// Allocator for monotonic [`MatchId`]s. One per orchestrator instance.
+#[derive(Debug, Default)]
+pub struct MatchIdAllocator {
+    next: AtomicU64,
+}
+
+impl MatchIdAllocator {
+    pub const fn new() -> Self {
+        Self {
+            next: AtomicU64::new(0),
+        }
+    }
+
+    /// Allocate the next id. Monotonic, never reused within this allocator.
+    pub fn allocate(&self) -> MatchId {
+        MatchId(self.next.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allocator_yields_monotonic_ids() {
+        let alloc = MatchIdAllocator::new();
+        let ids: Vec<_> = (0..5).map(|_| alloc.allocate()).collect();
+        assert_eq!(
+            ids,
+            vec![MatchId(0), MatchId(1), MatchId(2), MatchId(3), MatchId(4),]
+        );
+    }
+
+    #[test]
+    fn allocators_are_independent() {
+        let a = MatchIdAllocator::new();
+        let b = MatchIdAllocator::new();
+        assert_eq!(a.allocate(), MatchId(0));
+        assert_eq!(a.allocate(), MatchId(1));
+        assert_eq!(b.allocate(), MatchId(0));
+    }
+
+    #[test]
+    fn match_id_serialize_roundtrip() {
+        let id = MatchId(42);
+        let s = serde_json::to_string(&id).unwrap();
+        let back: MatchId = serde_json::from_str(&s).unwrap();
+        assert_eq!(id, back);
+    }
+}

--- a/eval/orchestrator/src/id.rs
+++ b/eval/orchestrator/src/id.rs
@@ -2,7 +2,7 @@
 //!
 //! `MatchId` is allocated at submit time and stays stable across broadcast,
 //! sink calls, and replay records. The allocator is explicit (not a global
-//! atomic) so each orchestrator instance — and each test — controls its own
+//! atomic) so each orchestrator instance, and each test, controls its own
 //! id space.
 
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/eval/orchestrator/src/lib.rs
+++ b/eval/orchestrator/src/lib.rs
@@ -1,0 +1,21 @@
+//! Concurrent match executor that runs `Vec<Matchup>` and emits a stream of
+//! `OrchestratorEvent`s. Domain-free: knows about [`pyrat_host`] and sinks,
+//! not SQLite, not Elo, not tournaments.
+
+pub mod descriptor;
+pub mod event;
+pub mod id;
+pub mod matchup;
+pub mod outcome;
+pub mod sink;
+pub mod sinks;
+pub mod state;
+
+pub use descriptor::{AdHocDescriptor, Descriptor};
+pub use event::OrchestratorEvent;
+pub use id::{MatchId, MatchIdAllocator};
+pub use matchup::{EmbeddedBotFactory, Matchup, PlayerSpec, Timing};
+pub use outcome::{FailureReason, MatchFailure, MatchOutcome};
+pub use sink::{MatchSink, NoOpSink, SinkError, SinkRole};
+pub use sinks::composite::CompositeSink;
+pub use state::ExecutorState;

--- a/eval/orchestrator/src/matchup.rs
+++ b/eval/orchestrator/src/matchup.rs
@@ -3,7 +3,7 @@
 //! `Matchup<D>` carries identity (`descriptor`) plus the concrete runtime
 //! values to invoke `pyrat_host::match_host::Match::new`. The descriptor
 //! is the durable identity passed to sinks; the matchup adds engine inputs
-//! (game_config, players, timing). The seed is the descriptor's — accessed
+//! (game_config, players, timing). The seed is the descriptor's, accessed
 //! via `descriptor.seed()` so engine and sinks can never disagree.
 
 use std::path::PathBuf;
@@ -46,6 +46,7 @@ pub type EmbeddedBotFactory = Arc<dyn Fn() -> Box<dyn EmbeddedBot> + Send + Sync
 
 /// How a player slot is materialised when the match starts.
 #[derive(Clone)]
+#[non_exhaustive]
 pub enum PlayerSpec {
     /// Launch a subprocess and accept it on the per-match TCP listener.
     Subprocess {
@@ -84,7 +85,7 @@ impl std::fmt::Debug for PlayerSpec {
 
 /// One match unit: identity plus everything `Match::new` needs.
 ///
-/// The seed is read via `descriptor.seed()` — there is no separate
+/// The seed is read via `descriptor.seed()`. There is no separate
 /// `Matchup::seed` field, so engine and forensic sinks can never disagree.
 #[derive(Clone)]
 pub struct Matchup<D: Descriptor> {
@@ -122,7 +123,7 @@ mod tests {
 
     use super::*;
 
-    /// Stateless bot used by the factory test — distinctness is observed
+    /// Stateless bot used by the factory test. Distinctness is observed
     /// through the shared counter, not through bot fields.
     struct CountingBot;
 

--- a/eval/orchestrator/src/matchup.rs
+++ b/eval/orchestrator/src/matchup.rs
@@ -1,0 +1,158 @@
+//! What the orchestrator needs to actually run one match.
+//!
+//! `Matchup<D>` carries identity (`descriptor`) plus the concrete runtime
+//! values to invoke `pyrat_host::match_host::Match::new`. The descriptor
+//! is the durable identity passed to sinks; the matchup adds engine inputs
+//! (game_config, players, timing). The seed is the descriptor's — accessed
+//! via `descriptor.seed()` so engine and sinks can never disagree.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use pyrat::game::builder::GameConfig;
+use pyrat_host::player::EmbeddedBot;
+use pyrat_host::wire::TimingMode;
+
+use crate::descriptor::Descriptor;
+
+/// Wire-level timing knobs handed to bots via `MatchConfig`. Host-side
+/// timing/policy (`SetupTiming`, `PlayingConfig`) is composed alongside
+/// these at run time.
+#[derive(Debug, Clone, Copy)]
+pub struct Timing {
+    pub mode: TimingMode,
+    pub move_timeout_ms: u32,
+    pub preprocessing_timeout_ms: u32,
+}
+
+impl Default for Timing {
+    fn default() -> Self {
+        Self {
+            mode: TimingMode::Wait,
+            move_timeout_ms: 3_000,
+            preprocessing_timeout_ms: 10_000,
+        }
+    }
+}
+
+/// Factory for an in-process bot. Invoked once per match so each match gets
+/// a fresh `&mut self` with no cross-match state leak.
+///
+/// `Box<dyn EmbeddedBot>` does not itself auto-impl `EmbeddedBot`, so the
+/// caller that hands the box to `EmbeddedPlayer::accept<B: EmbeddedBot>`
+/// is responsible for adapting it (blanket impl over `Box<T>` or a thin
+/// wrapper).
+pub type EmbeddedBotFactory = Arc<dyn Fn() -> Box<dyn EmbeddedBot> + Send + Sync>;
+
+/// How a player slot is materialised when the match starts.
+#[derive(Clone)]
+pub enum PlayerSpec {
+    /// Launch a subprocess and accept it on the per-match TCP listener.
+    Subprocess {
+        agent_id: String,
+        command: String,
+        working_dir: Option<PathBuf>,
+    },
+    /// Build an in-process bot via `factory`.
+    Embedded {
+        agent_id: String,
+        factory: EmbeddedBotFactory,
+    },
+}
+
+impl std::fmt::Debug for PlayerSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Subprocess {
+                agent_id,
+                command,
+                working_dir,
+            } => f
+                .debug_struct("Subprocess")
+                .field("agent_id", agent_id)
+                .field("command", command)
+                .field("working_dir", working_dir)
+                .finish(),
+            Self::Embedded { agent_id, .. } => f
+                .debug_struct("Embedded")
+                .field("agent_id", agent_id)
+                .field("factory", &"<closure>")
+                .finish(),
+        }
+    }
+}
+
+/// One match unit: identity plus everything `Match::new` needs.
+///
+/// The seed is read via `descriptor.seed()` — there is no separate
+/// `Matchup::seed` field, so engine and forensic sinks can never disagree.
+#[derive(Clone)]
+pub struct Matchup<D: Descriptor> {
+    pub descriptor: D,
+    pub game_config: GameConfig,
+    pub players: [PlayerSpec; 2],
+    pub timing: Timing,
+}
+
+impl<D: Descriptor> Matchup<D> {
+    /// Seed for engine state construction. Single source of truth.
+    pub fn seed(&self) -> u64 {
+        self.descriptor.seed()
+    }
+}
+
+impl<D: Descriptor + std::fmt::Debug> std::fmt::Debug for Matchup<D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Matchup")
+            .field("descriptor", &self.descriptor)
+            .field("players", &self.players)
+            .field("timing", &self.timing)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use pyrat::Direction;
+    use pyrat_bot_api::Options;
+    use pyrat_host::player::{EmbeddedBot, EmbeddedCtx};
+    use pyrat_protocol::HashedTurnState;
+
+    use super::*;
+
+    /// Stateless bot used by the factory test — distinctness is observed
+    /// through the shared counter, not through bot fields.
+    struct CountingBot;
+
+    impl Options for CountingBot {}
+
+    impl EmbeddedBot for CountingBot {
+        fn think(&mut self, _: &HashedTurnState, _: &EmbeddedCtx) -> Direction {
+            Direction::Stay
+        }
+    }
+
+    #[test]
+    fn embedded_factory_produces_fresh_instances() {
+        let counter = Arc::new(AtomicU32::new(0));
+        let counter_clone = counter.clone();
+        let factory: EmbeddedBotFactory = Arc::new(move || {
+            counter_clone.fetch_add(1, Ordering::SeqCst);
+            Box::new(CountingBot)
+        });
+
+        let _bot_a = factory();
+        let _bot_b = factory();
+        assert_eq!(counter.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn timing_default_uses_wait_mode() {
+        let t = Timing::default();
+        assert_eq!(t.mode, TimingMode::Wait);
+        assert!(t.move_timeout_ms > 0);
+        assert!(t.preprocessing_timeout_ms > 0);
+    }
+}

--- a/eval/orchestrator/src/outcome.rs
+++ b/eval/orchestrator/src/outcome.rs
@@ -37,13 +37,14 @@ pub struct MatchFailure<D: Descriptor> {
     pub reason: FailureReason,
     pub players: Option<[PlayerIdentity; 2]>,
     /// True when the store has a row for this failure (normal failure path).
-    /// False for kill-9 mid-match or required-sink terminal flush failure —
-    /// resume must re-issue at the same `attempt_index`.
+    /// False for kill-9 mid-match or required-sink terminal flush failure.
+    /// In the false case, resume must re-issue at the same `attempt_index`.
     pub durable_record: bool,
 }
 
 /// Why a match failed. Operational categories, not user-facing messages.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum FailureReason {
     SpawnFailed,
     HandshakeTimeout,

--- a/eval/orchestrator/src/outcome.rs
+++ b/eval/orchestrator/src/outcome.rs
@@ -1,0 +1,56 @@
+//! Terminal values that flow out of the orchestrator: success and failure.
+//!
+//! Both shapes carry the descriptor verbatim so sinks can correlate with
+//! the durable record they wrote at submit time. `durable_record` on
+//! `MatchFailure` distinguishes "store has a row for this failure" (the
+//! normal failure path) from "match was lost without a durable row"
+//! (kill-9 mid-match, or required-sink terminal flush failure).
+
+use std::time::SystemTime;
+
+use pyrat_host::match_host::MatchResult;
+use pyrat_host::player::PlayerIdentity;
+
+use crate::descriptor::Descriptor;
+
+/// Result of a match that completed cleanly.
+#[derive(Debug, Clone)]
+pub struct MatchOutcome<D: Descriptor> {
+    pub descriptor: D,
+    pub started_at: SystemTime,
+    pub finished_at: SystemTime,
+    pub result: MatchResult,
+    pub players: [PlayerIdentity; 2],
+}
+
+/// Result of a match that failed.
+///
+/// `players` is `Option` because a failure can occur before both players
+/// completed handshake (e.g. spawn failure, handshake timeout). `started_at`
+/// is similarly optional for failures detected before the playing phase
+/// began.
+#[derive(Debug, Clone)]
+pub struct MatchFailure<D: Descriptor> {
+    pub descriptor: D,
+    pub started_at: Option<SystemTime>,
+    pub failed_at: SystemTime,
+    pub reason: FailureReason,
+    pub players: Option<[PlayerIdentity; 2]>,
+    /// True when the store has a row for this failure (normal failure path).
+    /// False for kill-9 mid-match or required-sink terminal flush failure —
+    /// resume must re-issue at the same `attempt_index`.
+    pub durable_record: bool,
+}
+
+/// Why a match failed. Operational categories, not user-facing messages.
+#[derive(Debug, Clone)]
+pub enum FailureReason {
+    SpawnFailed,
+    HandshakeTimeout,
+    Disconnected,
+    ProtocolError,
+    Panic,
+    Cancelled,
+    SinkFlushError,
+    Internal(String),
+}

--- a/eval/orchestrator/src/sink.rs
+++ b/eval/orchestrator/src/sink.rs
@@ -3,8 +3,8 @@
 //! Sinks see every match event, the terminal outcome, and the failure path.
 //! The orchestrator is the producer; consumers (eval store, replay JSON,
 //! tests) plug in here. Sinks are classified `Required` or `Optional` at
-//! composition time — required-sink terminal failure is fatal to the
-//! match's durable record, optional-sink failure is a telemetry concern.
+//! composition time. Required-sink terminal failure is fatal to the
+//! match's durable record; optional-sink failure is a telemetry concern.
 
 use async_trait::async_trait;
 
@@ -28,7 +28,7 @@ pub enum SinkRole {
 }
 
 /// Error returned by sink callbacks. Criticality is per-sink (controlled
-/// by `SinkRole`), not per-error — `SinkError` carries only the source.
+/// by `SinkRole`), not per-error: `SinkError` carries only the source.
 #[derive(Debug, thiserror::Error)]
 #[error("sink error: {source}")]
 pub struct SinkError {
@@ -100,8 +100,8 @@ mod tests {
     use super::*;
     use crate::descriptor::AdHocDescriptor;
 
-    /// Confirms the trait is object-safe — `Box<dyn MatchSink<AdHocDescriptor>>`
-    /// must compile so PR 3 can hold heterogeneous sinks behind one type.
+    /// Confirms the trait is object-safe. `Box<dyn MatchSink<AdHocDescriptor>>`
+    /// must compile so the executor can hold heterogeneous sinks behind one type.
     #[test]
     fn match_sink_is_object_safe() {
         let _sink: Box<dyn MatchSink<AdHocDescriptor>> =

--- a/eval/orchestrator/src/sink.rs
+++ b/eval/orchestrator/src/sink.rs
@@ -1,0 +1,110 @@
+//! The sink seam.
+//!
+//! Sinks see every match event, the terminal outcome, and the failure path.
+//! The orchestrator is the producer; consumers (eval store, replay JSON,
+//! tests) plug in here. Sinks are classified `Required` or `Optional` at
+//! composition time — required-sink terminal failure is fatal to the
+//! match's durable record, optional-sink failure is a telemetry concern.
+
+use async_trait::async_trait;
+
+use pyrat_host::match_host::MatchEvent;
+use pyrat_host::player::PlayerIdentity;
+
+use crate::descriptor::Descriptor;
+use crate::id::MatchId;
+use crate::outcome::{MatchFailure, MatchOutcome};
+
+/// Sink role at composition time. Determines how `CompositeSink` handles
+/// errors from this child.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SinkRole {
+    /// A failure here means we can't claim the match was durably recorded.
+    /// Composite returns `Err` so the executor can demote the terminal.
+    Required,
+    /// A failure here is logged at `warn` and a counter increments.
+    /// The match outcome is unaffected.
+    Optional,
+}
+
+/// Error returned by sink callbacks. Criticality is per-sink (controlled
+/// by `SinkRole`), not per-error — `SinkError` carries only the source.
+#[derive(Debug, thiserror::Error)]
+#[error("sink error: {source}")]
+pub struct SinkError {
+    #[from]
+    pub source: anyhow::Error,
+}
+
+/// Sink callback surface. The orchestrator drives `on_match_event` per host
+/// event and a single `on_match_finished` *or* `on_match_failed` at the end.
+///
+/// Per-event calls are accept-only (a sink may buffer). Only terminals are
+/// flush points. Replay sinks can be stricter internally without changing
+/// the contract.
+#[async_trait]
+pub trait MatchSink<D: Descriptor>: Send + Sync {
+    async fn on_match_started(
+        &self,
+        descriptor: &D,
+        players: &[PlayerIdentity; 2],
+    ) -> Result<(), SinkError>;
+
+    async fn on_match_event(&self, id: MatchId, event: &MatchEvent) -> Result<(), SinkError>;
+
+    async fn on_match_finished(&self, outcome: &MatchOutcome<D>) -> Result<(), SinkError>;
+
+    async fn on_match_failed(&self, failure: &MatchFailure<D>) -> Result<(), SinkError>;
+}
+
+/// Drops every callback. Useful for tests that don't need persistence and
+/// for the default sink wiring before any consumer plugs in.
+#[derive(Debug, Default)]
+pub struct NoOpSink<D> {
+    _phantom: std::marker::PhantomData<fn() -> D>,
+}
+
+impl<D> NoOpSink<D> {
+    pub const fn new() -> Self {
+        Self {
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+#[async_trait]
+impl<D: Descriptor> MatchSink<D> for NoOpSink<D> {
+    async fn on_match_started(
+        &self,
+        _descriptor: &D,
+        _players: &[PlayerIdentity; 2],
+    ) -> Result<(), SinkError> {
+        Ok(())
+    }
+
+    async fn on_match_event(&self, _id: MatchId, _event: &MatchEvent) -> Result<(), SinkError> {
+        Ok(())
+    }
+
+    async fn on_match_finished(&self, _outcome: &MatchOutcome<D>) -> Result<(), SinkError> {
+        Ok(())
+    }
+
+    async fn on_match_failed(&self, _failure: &MatchFailure<D>) -> Result<(), SinkError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::descriptor::AdHocDescriptor;
+
+    /// Confirms the trait is object-safe — `Box<dyn MatchSink<AdHocDescriptor>>`
+    /// must compile so PR 3 can hold heterogeneous sinks behind one type.
+    #[test]
+    fn match_sink_is_object_safe() {
+        let _sink: Box<dyn MatchSink<AdHocDescriptor>> =
+            Box::new(NoOpSink::<AdHocDescriptor>::new());
+    }
+}

--- a/eval/orchestrator/src/sinks/composite.rs
+++ b/eval/orchestrator/src/sinks/composite.rs
@@ -3,7 +3,7 @@
 //! Children are stored with their [`SinkRole`]. On a terminal callback:
 //! - The first `Required` child to error short-circuits and returns `Err`.
 //!   The executor demotes the terminal to `MatchFailed { durable_record: false }`.
-//!   `Optional` children that follow are skipped — we don't write a forensic
+//!   `Optional` children that follow are skipped: we don't write a forensic
 //!   replay for a match the store couldn't record.
 //! - `Optional` errors log at `warn` and increment a counter; `Ok(())` is
 //!   still returned to the caller.
@@ -49,7 +49,7 @@ impl<D: Descriptor> CompositeSink<D> {
     }
 
     /// Total count of optional-sink errors logged across this composite's
-    /// lifetime. Useful for asserting in tests; PR 3 wires it to telemetry.
+    /// lifetime. Useful for asserting in tests and for telemetry wiring.
     pub fn optional_error_count(&self) -> u64 {
         self.optional_errors.load(Ordering::Relaxed)
     }
@@ -276,7 +276,7 @@ mod tests {
     }
 
     /// `Optional` listed before `Required` in the constructor must still see
-    /// the `Required` callback invoked first — partitioning by role at
+    /// the `Required` callback invoked first. Partitioning by role at
     /// construction prevents an optional forensic sink (e.g. replay) from
     /// writing side effects for a match the required sink later rejects.
     #[tokio::test]

--- a/eval/orchestrator/src/sinks/composite.rs
+++ b/eval/orchestrator/src/sinks/composite.rs
@@ -1,0 +1,332 @@
+//! Compose multiple sinks into one, with role-based error handling.
+//!
+//! Children are stored with their [`SinkRole`]. On a terminal callback:
+//! - The first `Required` child to error short-circuits and returns `Err`.
+//!   The executor demotes the terminal to `MatchFailed { durable_record: false }`.
+//!   `Optional` children that follow are skipped — we don't write a forensic
+//!   replay for a match the store couldn't record.
+//! - `Optional` errors log at `warn` and increment a counter; `Ok(())` is
+//!   still returned to the caller.
+//!
+//! The outcome is never mutated by the sink path. Losing an optional file
+//! is a telemetry concern; the match really did succeed.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tracing::warn;
+
+use pyrat_host::match_host::MatchEvent;
+use pyrat_host::player::PlayerIdentity;
+
+use crate::descriptor::Descriptor;
+use crate::id::MatchId;
+use crate::outcome::{MatchFailure, MatchOutcome};
+use crate::sink::{MatchSink, SinkError, SinkRole};
+
+/// Composes a list of `(role, sink)` children behind one `MatchSink`.
+pub struct CompositeSink<D: Descriptor> {
+    children: Vec<(SinkRole, Arc<dyn MatchSink<D>>)>,
+    optional_errors: AtomicU64,
+}
+
+impl<D: Descriptor> CompositeSink<D> {
+    /// Build a composite. Children are partitioned by role: every `Required`
+    /// sink is invoked before any `Optional` sink. Intra-role order is
+    /// preserved from the input. This guarantees that an `Optional` sink
+    /// (e.g. forensic replay) never produces side effects for a match the
+    /// `Required` sink (e.g. store) ends up rejecting.
+    pub fn new(children: Vec<(SinkRole, Arc<dyn MatchSink<D>>)>) -> Self {
+        let (required, optional): (Vec<_>, Vec<_>) = children
+            .into_iter()
+            .partition(|(role, _)| *role == SinkRole::Required);
+        let ordered = required.into_iter().chain(optional).collect();
+        Self {
+            children: ordered,
+            optional_errors: AtomicU64::new(0),
+        }
+    }
+
+    /// Total count of optional-sink errors logged across this composite's
+    /// lifetime. Useful for asserting in tests; PR 3 wires it to telemetry.
+    pub fn optional_error_count(&self) -> u64 {
+        self.optional_errors.load(Ordering::Relaxed)
+    }
+
+    /// Classify a single child's error by role: `Required` propagates,
+    /// `Optional` logs at `warn` and bumps the counter.
+    fn classify(&self, role: SinkRole, label: &'static str, err: SinkError) -> Option<SinkError> {
+        match role {
+            SinkRole::Required => Some(err),
+            SinkRole::Optional => {
+                self.optional_errors.fetch_add(1, Ordering::Relaxed);
+                warn!(callback = label, error = %err, "optional sink error");
+                None
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl<D: Descriptor> MatchSink<D> for CompositeSink<D> {
+    async fn on_match_started(
+        &self,
+        descriptor: &D,
+        players: &[PlayerIdentity; 2],
+    ) -> Result<(), SinkError> {
+        for (role, child) in &self.children {
+            let Err(e) = child.on_match_started(descriptor, players).await else {
+                continue;
+            };
+            if let Some(propagate) = self.classify(*role, "on_match_started", e) {
+                return Err(propagate);
+            }
+        }
+        Ok(())
+    }
+
+    async fn on_match_event(&self, id: MatchId, event: &MatchEvent) -> Result<(), SinkError> {
+        for (role, child) in &self.children {
+            let Err(e) = child.on_match_event(id, event).await else {
+                continue;
+            };
+            if let Some(propagate) = self.classify(*role, "on_match_event", e) {
+                return Err(propagate);
+            }
+        }
+        Ok(())
+    }
+
+    async fn on_match_finished(&self, outcome: &MatchOutcome<D>) -> Result<(), SinkError> {
+        for (role, child) in &self.children {
+            let Err(e) = child.on_match_finished(outcome).await else {
+                continue;
+            };
+            if let Some(propagate) = self.classify(*role, "on_match_finished", e) {
+                return Err(propagate);
+            }
+        }
+        Ok(())
+    }
+
+    async fn on_match_failed(&self, failure: &MatchFailure<D>) -> Result<(), SinkError> {
+        for (role, child) in &self.children {
+            let Err(e) = child.on_match_failed(failure).await else {
+                continue;
+            };
+            if let Some(propagate) = self.classify(*role, "on_match_failed", e) {
+                return Err(propagate);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::SystemTime;
+
+    use anyhow::anyhow;
+
+    use super::*;
+    use crate::descriptor::AdHocDescriptor;
+    use crate::id::MatchId;
+    use crate::outcome::{FailureReason, MatchFailure};
+    use crate::sink::SinkError;
+
+    fn ad_hoc(id: u64) -> AdHocDescriptor {
+        AdHocDescriptor {
+            match_id: MatchId(id),
+            seed: 0,
+            planned_at: SystemTime::UNIX_EPOCH,
+        }
+    }
+
+    fn failure(desc: AdHocDescriptor) -> MatchFailure<AdHocDescriptor> {
+        MatchFailure {
+            descriptor: desc,
+            started_at: None,
+            failed_at: SystemTime::UNIX_EPOCH,
+            reason: FailureReason::Internal("test".into()),
+            players: None,
+            durable_record: true,
+        }
+    }
+
+    /// Sink that returns Ok and counts calls.
+    struct CountingSink {
+        calls: Arc<AtomicU32>,
+    }
+
+    #[async_trait]
+    impl MatchSink<AdHocDescriptor> for CountingSink {
+        async fn on_match_started(
+            &self,
+            _descriptor: &AdHocDescriptor,
+            _players: &[PlayerIdentity; 2],
+        ) -> Result<(), SinkError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        async fn on_match_event(&self, _id: MatchId, _event: &MatchEvent) -> Result<(), SinkError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        async fn on_match_finished(
+            &self,
+            _outcome: &MatchOutcome<AdHocDescriptor>,
+        ) -> Result<(), SinkError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        async fn on_match_failed(
+            &self,
+            _failure: &MatchFailure<AdHocDescriptor>,
+        ) -> Result<(), SinkError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    /// Sink that always errors on the failed callback (used to drive the
+    /// classification path).
+    struct FailingSink;
+
+    #[async_trait]
+    impl MatchSink<AdHocDescriptor> for FailingSink {
+        async fn on_match_started(
+            &self,
+            _descriptor: &AdHocDescriptor,
+            _players: &[PlayerIdentity; 2],
+        ) -> Result<(), SinkError> {
+            Err(SinkError {
+                source: anyhow!("started boom"),
+            })
+        }
+        async fn on_match_event(&self, _id: MatchId, _event: &MatchEvent) -> Result<(), SinkError> {
+            Err(SinkError {
+                source: anyhow!("event boom"),
+            })
+        }
+        async fn on_match_finished(
+            &self,
+            _outcome: &MatchOutcome<AdHocDescriptor>,
+        ) -> Result<(), SinkError> {
+            Err(SinkError {
+                source: anyhow!("finished boom"),
+            })
+        }
+        async fn on_match_failed(
+            &self,
+            _failure: &MatchFailure<AdHocDescriptor>,
+        ) -> Result<(), SinkError> {
+            Err(SinkError {
+                source: anyhow!("failed boom"),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn required_error_short_circuits_and_returns_err() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let trailing: Arc<dyn MatchSink<AdHocDescriptor>> = Arc::new(CountingSink {
+            calls: calls.clone(),
+        });
+        let composite = CompositeSink::new(vec![
+            (SinkRole::Required, Arc::new(FailingSink)),
+            (SinkRole::Optional, trailing),
+        ]);
+
+        let desc = ad_hoc(1);
+        let result = composite.on_match_failed(&failure(desc)).await;
+        assert!(result.is_err(), "required sink err must propagate");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "trailing sinks must NOT be called once a Required sink errored"
+        );
+        assert_eq!(composite.optional_error_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn optional_error_does_not_propagate_and_required_still_runs() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let required: Arc<dyn MatchSink<AdHocDescriptor>> = Arc::new(CountingSink {
+            calls: calls.clone(),
+        });
+        let composite = CompositeSink::new(vec![
+            (SinkRole::Optional, Arc::new(FailingSink)),
+            (SinkRole::Required, required),
+        ]);
+
+        let desc = ad_hoc(2);
+        let result = composite.on_match_failed(&failure(desc)).await;
+        assert!(
+            result.is_ok(),
+            "optional sink err must NOT propagate to caller"
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "required sink must run regardless of optional sink error"
+        );
+        assert_eq!(composite.optional_error_count(), 1);
+    }
+
+    /// `Optional` listed before `Required` in the constructor must still see
+    /// the `Required` callback invoked first — partitioning by role at
+    /// construction prevents an optional forensic sink (e.g. replay) from
+    /// writing side effects for a match the required sink later rejects.
+    #[tokio::test]
+    async fn required_runs_before_optional_regardless_of_input_order() {
+        use std::sync::Mutex;
+        let order: Arc<Mutex<Vec<&'static str>>> = Arc::default();
+
+        struct OrderRecorder {
+            label: &'static str,
+            order: Arc<Mutex<Vec<&'static str>>>,
+        }
+        #[async_trait]
+        impl MatchSink<AdHocDescriptor> for OrderRecorder {
+            async fn on_match_started(
+                &self,
+                _: &AdHocDescriptor,
+                _: &[PlayerIdentity; 2],
+            ) -> Result<(), SinkError> {
+                Ok(())
+            }
+            async fn on_match_event(&self, _: MatchId, _: &MatchEvent) -> Result<(), SinkError> {
+                Ok(())
+            }
+            async fn on_match_finished(
+                &self,
+                _: &MatchOutcome<AdHocDescriptor>,
+            ) -> Result<(), SinkError> {
+                Ok(())
+            }
+            async fn on_match_failed(
+                &self,
+                _: &MatchFailure<AdHocDescriptor>,
+            ) -> Result<(), SinkError> {
+                self.order.lock().unwrap().push(self.label);
+                Ok(())
+            }
+        }
+
+        let opt: Arc<dyn MatchSink<AdHocDescriptor>> = Arc::new(OrderRecorder {
+            label: "optional",
+            order: order.clone(),
+        });
+        let req: Arc<dyn MatchSink<AdHocDescriptor>> = Arc::new(OrderRecorder {
+            label: "required",
+            order: order.clone(),
+        });
+        let composite =
+            CompositeSink::new(vec![(SinkRole::Optional, opt), (SinkRole::Required, req)]);
+
+        let _ = composite.on_match_failed(&failure(ad_hoc(3))).await;
+        assert_eq!(*order.lock().unwrap(), vec!["required", "optional"]);
+    }
+}

--- a/eval/orchestrator/src/sinks/mod.rs
+++ b/eval/orchestrator/src/sinks/mod.rs
@@ -1,0 +1,3 @@
+//! Sink implementations. The trait itself lives in [`crate::sink`].
+
+pub mod composite;

--- a/eval/orchestrator/src/state.rs
+++ b/eval/orchestrator/src/state.rs
@@ -13,7 +13,7 @@ use crate::id::MatchId;
 ///
 /// `finished` and `failed` are running totals over the orchestrator's
 /// lifetime; `queued` and `running` reflect the live view. `running` is
-/// keyed by id with the match's start time as value — snapshot consumers
+/// keyed by id with the match's start time as value, so snapshot consumers
 /// can render an in-flight list without joining against the broadcast.
 #[derive(Debug, Clone, Default)]
 pub struct ExecutorState {

--- a/eval/orchestrator/src/state.rs
+++ b/eval/orchestrator/src/state.rs
@@ -1,0 +1,24 @@
+//! Operational, domain-free executor state.
+//!
+//! Snapshot type the orchestrator publishes. Domain-free on purpose: the
+//! map value is a bare `SystemTime` so any consumer (live UI, dashboard,
+//! test) can observe progress without needing the eval's domain types.
+
+use std::collections::HashMap;
+use std::time::SystemTime;
+
+use crate::id::MatchId;
+
+/// Snapshot of the orchestrator's operational state.
+///
+/// `finished` and `failed` are running totals over the orchestrator's
+/// lifetime; `queued` and `running` reflect the live view. `running` is
+/// keyed by id with the match's start time as value — snapshot consumers
+/// can render an in-flight list without joining against the broadcast.
+#[derive(Debug, Clone, Default)]
+pub struct ExecutorState {
+    pub queued: u64,
+    pub running: HashMap<MatchId, SystemTime>,
+    pub finished: u64,
+    pub failed: u64,
+}


### PR DESCRIPTION
## Motivation

The eval package's orchestrator is the next chunk after the host restructure landed. `pyrat-headless` is a single-match runner; tournament-scale evaluation needs a concurrent executor that runs many matches, surfaces lifecycle events, and feeds durable sinks. Before any of that wiring lands (PR 3), the public surface needs to exist so the eval session and CLI can be designed against stable types.

## Solution

A new `pyrat-orchestrator` crate at `eval/orchestrator/`. Public surface only: types, traits, the sink seam. No `JoinSet`, no broadcast, no `run_match`. That arrives in PR 3.

### Modules

- `id`: `MatchId(u64)` + `MatchIdAllocator`, one per orchestrator instance.
- `descriptor`: `Descriptor` trait, `AdHocDescriptor` for run-one paths.
- `matchup`: `Matchup<D>` (engine inputs), `PlayerSpec` (subprocess vs embedded), `Timing`, `EmbeddedBotFactory`.
- `event`: `OrchestratorEvent<D>`, the id-tagged merged stream.
- `outcome`: `MatchOutcome<D>`, `MatchFailure<D>`, `FailureReason`.
- `sink`: `MatchSink<D>` trait, `SinkRole` (Required/Optional), `NoOpSink`, `SinkError`.
- `sinks/composite`: `CompositeSink<D>` for role-based fan-out.
- `state`: `ExecutorState` (queued/running/finished/failed).

### Two design points worth pinning

**Seed lives in one place.** Earlier drafts had \`Matchup::seed\` as a separate \`u64\` alongside \`descriptor.seed()\`. That's a footgun: engine and forensic sinks could disagree about which seed actually drove the match. Now there's one source:

\`\`\`rust
pub struct Matchup<D: Descriptor> {
    pub descriptor: D,
    pub game_config: GameConfig,
    pub players: [PlayerSpec; 2],
    pub timing: Timing,
}

impl<D: Descriptor> Matchup<D> {
    pub fn seed(&self) -> u64 {
        self.descriptor.seed()
    }
}
\`\`\`

**\`CompositeSink\` partitions by role at construction.** Every \`Required\` sink runs before any \`Optional\` sink, intra-role order preserved. A caller writing \`[(Optional, replay), (Required, store)]\` no longer ends up with a forensic replay file written for a match the store later rejects.

The plan's PR 2 spec called for \`Matchup::seed: u64\` and "calls each child in order"; this PR tightens both. Plan doc updated.

### Open for PR 3

\`Box<dyn EmbeddedBot>\` doesn't auto-impl \`EmbeddedBot\`. PR 3's \`run_match.rs\` will need either a blanket \`impl<T: EmbeddedBot> EmbeddedBot for Box<T>\` or a thin adapter before handing the box to \`EmbeddedPlayer::accept<B: EmbeddedBot>\`.

## Test Plan

11 unit tests covering:
- \`MatchId\` monotonicity and serde roundtrip
- \`AdHocDescriptor\` serde roundtrip and accessor parity
- \`EmbeddedBotFactory\` produces fresh instances per call
- \`Box<dyn MatchSink<AdHocDescriptor>>\` is object-safe
- \`CompositeSink\` Required short-circuit, Optional logging, role-based ordering

\`\`\`
cargo test -p pyrat-orchestrator         # 11 passing
cargo clippy --workspace --all-targets   # clean
cargo fmt --check                        # clean
\`\`\`