### PR TITLE
Implement pyrat-orchestrator executor, replay sink, and lifecycle invariants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3094,14 +3094,17 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "parking_lot",
  "pyrat-bot-api",
  "pyrat-host",
  "pyrat-protocol",
  "pyrat-rust",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/eval/orchestrator/Cargo.toml
+++ b/eval/orchestrator/Cargo.toml
@@ -10,7 +10,11 @@ workspace = true
 [dependencies]
 pyrat-host = { path = "../../server/host" }
 pyrat-rust = { path = "../../engine", default-features = false }
-tokio = { version = "1", features = ["sync"] }
+pyrat-bot-api = { path = "../../sdk/bot-api" }
+pyrat-protocol = { path = "../../server/protocol" }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net", "time"] }
+tokio-util = { version = "0.7", features = ["rt"] }
+parking_lot = "0.12"
 tracing = "0.1"
 async-trait = "0.1"
 thiserror = "2"
@@ -19,6 +23,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
-pyrat-bot-api = { path = "../../sdk/bot-api" }
-pyrat-protocol = { path = "../../server/protocol" }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "net"] }
+tempfile = "3"

--- a/eval/orchestrator/src/error.rs
+++ b/eval/orchestrator/src/error.rs
@@ -1,0 +1,31 @@
+//! Top-level orchestrator errors.
+//!
+//! Two layers:
+//! - [`OrchestratorError`]: what callers of `submit` / `shutdown` see.
+//! - [`OrchestratorInternalError`]: what the run-loop emits before exiting
+//!   uncleanly. Surfaces through the join handle.
+
+/// Failures observed by callers of the public [`Orchestrator`] API.
+///
+/// [`Orchestrator`]: crate::executor::Orchestrator
+#[derive(Debug, thiserror::Error)]
+pub enum OrchestratorError {
+    /// The orchestrator's run-loop has exited (cancellation, driver-drop,
+    /// or panic). New submissions can't be accepted.
+    #[error("orchestrator is shut down")]
+    ShutDown,
+}
+
+/// Internal failure modes the run-loop can hit. Surfaced through the
+/// orchestrator's join handle on shutdown. Mostly forensic, since the
+/// public API treats any of these as `ShutDown` to callers.
+#[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
+pub enum OrchestratorInternalError {
+    /// The owning driver dropped its [`mpsc::Receiver<DriverEvent>`]. The
+    /// run-loop cannot continue: terminal events with no consumer mean
+    /// matches whose outcomes nobody records.
+    ///
+    /// [`mpsc::Receiver<DriverEvent>`]: tokio::sync::mpsc::Receiver
+    #[error("driver receiver dropped, orchestrator cannot continue")]
+    DriverDropped,
+}

--- a/eval/orchestrator/src/event.rs
+++ b/eval/orchestrator/src/event.rs
@@ -5,6 +5,10 @@
 //! `MatchResult`, `PlayerIdentity`) that aren't serde-friendly. Persistence
 //! flows through sink callbacks (sinks extract fields and write them);
 //! replay flows through the `ReplayEvent` DTO.
+//!
+//! Two consumers, two channels: per-turn detail goes through a lossy
+//! `broadcast`, and lifecycle (queued/started/finished/failed) goes through
+//! a lossless `mpsc`. See [`DriverEvent`] for the lifecycle subset.
 
 use pyrat_host::match_host::MatchEvent;
 use pyrat_host::player::PlayerIdentity;
@@ -54,6 +58,78 @@ impl<D: Descriptor> OrchestratorEvent<D> {
             Self::MatchEvent { id, .. } => *id,
             Self::MatchFinished { outcome } => outcome.descriptor.match_id(),
             Self::MatchFailed { failure } => failure.descriptor.match_id(),
+        }
+    }
+}
+
+/// Lifecycle-only subset of [`OrchestratorEvent`] handed to the owning
+/// driver through a lossless bounded mpsc.
+///
+/// The driver (an `EvalSession`, the run-one CLI loop, etc.) consumes these
+/// to advance domain-level state: exactly the events that mutate
+/// `TournamentState`. Per-turn `OrchestratorEvent::MatchEvent` items are
+/// **not** carried on this channel; live observers subscribe to the
+/// orchestrator's broadcast for those.
+///
+/// Constructed from `OrchestratorEvent` via
+/// [`OrchestratorEvent::driver_event`]; the `MatchEvent` variant returns
+/// `None`.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum DriverEvent<D: Descriptor> {
+    MatchQueued {
+        id: MatchId,
+        descriptor: D,
+    },
+    MatchStarted {
+        id: MatchId,
+        descriptor: D,
+        players: [PlayerIdentity; 2],
+    },
+    MatchFinished {
+        outcome: MatchOutcome<D>,
+    },
+    MatchFailed {
+        failure: MatchFailure<D>,
+    },
+}
+
+impl<D: Descriptor> DriverEvent<D> {
+    /// `MatchId` carried by every variant.
+    pub fn match_id(&self) -> MatchId {
+        match self {
+            Self::MatchQueued { id, .. } | Self::MatchStarted { id, .. } => *id,
+            Self::MatchFinished { outcome } => outcome.descriptor.match_id(),
+            Self::MatchFailed { failure } => failure.descriptor.match_id(),
+        }
+    }
+}
+
+impl<D: Descriptor> OrchestratorEvent<D> {
+    /// Project to the lifecycle subset. Returns `None` for the per-turn
+    /// `MatchEvent` variant.
+    pub fn driver_event(&self) -> Option<DriverEvent<D>> {
+        match self {
+            Self::MatchQueued { id, descriptor } => Some(DriverEvent::MatchQueued {
+                id: *id,
+                descriptor: descriptor.clone(),
+            }),
+            Self::MatchStarted {
+                id,
+                descriptor,
+                players,
+            } => Some(DriverEvent::MatchStarted {
+                id: *id,
+                descriptor: descriptor.clone(),
+                players: players.clone(),
+            }),
+            Self::MatchEvent { .. } => None,
+            Self::MatchFinished { outcome } => Some(DriverEvent::MatchFinished {
+                outcome: outcome.clone(),
+            }),
+            Self::MatchFailed { failure } => Some(DriverEvent::MatchFailed {
+                failure: failure.clone(),
+            }),
         }
     }
 }

--- a/eval/orchestrator/src/executor.rs
+++ b/eval/orchestrator/src/executor.rs
@@ -1,0 +1,382 @@
+//! Concurrent match executor: the live half of `pyrat-orchestrator`.
+//!
+//! The executor reads `Matchup<D>` from a bounded submit channel, runs each
+//! one through [`pyrat_host::match_host::Match`] on a `JoinSet`, and
+//! publishes events down two channels:
+//!
+//! - **Lifecycle** (`MatchQueued` / `MatchStarted` / `MatchFinished` /
+//!   `MatchFailed`) over a bounded `mpsc::Sender<DriverEvent<D>>`. Lossless,
+//!   single-consumer; the owning driver (an `EvalSession`, the run-one
+//!   driver, etc.) holds the receiver.
+//! - **Live**, including per-turn `MatchEvent`s, over a `broadcast`. Lossy
+//!   on slow consumers (the live UI tradeoff).
+//!
+//! State transitions are serialised through a `parking_lot::Mutex` over
+//! [`ExecutorState`], the watch sender, and the broadcast send. The lock is
+//! never held across an `.await`; the only awaited step before grabbing it
+//! is `driver_tx.send`, which provides backpressure when the driver lags.
+//!
+//! Cancellation is RAII: each per-match task gets a child of the root
+//! `CancellationToken`, watches it inside its `select!`, and drops the
+//! `Match::run` future on cancel. `BotProcesses` (held inside that task)
+//! reaps subprocesses through `Drop`.
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use parking_lot::Mutex;
+use pyrat_host::match_host::{PlayingConfig, SetupTiming};
+use tokio::sync::{broadcast, mpsc, watch, Semaphore};
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::AbortOnDropHandle;
+use tracing::{error, warn};
+
+use crate::descriptor::Descriptor;
+use crate::error::{OrchestratorError, OrchestratorInternalError};
+use crate::event::OrchestratorEvent;
+use crate::id::MatchId;
+use crate::matchup::Matchup;
+use crate::run_match;
+use crate::sink::MatchSink;
+use crate::state::ExecutorState;
+
+// Re-export the lifecycle DTO so callers see one path: `Orchestrator` ⇒
+// `DriverEvent`.
+pub use crate::event::DriverEvent;
+
+/// Tunables for one [`Orchestrator`] instance.
+#[derive(Debug, Clone)]
+pub struct OrchestratorConfig {
+    /// Maximum number of matches running concurrently (semaphore capacity).
+    pub max_parallel: usize,
+    /// Bound on the `submit` mpsc. Backpressure surface for very fast
+    /// planners.
+    pub submit_capacity: usize,
+    /// Bound on the lifecycle `mpsc<DriverEvent>`. Once full, the run-loop
+    /// awaits on `send`: the natural backpressure for a slow driver.
+    pub driver_events_capacity: usize,
+    /// Bound on the live `broadcast`. Slow consumers see `Lagged(n)` and
+    /// skip ahead (that's the design; live broadcast is lossy).
+    pub broadcast_capacity: usize,
+    /// Default host-side setup timing for every match.
+    pub setup_timing: SetupTiming,
+    /// Default host-side playing config for every match. Cloned per match
+    /// because [`PlayingConfig`] is `Clone` and the host owns it as a
+    /// per-`Match` value.
+    pub playing_config: PlayingConfig,
+    /// TCP `Identify → Welcome` handshake timeout passed to
+    /// `accept_players`. Per-match, not per-orchestrator-lifetime.
+    pub handshake_timeout: Duration,
+}
+
+impl Default for OrchestratorConfig {
+    fn default() -> Self {
+        Self {
+            max_parallel: 1,
+            submit_capacity: 64,
+            driver_events_capacity: 64,
+            broadcast_capacity: 256,
+            setup_timing: SetupTiming::default(),
+            playing_config: PlayingConfig::default(),
+            handshake_timeout: Duration::from_secs(10),
+        }
+    }
+}
+
+/// Per-match runtime config threaded through `run_match`. Cheap to clone
+/// (Arc'd at the spawn site).
+#[derive(Debug)]
+pub(crate) struct RunConfig {
+    pub setup_timing: SetupTiming,
+    pub playing_config: PlayingConfig,
+    pub handshake_timeout: Duration,
+}
+
+/// Shared state used by both the run-loop and per-match tasks.
+pub(crate) struct ExecutorInner<D: Descriptor> {
+    /// Live state, also acting as the publish mutex. Held only across
+    /// `apply_state_transition` + `state_tx.send_replace` + `broadcast.send`,
+    /// none of which `.await`.
+    state: Mutex<ExecutorState>,
+    state_tx: watch::Sender<ExecutorState>,
+    broadcast: broadcast::Sender<OrchestratorEvent<D>>,
+    /// Lifecycle feed. Run-loop and per-match tasks `.await` on it before
+    /// taking the publish mutex.
+    driver_tx: mpsc::Sender<DriverEvent<D>>,
+    /// The composed sink (store / replay / etc.). All sink calls go
+    /// through `Arc<dyn MatchSink>` so per-match tasks can share it.
+    pub(crate) sink: Arc<dyn MatchSink<D>>,
+}
+
+impl<D: Descriptor> ExecutorInner<D> {
+    /// Publish a lifecycle event (queued/started/finished/failed). Awaits
+    /// the driver mpsc first; on `SendError` returns
+    /// `OrchestratorInternalError::DriverDropped` so the run-loop can
+    /// trigger root cancellation.
+    pub(crate) async fn publish_lifecycle(
+        &self,
+        event: OrchestratorEvent<D>,
+    ) -> Result<(), OrchestratorInternalError> {
+        let driver = event
+            .driver_event()
+            .expect("publish_lifecycle called with per-turn MatchEvent");
+
+        // 1. Driver mpsc: bounded, awaited, may backpressure.
+        self.driver_tx
+            .send(driver)
+            .await
+            .map_err(|_| OrchestratorInternalError::DriverDropped)?;
+
+        // 2. Sync state-update + broadcast under publish mutex.
+        let mut state = self.state.lock();
+        apply_state_transition(&mut state, &event);
+        // `send_replace` swaps without await; clone is cheap relative to
+        // the sink path that just ran.
+        let _ = self.state_tx.send_replace(state.clone());
+        // broadcast.send returns SendError when there are no receivers,
+        // expected, lossy by design.
+        let _ = self.broadcast.send(event);
+        Ok(())
+    }
+
+    /// Publish a per-turn `MatchEvent` to live observers. No state mutation,
+    /// no driver mpsc, just broadcast.
+    pub(crate) fn publish_per_turn(&self, event: OrchestratorEvent<D>) {
+        let _ = self.broadcast.send(event);
+    }
+
+    /// Take an atomic snapshot of state alongside a fresh broadcast
+    /// receiver. The mutex is held only across `.lock()` + clone +
+    /// `subscribe()`; no awaits, so events published between the snapshot
+    /// and the new receiver creation are impossible.
+    pub(crate) fn atomic_subscribe(
+        &self,
+    ) -> (ExecutorState, broadcast::Receiver<OrchestratorEvent<D>>) {
+        let state = self.state.lock();
+        let snapshot = state.clone();
+        let rx = self.broadcast.subscribe();
+        drop(state);
+        (snapshot, rx)
+    }
+}
+
+fn apply_state_transition<D: Descriptor>(state: &mut ExecutorState, event: &OrchestratorEvent<D>) {
+    match event {
+        OrchestratorEvent::MatchQueued { .. } => {
+            state.queued = state.queued.saturating_add(1);
+        },
+        OrchestratorEvent::MatchStarted { id, .. } => {
+            state.queued = state.queued.saturating_sub(1);
+            state.running.insert(*id, SystemTime::now());
+        },
+        OrchestratorEvent::MatchFinished { outcome } => {
+            state.running.remove(&outcome.descriptor.match_id());
+            state.finished = state.finished.saturating_add(1);
+        },
+        OrchestratorEvent::MatchFailed { failure } => {
+            let id = failure.descriptor.match_id();
+            // The match might have been queued-only (failed before
+            // MatchStarted) or actually running. The two cases differ only
+            // in which counter to decrement.
+            if state.running.remove(&id).is_none() {
+                state.queued = state.queued.saturating_sub(1);
+            }
+            state.failed = state.failed.saturating_add(1);
+        },
+        OrchestratorEvent::MatchEvent { .. } => {
+            unreachable!("apply_state_transition called for per-turn event")
+        },
+    }
+}
+
+/// Concurrent match executor. Owns the run-loop task; drops it on `Drop`.
+pub struct Orchestrator<D: Descriptor> {
+    inner: Arc<ExecutorInner<D>>,
+    submit_tx: mpsc::Sender<Matchup<D>>,
+    root_cancel: CancellationToken,
+    /// Aborts the run-loop if the orchestrator is dropped without
+    /// `shutdown` being called.
+    _run_loop: AbortOnDropHandle<()>,
+    semaphore: Arc<Semaphore>,
+    allocator: crate::id::MatchIdAllocator,
+}
+
+impl<D: Descriptor> Orchestrator<D> {
+    /// Construct an orchestrator. Returns `(self, driver_rx)`. The caller
+    /// (the "driver", typically an `EvalSession` or a CLI loop) consumes
+    /// the lifecycle mpsc exclusively. Dropping `driver_rx` is fatal: the
+    /// run-loop sees `SendError` on the next lifecycle publish, cancels
+    /// every match, drains, and exits.
+    pub fn new(
+        config: OrchestratorConfig,
+        sink: Arc<dyn MatchSink<D>>,
+    ) -> (Self, mpsc::Receiver<DriverEvent<D>>) {
+        let (submit_tx, submit_rx) = mpsc::channel::<Matchup<D>>(config.submit_capacity);
+        let (driver_tx, driver_rx) = mpsc::channel::<DriverEvent<D>>(config.driver_events_capacity);
+        let (broadcast_tx, _broadcast_rx) =
+            broadcast::channel::<OrchestratorEvent<D>>(config.broadcast_capacity);
+        let initial_state = ExecutorState::default();
+        let (state_tx, _state_rx) = watch::channel(initial_state.clone());
+
+        let inner = Arc::new(ExecutorInner {
+            state: Mutex::new(initial_state),
+            state_tx,
+            broadcast: broadcast_tx,
+            driver_tx,
+            sink,
+        });
+
+        let semaphore = Arc::new(Semaphore::new(config.max_parallel));
+        let root_cancel = CancellationToken::new();
+        let run_cfg = Arc::new(RunConfig {
+            setup_timing: config.setup_timing,
+            playing_config: config.playing_config,
+            handshake_timeout: config.handshake_timeout,
+        });
+
+        let inner_for_loop = inner.clone();
+        let sem_for_loop = semaphore.clone();
+        let cancel_for_loop = root_cancel.clone();
+        let run_loop_handle = tokio::spawn(run_loop(
+            inner_for_loop,
+            submit_rx,
+            sem_for_loop,
+            cancel_for_loop,
+            run_cfg,
+        ));
+        let _run_loop = AbortOnDropHandle::new(run_loop_handle);
+
+        (
+            Self {
+                inner,
+                submit_tx,
+                root_cancel,
+                _run_loop,
+                semaphore,
+                allocator: crate::id::MatchIdAllocator::new(),
+            },
+            driver_rx,
+        )
+    }
+
+    /// Allocate a fresh `MatchId` from this orchestrator's monotonic space.
+    /// Use it to populate the descriptor before [`Self::submit`].
+    pub fn allocate_id(&self) -> MatchId {
+        self.allocator.allocate()
+    }
+
+    /// Submit a matchup. Backpressure: if the submit channel is full,
+    /// awaits until a slot frees. Returns `ShutDown` if the run-loop has
+    /// already exited.
+    pub async fn submit(&self, matchup: Matchup<D>) -> Result<(), OrchestratorError> {
+        self.submit_tx
+            .send(matchup)
+            .await
+            .map_err(|_| OrchestratorError::ShutDown)
+    }
+
+    /// Atomic `(state_snapshot, broadcast_receiver)`. Lifecycle effects
+    /// reflected in the snapshot precede any subsequent broadcast item the
+    /// returned receiver observes.
+    pub fn subscribe(&self) -> (ExecutorState, broadcast::Receiver<OrchestratorEvent<D>>) {
+        self.inner.atomic_subscribe()
+    }
+
+    /// Late lossy subscription to the broadcast stream. Same as
+    /// `subscribe().1` but without the snapshot.
+    pub fn events(&self) -> broadcast::Receiver<OrchestratorEvent<D>> {
+        self.inner.broadcast.subscribe()
+    }
+
+    /// Watch over the executor state. Useful for one-shot snapshots and
+    /// idle polling.
+    pub fn state(&self) -> watch::Receiver<ExecutorState> {
+        self.inner.state_tx.subscribe()
+    }
+
+    /// Available semaphore permits (`max_parallel - in_flight`).
+    pub fn available_capacity(&self) -> usize {
+        self.semaphore.available_permits()
+    }
+
+    /// True when nothing is queued or running. Snapshot-based, may race
+    /// with submit; use `state().changed()` for edge detection.
+    pub fn idle(&self) -> bool {
+        let s = self.inner.state.lock();
+        s.queued == 0 && s.running.is_empty()
+    }
+
+    /// Trigger graceful shutdown: cancel the root token, close the submit
+    /// channel, and wait for the run-loop to drain. Returns once the
+    /// run-loop has exited.
+    pub async fn shutdown(self) {
+        self.root_cancel.cancel();
+        // Drop submit_tx so any blocked sender returns; the run-loop's
+        // `recv` returns None and breaks the loop. AbortOnDropHandle
+        // aborts the run-loop task on drop.
+        drop(self.submit_tx);
+        drop(self._run_loop);
+    }
+
+    /// Synchronous abort: cancel the root token immediately. The run-loop
+    /// is aborted at orchestrator drop time via `AbortOnDropHandle`. Use
+    /// when graceful shutdown isn't needed.
+    pub fn abort(&self) {
+        self.root_cancel.cancel();
+    }
+}
+
+async fn run_loop<D: Descriptor>(
+    inner: Arc<ExecutorInner<D>>,
+    mut submit_rx: mpsc::Receiver<Matchup<D>>,
+    semaphore: Arc<Semaphore>,
+    root_cancel: CancellationToken,
+    run_cfg: Arc<RunConfig>,
+) {
+    let mut tasks: JoinSet<()> = JoinSet::new();
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = root_cancel.cancelled() => break,
+            joined = tasks.join_next(), if !tasks.is_empty() => {
+                if let Some(Err(e)) = joined {
+                    if e.is_panic() {
+                        // run_match catches Match::run errors and emits
+                        // MatchFailed { Panic }. If run_match itself
+                        // panicked, no terminal was published.
+                        error!(error = %e, "run_match task panicked unexpectedly");
+                    } else if e.is_cancelled() {
+                        // Force-aborted task. This shouldn't happen
+                        // because we drop futures cooperatively, but it's
+                        // legitimate during shutdown.
+                        warn!("run_match task was force-aborted");
+                    }
+                }
+            }
+            maybe_item = submit_rx.recv() => {
+                let Some(matchup) = maybe_item else { break; };
+                let inner_c = inner.clone();
+                let sem_c = semaphore.clone();
+                let cfg_c = run_cfg.clone();
+                let cancel = root_cancel.child_token();
+                tasks.spawn(async move {
+                    run_match::run_match(inner_c, matchup, cancel, sem_c, cfg_c).await;
+                });
+            }
+        }
+    }
+
+    // Drain in-flight tasks. Each child sees root_cancel.cancelled() in
+    // its biased select and bails through Drop on the run future. Wait
+    // bounded so a misbehaving sink doesn't strand shutdown forever.
+    let drain = async { while tasks.join_next().await.is_some() {} };
+    if tokio::time::timeout(Duration::from_secs(10), drain)
+        .await
+        .is_err()
+    {
+        warn!("orchestrator shutdown drain timed out, aborting stragglers");
+        tasks.shutdown().await;
+    }
+}

--- a/eval/orchestrator/src/executor.rs
+++ b/eval/orchestrator/src/executor.rs
@@ -20,16 +20,31 @@
 //! `CancellationToken`, watches it inside its `select!`, and drops the
 //! `Match::run` future on cancel. `BotProcesses` (held inside that task)
 //! reaps subprocesses through `Drop`.
+//!
+//! On `DriverDropped` (the lifecycle mpsc receiver was dropped) the next
+//! `publish_lifecycle` call cancels the root token, which is what unwinds
+//! the run-loop and per-match tasks. The broadcast `Sender` lives on
+//! `ExecutorInner` and only closes when the orchestrator itself drops; the
+//! "close broadcast" wording in the eval brief is aspirational. The
+//! practical equivalent (cancel matches → run-loop exits → no further
+//! events emitted) is what's shipped here.
+//!
+//! Panic recovery: per-match tasks normally own their own terminal
+//! publication. If a task panics or is force-aborted, the run-loop
+//! correlates the `JoinError` back to the descriptor via an
+//! `in_flight: HashMap<task::Id, D>` (populated at spawn time) and
+//! synthesises a `MatchFailed { Panic | Cancelled, durable_record: false }`
+//! terminal so the lifecycle mpsc and `state.running` stay consistent.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use parking_lot::Mutex;
 use pyrat_host::match_host::{PlayingConfig, SetupTiming};
 use tokio::sync::{broadcast, mpsc, watch, Semaphore};
-use tokio::task::JoinSet;
+use tokio::task::{JoinError, JoinHandle, JoinSet};
 use tokio_util::sync::CancellationToken;
-use tokio_util::task::AbortOnDropHandle;
 use tracing::{error, warn};
 
 use crate::descriptor::Descriptor;
@@ -37,6 +52,7 @@ use crate::error::{OrchestratorError, OrchestratorInternalError};
 use crate::event::OrchestratorEvent;
 use crate::id::MatchId;
 use crate::matchup::Matchup;
+use crate::outcome::{FailureReason, MatchFailure};
 use crate::run_match;
 use crate::sink::MatchSink;
 use crate::state::ExecutorState;
@@ -107,13 +123,21 @@ pub(crate) struct ExecutorInner<D: Descriptor> {
     /// The composed sink (store / replay / etc.). All sink calls go
     /// through `Arc<dyn MatchSink>` so per-match tasks can share it.
     pub(crate) sink: Arc<dyn MatchSink<D>>,
+    /// Root cancellation. Cancelled on shutdown, or by `publish_lifecycle`
+    /// when the driver receiver is gone (`DriverDropped` is fatal).
+    root_cancel: CancellationToken,
+    /// Descriptors of every spawned per-match task, keyed by `task::Id`.
+    /// Populated at spawn (run-loop), removed on clean exit, or used by
+    /// `handle_joined` to synthesise a terminal when a task panics or is
+    /// force-aborted.
+    pub(crate) in_flight: Mutex<HashMap<tokio::task::Id, D>>,
 }
 
 impl<D: Descriptor> ExecutorInner<D> {
     /// Publish a lifecycle event (queued/started/finished/failed). Awaits
-    /// the driver mpsc first; on `SendError` returns
-    /// `OrchestratorInternalError::DriverDropped` so the run-loop can
-    /// trigger root cancellation.
+    /// the driver mpsc first; on `SendError` cancels the root token (so
+    /// the run-loop unwinds) and returns
+    /// `OrchestratorInternalError::DriverDropped`.
     pub(crate) async fn publish_lifecycle(
         &self,
         event: OrchestratorEvent<D>,
@@ -123,10 +147,13 @@ impl<D: Descriptor> ExecutorInner<D> {
             .expect("publish_lifecycle called with per-turn MatchEvent");
 
         // 1. Driver mpsc: bounded, awaited, may backpressure.
-        self.driver_tx
-            .send(driver)
-            .await
-            .map_err(|_| OrchestratorInternalError::DriverDropped)?;
+        if self.driver_tx.send(driver).await.is_err() {
+            // Driver receiver gone. Cancel root so the run-loop and any
+            // sibling per-match tasks unwind on their next cancel-arm tick.
+            // Idempotent: re-cancel is a no-op.
+            self.root_cancel.cancel();
+            return Err(OrchestratorInternalError::DriverDropped);
+        }
 
         // 2. Sync state-update + broadcast under publish mutex.
         let mut state = self.state.lock();
@@ -190,14 +217,18 @@ fn apply_state_transition<D: Descriptor>(state: &mut ExecutorState, event: &Orch
     }
 }
 
-/// Concurrent match executor. Owns the run-loop task; drops it on `Drop`.
+/// Concurrent match executor. Owns the run-loop task; aborts it on `Drop`
+/// if `shutdown` wasn't called, awaits it cleanly if it was.
 pub struct Orchestrator<D: Descriptor> {
     inner: Arc<ExecutorInner<D>>,
-    submit_tx: mpsc::Sender<Matchup<D>>,
+    /// `Option` so `shutdown(self)` can take the sender out and drop it
+    /// (closing the run-loop's submit_rx) before awaiting the run-loop.
+    submit_tx: Option<mpsc::Sender<Matchup<D>>>,
     root_cancel: CancellationToken,
-    /// Aborts the run-loop if the orchestrator is dropped without
-    /// `shutdown` being called.
-    _run_loop: AbortOnDropHandle<()>,
+    /// `Option` so `shutdown(self)` can take the handle and `.await` it.
+    /// On a drop without prior shutdown, the manual `Drop` impl below
+    /// aborts whatever is left.
+    run_loop_handle: Option<JoinHandle<()>>,
     semaphore: Arc<Semaphore>,
     allocator: crate::id::MatchIdAllocator,
 }
@@ -206,8 +237,8 @@ impl<D: Descriptor> Orchestrator<D> {
     /// Construct an orchestrator. Returns `(self, driver_rx)`. The caller
     /// (the "driver", typically an `EvalSession` or a CLI loop) consumes
     /// the lifecycle mpsc exclusively. Dropping `driver_rx` is fatal: the
-    /// run-loop sees `SendError` on the next lifecycle publish, cancels
-    /// every match, drains, and exits.
+    /// next lifecycle publish sees `SendError`, cancels the root token,
+    /// the run-loop unwinds, drains, and exits.
     pub fn new(
         config: OrchestratorConfig,
         sink: Arc<dyn MatchSink<D>>,
@@ -219,16 +250,18 @@ impl<D: Descriptor> Orchestrator<D> {
         let initial_state = ExecutorState::default();
         let (state_tx, _state_rx) = watch::channel(initial_state.clone());
 
+        let root_cancel = CancellationToken::new();
         let inner = Arc::new(ExecutorInner {
             state: Mutex::new(initial_state),
             state_tx,
             broadcast: broadcast_tx,
             driver_tx,
             sink,
+            root_cancel: root_cancel.clone(),
+            in_flight: Mutex::new(HashMap::new()),
         });
 
         let semaphore = Arc::new(Semaphore::new(config.max_parallel));
-        let root_cancel = CancellationToken::new();
         let run_cfg = Arc::new(RunConfig {
             setup_timing: config.setup_timing,
             playing_config: config.playing_config,
@@ -245,14 +278,13 @@ impl<D: Descriptor> Orchestrator<D> {
             cancel_for_loop,
             run_cfg,
         ));
-        let _run_loop = AbortOnDropHandle::new(run_loop_handle);
 
         (
             Self {
                 inner,
-                submit_tx,
+                submit_tx: Some(submit_tx),
                 root_cancel,
-                _run_loop,
+                run_loop_handle: Some(run_loop_handle),
                 semaphore,
                 allocator: crate::id::MatchIdAllocator::new(),
             },
@@ -268,10 +300,10 @@ impl<D: Descriptor> Orchestrator<D> {
 
     /// Submit a matchup. Backpressure: if the submit channel is full,
     /// awaits until a slot frees. Returns `ShutDown` if the run-loop has
-    /// already exited.
+    /// already exited (or `shutdown` consumed the sender).
     pub async fn submit(&self, matchup: Matchup<D>) -> Result<(), OrchestratorError> {
-        self.submit_tx
-            .send(matchup)
+        let tx = self.submit_tx.as_ref().ok_or(OrchestratorError::ShutDown)?;
+        tx.send(matchup)
             .await
             .map_err(|_| OrchestratorError::ShutDown)
     }
@@ -308,22 +340,40 @@ impl<D: Descriptor> Orchestrator<D> {
     }
 
     /// Trigger graceful shutdown: cancel the root token, close the submit
-    /// channel, and wait for the run-loop to drain. Returns once the
-    /// run-loop has exited.
-    pub async fn shutdown(self) {
+    /// channel, and await the run-loop drain. Returns once the run-loop
+    /// task has actually exited (including its bounded straggler-drain
+    /// timeout). Per-match terminal events fire normally en route, so
+    /// callers must keep the lifecycle `driver_rx` polled — otherwise
+    /// `publish_lifecycle` from a draining task will backpressure-stall on
+    /// `driver_tx.send`.
+    pub async fn shutdown(mut self) {
         self.root_cancel.cancel();
-        // Drop submit_tx so any blocked sender returns; the run-loop's
-        // `recv` returns None and breaks the loop. AbortOnDropHandle
-        // aborts the run-loop task on drop.
-        drop(self.submit_tx);
-        drop(self._run_loop);
+        // Drop submit_tx so any blocked sender returns and the run-loop's
+        // `recv` returns None.
+        drop(self.submit_tx.take());
+        if let Some(h) = self.run_loop_handle.take() {
+            let _ = h.await;
+        }
     }
 
     /// Synchronous abort: cancel the root token immediately. The run-loop
-    /// is aborted at orchestrator drop time via `AbortOnDropHandle`. Use
+    /// task is aborted at orchestrator drop time via the `Drop` impl. Use
     /// when graceful shutdown isn't needed.
     pub fn abort(&self) {
         self.root_cancel.cancel();
+    }
+}
+
+impl<D: Descriptor> Drop for Orchestrator<D> {
+    /// Belt-and-braces. If the orchestrator is dropped without `shutdown`
+    /// being awaited, cancel root and abort the run-loop task to avoid
+    /// stranding it. `shutdown` already takes both fields, so this is a
+    /// no-op on the graceful path.
+    fn drop(&mut self) {
+        self.root_cancel.cancel();
+        if let Some(h) = self.run_loop_handle.take() {
+            h.abort();
+        }
     }
 }
 
@@ -340,43 +390,103 @@ async fn run_loop<D: Descriptor>(
         tokio::select! {
             biased;
             _ = root_cancel.cancelled() => break,
-            joined = tasks.join_next(), if !tasks.is_empty() => {
-                if let Some(Err(e)) = joined {
-                    if e.is_panic() {
-                        // run_match catches Match::run errors and emits
-                        // MatchFailed { Panic }. If run_match itself
-                        // panicked, no terminal was published.
-                        error!(error = %e, "run_match task panicked unexpectedly");
-                    } else if e.is_cancelled() {
-                        // Force-aborted task. This shouldn't happen
-                        // because we drop futures cooperatively, but it's
-                        // legitimate during shutdown.
-                        warn!("run_match task was force-aborted");
-                    }
-                }
+            Some(joined) = tasks.join_next_with_id(), if !tasks.is_empty() => {
+                handle_joined(&inner, joined).await;
             }
             maybe_item = submit_rx.recv() => {
                 let Some(matchup) = maybe_item else { break; };
+                let descriptor = matchup.descriptor.clone();
                 let inner_c = inner.clone();
                 let sem_c = semaphore.clone();
                 let cfg_c = run_cfg.clone();
                 let cancel = root_cancel.child_token();
-                tasks.spawn(async move {
+                let abort_handle = tasks.spawn(async move {
                     run_match::run_match(inner_c, matchup, cancel, sem_c, cfg_c).await;
                 });
+                inner.in_flight.lock().insert(abort_handle.id(), descriptor);
             }
         }
     }
 
     // Drain in-flight tasks. Each child sees root_cancel.cancelled() in
-    // its biased select and bails through Drop on the run future. Wait
-    // bounded so a misbehaving sink doesn't strand shutdown forever.
-    let drain = async { while tasks.join_next().await.is_some() {} };
-    if tokio::time::timeout(Duration::from_secs(10), drain)
-        .await
-        .is_err()
+    // its biased select and bails through Drop on the run future. We use
+    // `join_next_with_id` so panicked / force-aborted stragglers are
+    // routed through `handle_joined` and synthesise terminals — without
+    // that, `state.running` would retain the straggler's id forever.
     {
-        warn!("orchestrator shutdown drain timed out, aborting stragglers");
-        tasks.shutdown().await;
+        let drain_inner = &inner;
+        let drain = async {
+            while let Some(joined) = tasks.join_next_with_id().await {
+                handle_joined(drain_inner, joined).await;
+            }
+        };
+        if tokio::time::timeout(Duration::from_secs(10), drain)
+            .await
+            .is_err()
+        {
+            warn!("orchestrator shutdown drain timed out, aborting stragglers");
+            tasks.abort_all();
+            while let Some(joined) = tasks.join_next_with_id().await {
+                handle_joined(&inner, joined).await;
+            }
+        }
+    }
+}
+
+/// Per-task disposition handler shared by the main select loop, the drain
+/// loop, and the post-timeout force-abort drain. Clean exits remove the
+/// in-flight entry; `JoinError`s look up the descriptor and synthesise a
+/// terminal `MatchFailed` so the lifecycle mpsc and `state.running` stay
+/// consistent. After publishing, calls `sink.on_match_abandoned` so
+/// stateful sinks (e.g. `ReplaySink`'s per-match buffer) release whatever
+/// the dead task populated before going down. Both publishes are
+/// best-effort; a failed publish here means the driver receiver is gone
+/// (which already triggered root cancel via `publish_lifecycle`).
+async fn handle_joined<D: Descriptor>(
+    inner: &Arc<ExecutorInner<D>>,
+    joined: Result<(tokio::task::Id, ()), JoinError>,
+) {
+    match joined {
+        Ok((id, ())) => {
+            // Per-match task already published its own terminal.
+            inner.in_flight.lock().remove(&id);
+        },
+        Err(je) => {
+            let task_id = je.id();
+            let descriptor = match inner.in_flight.lock().remove(&task_id) {
+                Some(d) => d,
+                None => {
+                    // Defensive: spawn-side insert is synchronous before
+                    // any `.await`, so the entry should be present.
+                    error!(?task_id, "JoinError for unknown in-flight task id");
+                    return;
+                },
+            };
+            let match_id = descriptor.match_id();
+            let reason = if je.is_panic() {
+                error!(?task_id, %match_id, error = %je, "run_match task panicked");
+                FailureReason::Panic
+            } else if je.is_cancelled() {
+                warn!(?task_id, %match_id, "run_match task was force-aborted");
+                FailureReason::Cancelled
+            } else {
+                FailureReason::Internal(format!("join error: {je}"))
+            };
+            let failure = MatchFailure {
+                descriptor,
+                started_at: None,
+                failed_at: SystemTime::now(),
+                reason,
+                players: None,
+                durable_record: false,
+            };
+            let _ = inner
+                .publish_lifecycle(OrchestratorEvent::MatchFailed { failure })
+                .await;
+            // Best-effort cleanup of any stateful sink buffers populated
+            // by the dead task before it went down. Errors are ignored;
+            // composite/optional sinks log them through their own paths.
+            let _ = inner.sink.on_match_abandoned(match_id).await;
+        },
     }
 }

--- a/eval/orchestrator/src/lib.rs
+++ b/eval/orchestrator/src/lib.rs
@@ -3,19 +3,27 @@
 //! not SQLite, not Elo, not tournaments.
 
 pub mod descriptor;
+pub mod error;
 pub mod event;
+pub mod executor;
 pub mod id;
 pub mod matchup;
 pub mod outcome;
+pub mod replay_event;
+mod run_match;
 pub mod sink;
 pub mod sinks;
 pub mod state;
 
 pub use descriptor::{AdHocDescriptor, Descriptor};
-pub use event::OrchestratorEvent;
+pub use error::{OrchestratorError, OrchestratorInternalError};
+pub use event::{DriverEvent, OrchestratorEvent};
+pub use executor::{Orchestrator, OrchestratorConfig};
 pub use id::{MatchId, MatchIdAllocator};
 pub use matchup::{EmbeddedBotFactory, Matchup, PlayerSpec, Timing};
 pub use outcome::{FailureReason, MatchFailure, MatchOutcome};
+pub use replay_event::{ReplayEvent, ReplayInfo, ReplayMatchConfig, ReplayMatchResult};
 pub use sink::{MatchSink, NoOpSink, SinkError, SinkRole};
 pub use sinks::composite::CompositeSink;
+pub use sinks::replay::{DirectoryWriter, MemoryWriter, ReplayFile, ReplaySink, ReplayWriter};
 pub use state::ExecutorState;

--- a/eval/orchestrator/src/matchup.rs
+++ b/eval/orchestrator/src/matchup.rs
@@ -54,9 +54,14 @@ pub enum PlayerSpec {
         command: String,
         working_dir: Option<PathBuf>,
     },
-    /// Build an in-process bot via `factory`.
+    /// Build an in-process bot via `factory`. `name` and `author` populate
+    /// the `PlayerIdentity` handed to `EmbeddedPlayer::accept`; without them
+    /// every embedded bot would identify anonymously in `BotIdentified`
+    /// events, replays, and the durable record.
     Embedded {
         agent_id: String,
+        name: String,
+        author: String,
         factory: EmbeddedBotFactory,
     },
 }
@@ -74,9 +79,16 @@ impl std::fmt::Debug for PlayerSpec {
                 .field("command", command)
                 .field("working_dir", working_dir)
                 .finish(),
-            Self::Embedded { agent_id, .. } => f
+            Self::Embedded {
+                agent_id,
+                name,
+                author,
+                ..
+            } => f
                 .debug_struct("Embedded")
                 .field("agent_id", agent_id)
+                .field("name", name)
+                .field("author", author)
                 .field("factory", &"<closure>")
                 .finish(),
         }
@@ -147,6 +159,24 @@ mod tests {
         let _bot_a = factory();
         let _bot_b = factory();
         assert_eq!(counter.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn embedded_spec_carries_name_and_author() {
+        let factory: EmbeddedBotFactory = Arc::new(|| Box::new(CountingBot));
+        let spec = PlayerSpec::Embedded {
+            agent_id: "pyrat/test".into(),
+            name: "Tester".into(),
+            author: "team".into(),
+            factory,
+        };
+        match spec {
+            PlayerSpec::Embedded { name, author, .. } => {
+                assert_eq!(name, "Tester");
+                assert_eq!(author, "team");
+            },
+            other => panic!("expected Embedded, got {other:?}"),
+        }
     }
 
     #[test]

--- a/eval/orchestrator/src/outcome.rs
+++ b/eval/orchestrator/src/outcome.rs
@@ -10,6 +10,7 @@ use std::time::SystemTime;
 
 use pyrat_host::match_host::MatchResult;
 use pyrat_host::player::PlayerIdentity;
+use pyrat_host::wire::Player as PlayerSlot;
 
 use crate::descriptor::Descriptor;
 
@@ -43,15 +44,30 @@ pub struct MatchFailure<D: Descriptor> {
 }
 
 /// Why a match failed. Operational categories, not user-facing messages.
+///
+/// `ProtocolError`, `Disconnected`, and `SinkFlushError` carry payloads so a
+/// failed-tournament forensic pass has enough context to triage without
+/// reaching back into per-match logs: the underlying error string for
+/// protocol faults, the player slot for clean disconnects, the propagated
+/// sink error string for flush failures.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum FailureReason {
     SpawnFailed,
     HandshakeTimeout,
-    Disconnected,
-    ProtocolError,
+    /// A player closed transport-cleanly while Match needed it. The slot
+    /// identifies which one.
+    Disconnected(PlayerSlot),
+    /// Protocol-layer fault (timeout, hash mismatch, malformed message).
+    /// Payload is the underlying `MatchError`/`PlayerError` rendered via
+    /// `Display` at the fault site, enough to triage without reaching back
+    /// into per-match logs.
+    ProtocolError(String),
     Panic,
     Cancelled,
-    SinkFlushError,
+    /// A `Required` sink errored on a terminal callback (or on
+    /// `on_match_event` while a match was running). Payload is the
+    /// `SinkError` rendered via `Display`.
+    SinkFlushError(String),
     Internal(String),
 }

--- a/eval/orchestrator/src/replay_event.rs
+++ b/eval/orchestrator/src/replay_event.rs
@@ -1,0 +1,412 @@
+//! Serde-friendly mirror of [`MatchEvent`] for replay JSON files.
+//!
+//! `MatchEvent` carries flatbuffers-generated wire types (`Player`,
+//! `Direction`, `TimingMode`, `GameResult`) that don't derive `Serialize`,
+//! so a sink can't write them directly. The DTO at this boundary flattens
+//! every wire value to a primitive (`u8` for enums, `(u8, u8)` for
+//! `Coordinates`) so a `serde_json` writer doesn't need to reach into the
+//! protocol crate.
+//!
+//! The conversion is **one-way**: `From<&MatchEvent>`. We never reconstruct
+//! a `MatchEvent` from a replay file: replays are forensic records, not
+//! a substitute for a live match.
+//!
+//! `MatchEvent` is `#[non_exhaustive]`, so the catch-all maps unknown host
+//! variants to [`ReplayEvent::Unknown`] with a `Debug`-rendered string.
+//! Lossy but explicit: a forensic file ending in `Unknown` records *that*
+//! the host emitted something the orchestrator didn't recognise, with
+//! enough detail to chase it down.
+
+use pyrat::Direction;
+use pyrat_host::match_host::{MatchEvent, MatchResult};
+use pyrat_protocol::{Info, MatchConfig};
+use serde::{Deserialize, Serialize};
+
+/// `(x, y)` pair, the wire encoding for `pyrat::Coordinates`.
+type CoordPair = (u8, u8);
+
+/// Flat mirror of [`MatchEvent`] suitable for JSON serialisation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ReplayEvent {
+    BotIdentified {
+        /// Slot the bot was assigned (Player1 = 0, Player2 = 1).
+        player: u8,
+        name: String,
+        author: String,
+        agent_id: String,
+    },
+    PreprocessingStarted,
+    SetupComplete,
+    MatchStarted {
+        config: ReplayMatchConfig,
+    },
+    TurnPlayed {
+        turn: u16,
+        state_hash: u64,
+        p1_position: CoordPair,
+        p2_position: CoordPair,
+        p1_score: f32,
+        p2_score: f32,
+        p1_mud_turns: u8,
+        p2_mud_turns: u8,
+        p1_action: u8,
+        p2_action: u8,
+        p1_last_move: u8,
+        p2_last_move: u8,
+        cheese: Vec<CoordPair>,
+        p1_think_ms: u32,
+        p2_think_ms: u32,
+    },
+    BotInfo {
+        sender: u8,
+        turn: u16,
+        state_hash: u64,
+        info: ReplayInfo,
+    },
+    BotProvisional {
+        sender: u8,
+        turn: u16,
+        state_hash: u64,
+        direction: u8,
+    },
+    BotTimeout {
+        player: u8,
+        turn: u16,
+    },
+    /// Synthesised by the replay sink at terminal time. The host's
+    /// `MatchOver` is suppressed by the orchestrator (see `run_match.rs`),
+    /// so any `ReplayEvent::MatchOver` in a file came from the sink, not
+    /// the host event stream.
+    MatchOver {
+        result: ReplayMatchResult,
+    },
+    /// Catch-all for `MatchEvent` variants the orchestrator doesn't yet
+    /// recognise. Carries the `Debug` rendering as the only crumb.
+    Unknown {
+        variant_debug: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReplayMatchConfig {
+    pub width: u8,
+    pub height: u8,
+    pub max_turns: u16,
+    pub walls: Vec<(CoordPair, CoordPair)>,
+    /// `(pos1, pos2, turns)` triples. `pos1 <= pos2` is enforced by
+    /// `pyrat_host::match_config::build_match_config`.
+    pub mud: Vec<(CoordPair, CoordPair, u8)>,
+    pub cheese: Vec<CoordPair>,
+    pub player1_start: CoordPair,
+    pub player2_start: CoordPair,
+    /// `TimingMode` as a wire-level `u8`.
+    pub timing: u8,
+    pub move_timeout_ms: u32,
+    pub preprocessing_timeout_ms: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReplayMatchResult {
+    /// `GameResult` as a wire-level `u8` (Player1 = 0, Player2 = 1, Draw = 2).
+    pub result: u8,
+    pub player1_score: f32,
+    pub player2_score: f32,
+    pub turns_played: u16,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReplayInfo {
+    pub player: u8,
+    pub multipv: u16,
+    pub target: Option<CoordPair>,
+    pub depth: u16,
+    pub nodes: u32,
+    pub score: Option<f32>,
+    /// `Direction`s rendered as `u8`.
+    pub pv: Vec<u8>,
+    pub message: String,
+    pub turn: u16,
+    pub state_hash: u64,
+}
+
+fn coord(c: pyrat::Coordinates) -> CoordPair {
+    (c.x, c.y)
+}
+
+fn dir(d: Direction) -> u8 {
+    d as u8
+}
+
+impl From<&MatchConfig> for ReplayMatchConfig {
+    fn from(cfg: &MatchConfig) -> Self {
+        Self {
+            width: cfg.width,
+            height: cfg.height,
+            max_turns: cfg.max_turns,
+            walls: cfg
+                .walls
+                .iter()
+                .map(|(a, b)| (coord(*a), coord(*b)))
+                .collect(),
+            mud: cfg
+                .mud
+                .iter()
+                .map(|m| (coord(m.pos1), coord(m.pos2), m.turns))
+                .collect(),
+            cheese: cfg.cheese.iter().copied().map(coord).collect(),
+            player1_start: coord(cfg.player1_start),
+            player2_start: coord(cfg.player2_start),
+            timing: cfg.timing.0,
+            move_timeout_ms: cfg.move_timeout_ms,
+            preprocessing_timeout_ms: cfg.preprocessing_timeout_ms,
+        }
+    }
+}
+
+impl From<&MatchResult> for ReplayMatchResult {
+    fn from(r: &MatchResult) -> Self {
+        Self {
+            result: r.result.0,
+            player1_score: r.player1_score,
+            player2_score: r.player2_score,
+            turns_played: r.turns_played,
+        }
+    }
+}
+
+impl From<&Info> for ReplayInfo {
+    fn from(info: &Info) -> Self {
+        Self {
+            player: info.player.0,
+            multipv: info.multipv,
+            target: info.target.map(coord),
+            depth: info.depth,
+            nodes: info.nodes,
+            score: info.score,
+            pv: info.pv.iter().copied().map(dir).collect(),
+            message: info.message.clone(),
+            turn: info.turn,
+            state_hash: info.state_hash,
+        }
+    }
+}
+
+impl From<&MatchEvent> for ReplayEvent {
+    fn from(event: &MatchEvent) -> Self {
+        match event {
+            MatchEvent::BotIdentified {
+                player,
+                name,
+                author,
+                agent_id,
+            } => Self::BotIdentified {
+                player: player.0,
+                name: name.clone(),
+                author: author.clone(),
+                agent_id: agent_id.clone(),
+            },
+            MatchEvent::PreprocessingStarted => Self::PreprocessingStarted,
+            MatchEvent::SetupComplete => Self::SetupComplete,
+            MatchEvent::MatchStarted { config } => Self::MatchStarted {
+                config: config.into(),
+            },
+            MatchEvent::TurnPlayed {
+                state,
+                p1_action,
+                p2_action,
+                p1_think_ms,
+                p2_think_ms,
+            } => Self::TurnPlayed {
+                turn: state.turn,
+                state_hash: state.state_hash(),
+                p1_position: coord(state.player1_position),
+                p2_position: coord(state.player2_position),
+                p1_score: state.player1_score,
+                p2_score: state.player2_score,
+                p1_mud_turns: state.player1_mud_turns,
+                p2_mud_turns: state.player2_mud_turns,
+                p1_action: dir(*p1_action),
+                p2_action: dir(*p2_action),
+                p1_last_move: dir(state.player1_last_move),
+                p2_last_move: dir(state.player2_last_move),
+                cheese: state.cheese.iter().copied().map(coord).collect(),
+                p1_think_ms: *p1_think_ms,
+                p2_think_ms: *p2_think_ms,
+            },
+            MatchEvent::BotInfo {
+                sender,
+                turn,
+                state_hash,
+                info,
+            } => Self::BotInfo {
+                sender: sender.0,
+                turn: *turn,
+                state_hash: *state_hash,
+                info: info.into(),
+            },
+            MatchEvent::BotProvisional {
+                sender,
+                turn,
+                state_hash,
+                direction,
+            } => Self::BotProvisional {
+                sender: sender.0,
+                turn: *turn,
+                state_hash: *state_hash,
+                direction: dir(*direction),
+            },
+            MatchEvent::BotTimeout { player, turn } => Self::BotTimeout {
+                player: player.0,
+                turn: *turn,
+            },
+            MatchEvent::MatchOver { result } => Self::MatchOver {
+                result: result.into(),
+            },
+            // `MatchEvent` is `#[non_exhaustive]`. Future variants land here
+            // until the orchestrator catches up.
+            other => Self::Unknown {
+                variant_debug: format!("{other:?}"),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyrat::Coordinates;
+    use pyrat_host::wire::{GameResult, Player as PlayerSlot, TimingMode};
+    use pyrat_protocol::{HashedTurnState, TurnState};
+
+    fn sample_match_config() -> MatchConfig {
+        MatchConfig {
+            width: 5,
+            height: 5,
+            max_turns: 100,
+            walls: vec![(Coordinates::new(0, 0), Coordinates::new(0, 1))],
+            mud: vec![pyrat_protocol::MudEntry {
+                pos1: Coordinates::new(1, 1),
+                pos2: Coordinates::new(2, 1),
+                turns: 3,
+            }],
+            cheese: vec![Coordinates::new(2, 2)],
+            player1_start: Coordinates::new(0, 0),
+            player2_start: Coordinates::new(4, 4),
+            timing: TimingMode::Wait,
+            move_timeout_ms: 1000,
+            preprocessing_timeout_ms: 5000,
+        }
+    }
+
+    fn sample_turn_state() -> HashedTurnState {
+        HashedTurnState::with_unverified_hash(
+            TurnState {
+                turn: 7,
+                player1_position: Coordinates::new(1, 1),
+                player2_position: Coordinates::new(3, 3),
+                player1_score: 1.5,
+                player2_score: 0.5,
+                player1_mud_turns: 0,
+                player2_mud_turns: 2,
+                cheese: vec![Coordinates::new(2, 2)],
+                player1_last_move: Direction::Up,
+                player2_last_move: Direction::Stay,
+            },
+            0xCAFEF00D,
+        )
+    }
+
+    /// Every known `MatchEvent` variant maps to a non-`Unknown` `ReplayEvent`
+    /// and survives a serde round-trip. If the host adds a variant, the
+    /// match in `From<&MatchEvent>` falls through to `Unknown`. This test
+    /// fails loudly so the mapping table gets updated.
+    ///
+    /// Round-trip note: `ReplayEvent` is `Serialize + Deserialize` for the
+    /// JSON format. The deserialised value should be byte-equal to the
+    /// serialised one (no semantic equivalence checks needed beyond JSON
+    /// round-tripping).
+    #[test]
+    fn every_match_event_variant_maps_to_non_unknown_and_roundtrips() {
+        let cfg = sample_match_config();
+        let result = MatchResult {
+            result: GameResult::Player1,
+            player1_score: 4.0,
+            player2_score: 0.0,
+            turns_played: 42,
+        };
+        let info = Info {
+            player: PlayerSlot::Player1,
+            multipv: 1,
+            target: Some(Coordinates::new(2, 2)),
+            depth: 3,
+            nodes: 100,
+            score: Some(0.75),
+            pv: vec![Direction::Up, Direction::Right],
+            message: "ok".into(),
+            turn: 7,
+            state_hash: 0xDEADBEEF,
+        };
+
+        let cases: Vec<MatchEvent> = vec![
+            MatchEvent::BotIdentified {
+                player: PlayerSlot::Player1,
+                name: "n".into(),
+                author: "a".into(),
+                agent_id: "id".into(),
+            },
+            MatchEvent::PreprocessingStarted,
+            MatchEvent::SetupComplete,
+            MatchEvent::MatchStarted { config: cfg },
+            MatchEvent::TurnPlayed {
+                state: sample_turn_state(),
+                p1_action: Direction::Up,
+                p2_action: Direction::Stay,
+                p1_think_ms: 5,
+                p2_think_ms: 6,
+            },
+            MatchEvent::BotInfo {
+                sender: PlayerSlot::Player1,
+                turn: 7,
+                state_hash: 0xDEAD,
+                info,
+            },
+            MatchEvent::BotProvisional {
+                sender: PlayerSlot::Player2,
+                turn: 7,
+                state_hash: 0xBEEF,
+                direction: Direction::Down,
+            },
+            MatchEvent::BotTimeout {
+                player: PlayerSlot::Player2,
+                turn: 7,
+            },
+            MatchEvent::MatchOver { result },
+        ];
+
+        for ev in &cases {
+            let dto = ReplayEvent::from(ev);
+            assert!(
+                !matches!(dto, ReplayEvent::Unknown { .. }),
+                "variant {ev:?} mapped to Unknown; update From<&MatchEvent>"
+            );
+            let json = serde_json::to_string(&dto).expect("serialise");
+            let _back: ReplayEvent = serde_json::from_str(&json).expect("deserialise");
+        }
+    }
+
+    #[test]
+    fn match_result_to_replay_uses_wire_u8() {
+        let r = MatchResult {
+            result: GameResult::Player2,
+            player1_score: 1.0,
+            player2_score: 2.0,
+            turns_played: 12,
+        };
+        let dto = ReplayMatchResult::from(&r);
+        assert_eq!(dto.result, GameResult::Player2.0);
+        assert_eq!(dto.player1_score, 1.0);
+        assert_eq!(dto.player2_score, 2.0);
+        assert_eq!(dto.turns_played, 12);
+    }
+}

--- a/eval/orchestrator/src/run_match.rs
+++ b/eval/orchestrator/src/run_match.rs
@@ -133,11 +133,12 @@ pub(crate) async fn run_match<D: Descriptor>(
     let setup = match setup_players(&matchup, &cfg, &handshake_sink, &cancel).await {
         Ok(s) => s,
         Err(setup_err) => {
+            // Operational setup failures (spawn / launch / accept /
+            // handshake) are recordable: build a durable MatchFailure and
+            // call sink.on_match_failed so a Required store sink can write
+            // the row. `Cancelled` (user-initiated) stays non-durable.
             let reason = setup_err.into_failure_reason();
-            // Setup happens before `on_match_started` ever fires, so we
-            // intentionally skip `sink.on_match_failed`. Sinks see
-            // started before they see terminals.
-            publish_failure(&inner, &matchup, None, reason, None, false).await;
+            record_pre_started_failure(&inner, &matchup, reason, None).await;
             return;
         },
     };
@@ -180,18 +181,13 @@ pub(crate) async fn run_match<D: Descriptor>(
     let game = match matchup.game_config.create(Some(matchup.seed())) {
         Ok(g) => g,
         Err(s) => {
-            let failure = MatchFailure {
-                descriptor: matchup.descriptor.clone(),
-                started_at: None,
-                failed_at: SystemTime::now(),
-                reason: FailureReason::Internal(format!("game state build failed: {s}")),
-                players: Some(identities.clone()),
-                durable_record: false,
-            };
-            let _ = inner.sink.on_match_failed(&failure).await;
-            let _ = inner
-                .publish_lifecycle(OrchestratorEvent::MatchFailed { failure })
-                .await;
+            record_pre_started_failure(
+                &inner,
+                &matchup,
+                FailureReason::Internal(format!("game state build failed: {s}")),
+                Some(identities.clone()),
+            )
+            .await;
             return;
         },
     };
@@ -310,7 +306,10 @@ async fn build_terminal<D: Descriptor>(
         durable_record,
     };
     let demote_to_sink_flush = |e: SinkError| OrchestratorEvent::MatchFailed {
-        failure: make_failure(FailureReason::SinkFlushError(e.to_string()), false),
+        failure: make_failure(
+            FailureReason::SinkFlushError(format!("{:#}", e.source)),
+            false,
+        ),
     };
 
     match (run_result, sink_event_error) {
@@ -355,10 +354,55 @@ async fn build_terminal<D: Descriptor>(
     }
 }
 
-/// Publish a pre-MatchStarted failure (no sink terminal call). Used for
-/// cancel-while-queued, setup errors (bind/launch/accept/embedded-accept),
-/// and engine-state build errors. Sinks haven't seen `on_match_started` for
-/// this match, so calling `on_match_failed` would be incoherent.
+/// Build a `MatchFailure` for a pre-MatchStarted operational failure (setup
+/// error, engine-state build error), call `sink.on_match_failed` so a
+/// Required store sink can record a durable row, and publish. On sink error,
+/// demote to `SinkFlushError { durable_record: false }`.
+///
+/// `Cancelled` (user-initiated) stays non-durable and skips the sink entirely:
+/// the honest invariant at `plan.md:440` lists kill-9 / required-flush /
+/// user-cancel / panic as the non-recordable cases. Other reasons map to
+/// recordable failures with `started_at: None`.
+async fn record_pre_started_failure<D: Descriptor>(
+    inner: &Arc<ExecutorInner<D>>,
+    matchup: &Matchup<D>,
+    reason: FailureReason,
+    players: Option<[PlayerIdentity; 2]>,
+) {
+    let durable = !matches!(reason, FailureReason::Cancelled);
+    let failure = MatchFailure {
+        descriptor: matchup.descriptor.clone(),
+        started_at: None,
+        failed_at: SystemTime::now(),
+        reason,
+        players,
+        durable_record: durable,
+    };
+    if !durable {
+        let _ = inner
+            .publish_lifecycle(OrchestratorEvent::MatchFailed { failure })
+            .await;
+        return;
+    }
+    let final_failure = match inner.sink.on_match_failed(&failure).await {
+        Ok(()) => failure,
+        Err(e) => MatchFailure {
+            reason: FailureReason::SinkFlushError(format!("{:#}", e.source)),
+            durable_record: false,
+            ..failure
+        },
+    };
+    let _ = inner
+        .publish_lifecycle(OrchestratorEvent::MatchFailed {
+            failure: final_failure,
+        })
+        .await;
+}
+
+/// Publish a pre-MatchStarted failure without calling the sink. Used for
+/// cancel-while-queued (sinks haven't seen started; user cancelled, not a
+/// recordable failure). The sink-on-`on_match_started` error path inlines
+/// its own publish because the sink is the broken one.
 async fn publish_failure<D: Descriptor>(
     inner: &Arc<ExecutorInner<D>>,
     matchup: &Matchup<D>,

--- a/eval/orchestrator/src/run_match.rs
+++ b/eval/orchestrator/src/run_match.rs
@@ -1,0 +1,572 @@
+//! Per-match work spawned on the orchestrator's `JoinSet`.
+//!
+//! Each call:
+//! 1. Publishes `MatchQueued` and waits for a parallelism slot.
+//! 2. Sets up players (subprocess via TCP, embedded in-process, or mixed).
+//! 3. Calls `sink.on_match_started`. A Required failure here demotes
+//!    immediately to `MatchFailed { SinkFlushError, durable_record: false }`.
+//!    `Match` is never constructed, so player handles are explicitly
+//!    closed to reap subprocess sessions.
+//! 4. Constructs `Match`, publishes `MatchStarted`, and races
+//!    `Match::run` against root cancellation, draining host events through
+//!    a per-match `mpsc::UnboundedReceiver`.
+//! 5. Routes events: `MatchOver` is suppressed; everything else goes
+//!    through `sink.on_match_event` → live broadcast. A Required event
+//!    error stops broadcast forwarding but keeps draining so the engine
+//!    loop completes cleanly.
+//! 6. Builds the terminal lifecycle event from `Match::run`'s returned
+//!    `MatchResult` (success), the `MatchError` (failure), or cancellation
+//!    state. Calls the appropriate sink terminal callback; demotes to
+//!    `SinkFlushError` if the Required sink errors there too.
+//!
+//! Cancel-safety is by Drop: the `Match::run` future is dropped from a
+//! biased `select!` arm. Subprocess children are reaped through
+//! `BotProcesses`'s `Drop` (held as a local until function exit).
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use pyrat::Direction;
+use pyrat_bot_api::Options;
+use pyrat_host::launch::{launch_bots, BotConfig, BotProcesses, LaunchError};
+use pyrat_host::match_config::build_match_config;
+use pyrat_host::match_host::{Match, MatchError, MatchEvent, MatchResult};
+use pyrat_host::player::{
+    accept_players, AcceptError, EmbeddedBot, EmbeddedCtx, EmbeddedPlayer, EventSink, Player,
+    PlayerError, PlayerIdentity, TcpPlayer,
+};
+use pyrat_host::wire::{GameResult, Player as PlayerSlot};
+use pyrat_protocol::HashedTurnState;
+use tokio::net::TcpListener;
+use tokio::sync::{mpsc, OwnedSemaphorePermit, Semaphore};
+use tokio_util::sync::CancellationToken;
+
+use crate::descriptor::Descriptor;
+use crate::event::OrchestratorEvent;
+use crate::executor::{ExecutorInner, RunConfig};
+use crate::id::MatchId;
+use crate::matchup::{Matchup, PlayerSpec};
+use crate::outcome::{FailureReason, MatchFailure, MatchOutcome};
+use crate::sink::SinkError;
+
+/// Adapter so a `Box<dyn EmbeddedBot>` (what factories produce) can be
+/// handed to `EmbeddedPlayer::accept<B: EmbeddedBot>`.
+///
+/// The host crate's `EmbeddedBot` is sized, so `Box<dyn EmbeddedBot>` does
+/// not auto-impl it. The alternative is adding a blanket
+/// `impl<T: ?Sized + EmbeddedBot> EmbeddedBot for Box<T>` upstream, which
+/// would touch the host trait. Wrapping at the orchestrator boundary
+/// keeps the blast radius local.
+struct BoxedEmbeddedBot(Box<dyn EmbeddedBot>);
+
+impl Options for BoxedEmbeddedBot {
+    fn option_defs(&self) -> Vec<pyrat_protocol::OptionDef> {
+        self.0.option_defs()
+    }
+
+    fn apply_option(&mut self, name: &str, value: &str) -> Result<(), String> {
+        self.0.apply_option(name, value)
+    }
+}
+
+impl EmbeddedBot for BoxedEmbeddedBot {
+    fn think(&mut self, state: &HashedTurnState, ctx: &EmbeddedCtx) -> Direction {
+        self.0.think(state, ctx)
+    }
+
+    fn preprocess(&mut self, state: &HashedTurnState, ctx: &EmbeddedCtx) {
+        self.0.preprocess(state, ctx)
+    }
+
+    fn on_game_over(&mut self, result: GameResult, scores: (f32, f32)) {
+        self.0.on_game_over(result, scores)
+    }
+}
+
+pub(crate) async fn run_match<D: Descriptor>(
+    inner: Arc<ExecutorInner<D>>,
+    matchup: Matchup<D>,
+    cancel: CancellationToken,
+    semaphore: Arc<Semaphore>,
+    cfg: Arc<RunConfig>,
+) {
+    let id = matchup.descriptor.match_id();
+
+    // ── 1. Publish MatchQueued. Driver-dropped is fatal upstream.
+    let queued = OrchestratorEvent::MatchQueued {
+        id,
+        descriptor: matchup.descriptor.clone(),
+    };
+    if inner.publish_lifecycle(queued).await.is_err() {
+        return;
+    }
+
+    // ── 2. Wait for a parallelism slot.
+    let _permit: OwnedSemaphorePermit = match acquire_permit(&semaphore, &cancel).await {
+        Some(p) => p,
+        None => {
+            // Cancelled before slot. No on_match_started fired, so don't
+            // call sink.on_match_failed (sinks see started before they
+            // see terminals).
+            publish_failure(
+                &inner,
+                &matchup,
+                None,
+                FailureReason::Cancelled,
+                None,
+                false,
+            )
+            .await;
+            return;
+        },
+    };
+
+    // ── 3. Build the per-match event channel up front. The same `event_tx`
+    // is wrapped as an `EventSink` for the player handshake (where pre-Match
+    // sideband would land if it ever fired) and handed to `Match::new`.
+    // One channel, one drain loop.
+    let (event_tx, mut event_rx) = mpsc::unbounded_channel::<MatchEvent>();
+    let handshake_sink = EventSink::new(event_tx.clone());
+
+    // ── 4. Player setup.
+    let setup = match setup_players(&matchup, &cfg, &handshake_sink, &cancel).await {
+        Ok(s) => s,
+        Err(setup_err) => {
+            let reason = setup_err.into_failure_reason();
+            // Setup happens before `on_match_started` ever fires, so we
+            // intentionally skip `sink.on_match_failed`. Sinks see
+            // started before they see terminals.
+            publish_failure(&inner, &matchup, None, reason, None, false).await;
+            return;
+        },
+    };
+    // `_bot_procs` is held to function exit so subprocess children are
+    // reaped via RAII on every path, including a dropped run future.
+    let SetupOutput {
+        players,
+        identities,
+        bot_procs: _bot_procs,
+    } = setup;
+
+    // ── 5. Pre-Match sink callback. Required failure here demotes to
+    // `SinkFlushError, durable_record: false, started_at: None` per the
+    // contract: we never construct `Match`, so the match never started.
+    if let Err(e) = inner
+        .sink
+        .on_match_started(&matchup.descriptor, &identities)
+        .await
+    {
+        // Close player handles so subprocess sessions reap. We can't call
+        // sink.on_match_failed (the sink is the broken one).
+        let [p1, p2] = players;
+        let _ = p1.close().await;
+        let _ = p2.close().await;
+        let failure = MatchFailure {
+            descriptor: matchup.descriptor.clone(),
+            started_at: None,
+            failed_at: SystemTime::now(),
+            reason: FailureReason::SinkFlushError(e.to_string()),
+            players: Some(identities),
+            durable_record: false,
+        };
+        let _ = inner
+            .publish_lifecycle(OrchestratorEvent::MatchFailed { failure })
+            .await;
+        return;
+    }
+
+    // ── 6. Build engine state + protocol-level config.
+    let game = match matchup.game_config.create(Some(matchup.seed())) {
+        Ok(g) => g,
+        Err(s) => {
+            let failure = MatchFailure {
+                descriptor: matchup.descriptor.clone(),
+                started_at: None,
+                failed_at: SystemTime::now(),
+                reason: FailureReason::Internal(format!("game state build failed: {s}")),
+                players: Some(identities.clone()),
+                durable_record: false,
+            };
+            let _ = inner.sink.on_match_failed(&failure).await;
+            let _ = inner
+                .publish_lifecycle(OrchestratorEvent::MatchFailed { failure })
+                .await;
+            return;
+        },
+    };
+    let match_config = build_match_config(
+        &game,
+        matchup.timing.mode,
+        matchup.timing.move_timeout_ms,
+        matchup.timing.preprocessing_timeout_ms,
+    );
+
+    // ── 7. Publish MatchStarted, mark started_at.
+    let started_at = SystemTime::now();
+    let started_event = OrchestratorEvent::MatchStarted {
+        id,
+        descriptor: matchup.descriptor.clone(),
+        players: identities.clone(),
+    };
+    if inner.publish_lifecycle(started_event).await.is_err() {
+        return;
+    }
+
+    // ── 8. Construct Match and drive the run loop.
+    let game_match = Match::new(
+        game,
+        players,
+        match_config,
+        [vec![], vec![]],
+        cfg.setup_timing.clone(),
+        cfg.playing_config.clone(),
+        Some(event_tx),
+    );
+
+    let mut run_fut = std::pin::pin!(game_match.run());
+    let mut sink_event_error: Option<SinkError> = None;
+    let mut rx_open = true;
+
+    let run_result: Option<Result<MatchResult, MatchError>> = loop {
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => break None,
+            res = &mut run_fut => {
+                // Drain anything buffered before exiting the loop. The
+                // `try_recv` keeps draining cheap; per-event errors are
+                // recorded into `sink_event_error` and decided after.
+                while let Ok(evt) = event_rx.try_recv() {
+                    handle_event(&inner, id, evt, &mut sink_event_error).await;
+                }
+                break Some(res);
+            }
+            evt = event_rx.recv(), if rx_open => match evt {
+                Some(e) => handle_event(&inner, id, e, &mut sink_event_error).await,
+                // Defensive: in normal operation `Match::run` holds the
+                // sender via `MatchCtx` until `finalize` consumes it, so
+                // `recv` cannot return None before `run_fut` resolves.
+                // The guard makes the loop non-spinning if that invariant
+                // ever breaks.
+                None => { rx_open = false; }
+            }
+        }
+    };
+
+    // ── 9. Build and publish the terminal event.
+    let finished_at = SystemTime::now();
+    let terminal = build_terminal(
+        &inner,
+        &matchup,
+        &identities,
+        started_at,
+        finished_at,
+        run_result,
+        sink_event_error,
+    )
+    .await;
+    let _ = inner.publish_lifecycle(terminal).await;
+}
+
+/// Apply one host event to the sink+broadcast pipe, with the Required-error
+/// gate. Suppresses `MatchOver` (the canonical terminal value comes from
+/// `Match::run()`'s returned `MatchResult`).
+async fn handle_event<D: Descriptor>(
+    inner: &Arc<ExecutorInner<D>>,
+    id: MatchId,
+    event: MatchEvent,
+    sink_err: &mut Option<SinkError>,
+) {
+    if matches!(event, MatchEvent::MatchOver { .. }) {
+        return;
+    }
+    if sink_err.is_some() {
+        // Required sink already errored; keep draining the engine loop
+        // but don't talk to the sink and don't publish.
+        return;
+    }
+    if let Err(e) = inner.sink.on_match_event(id, &event).await {
+        *sink_err = Some(e);
+        return;
+    }
+    inner.publish_per_turn(OrchestratorEvent::MatchEvent { id, event });
+}
+
+async fn build_terminal<D: Descriptor>(
+    inner: &Arc<ExecutorInner<D>>,
+    matchup: &Matchup<D>,
+    identities: &[PlayerIdentity; 2],
+    started_at: SystemTime,
+    finished_at: SystemTime,
+    run_result: Option<Result<MatchResult, MatchError>>,
+    sink_event_error: Option<SinkError>,
+) -> OrchestratorEvent<D> {
+    let make_failure = |reason: FailureReason, durable_record: bool| MatchFailure {
+        descriptor: matchup.descriptor.clone(),
+        started_at: Some(started_at),
+        failed_at: finished_at,
+        reason,
+        players: Some(identities.clone()),
+        durable_record,
+    };
+    let demote_to_sink_flush = |e: SinkError| OrchestratorEvent::MatchFailed {
+        failure: make_failure(FailureReason::SinkFlushError(e.to_string()), false),
+    };
+
+    match (run_result, sink_event_error) {
+        // Cancelled while Match::run was alive.
+        (None, _) => {
+            let failure = make_failure(FailureReason::Cancelled, false);
+            // Best-effort sink terminal. Required errors here demote to
+            // SinkFlushError (durable_record was already false).
+            if let Err(e) = inner.sink.on_match_failed(&failure).await {
+                return demote_to_sink_flush(e);
+            }
+            OrchestratorEvent::MatchFailed { failure }
+        },
+
+        // Sink errored mid-event. Don't talk to the sink again (it's the
+        // broken one). Just publish.
+        (Some(_), Some(sink_err)) => demote_to_sink_flush(sink_err),
+
+        // Match::run returned a result.
+        (Some(Ok(result)), None) => {
+            let outcome = MatchOutcome {
+                descriptor: matchup.descriptor.clone(),
+                started_at,
+                finished_at,
+                result,
+                players: identities.clone(),
+            };
+            match inner.sink.on_match_finished(&outcome).await {
+                Ok(()) => OrchestratorEvent::MatchFinished { outcome },
+                Err(e) => demote_to_sink_flush(e),
+            }
+        },
+
+        // Match::run returned a host-level error.
+        (Some(Err(match_err)), None) => {
+            let failure = make_failure(failure_reason_from_match_error(&match_err), true);
+            match inner.sink.on_match_failed(&failure).await {
+                Ok(()) => OrchestratorEvent::MatchFailed { failure },
+                Err(e) => demote_to_sink_flush(e),
+            }
+        },
+    }
+}
+
+/// Publish a pre-MatchStarted failure (no sink terminal call). Used for
+/// cancel-while-queued, setup errors (bind/launch/accept/embedded-accept),
+/// and engine-state build errors. Sinks haven't seen `on_match_started` for
+/// this match, so calling `on_match_failed` would be incoherent.
+async fn publish_failure<D: Descriptor>(
+    inner: &Arc<ExecutorInner<D>>,
+    matchup: &Matchup<D>,
+    started_at: Option<SystemTime>,
+    reason: FailureReason,
+    players: Option<[PlayerIdentity; 2]>,
+    durable_record: bool,
+) {
+    let failure = MatchFailure {
+        descriptor: matchup.descriptor.clone(),
+        started_at,
+        failed_at: SystemTime::now(),
+        reason,
+        players,
+        durable_record,
+    };
+    let _ = inner
+        .publish_lifecycle(OrchestratorEvent::MatchFailed { failure })
+        .await;
+}
+
+async fn acquire_permit(
+    semaphore: &Arc<Semaphore>,
+    cancel: &CancellationToken,
+) -> Option<OwnedSemaphorePermit> {
+    tokio::select! {
+        biased;
+        _ = cancel.cancelled() => None,
+        p = Arc::clone(semaphore).acquire_owned() => p.ok(),
+    }
+}
+
+// ── Player setup ─────────────────────────────────────────────────────
+
+struct SetupOutput {
+    players: [Box<dyn Player>; 2],
+    identities: [PlayerIdentity; 2],
+    /// `Some` when at least one slot launched a subprocess, `None` for
+    /// pure-embedded matches.
+    bot_procs: Option<BotProcesses>,
+}
+
+#[derive(Debug)]
+enum SetupError {
+    Cancelled,
+    Bind(std::io::Error),
+    Launch(LaunchError),
+    Accept(AcceptError),
+    EmbeddedAccept {
+        slot: PlayerSlot,
+        source: PlayerError,
+    },
+    AcceptIncomplete {
+        slot: PlayerSlot,
+    },
+    Internal(String),
+}
+
+impl SetupError {
+    fn into_failure_reason(self) -> FailureReason {
+        match self {
+            Self::Cancelled => FailureReason::Cancelled,
+            Self::Bind(e) => FailureReason::Internal(format!("bind: {e}")),
+            Self::Launch(e) => {
+                tracing::warn!(error = %e, "launch_bots failed");
+                FailureReason::SpawnFailed
+            },
+            Self::Accept(AcceptError::Timeout) => FailureReason::HandshakeTimeout,
+            Self::Accept(other) => FailureReason::Internal(other.to_string()),
+            Self::EmbeddedAccept { slot, source } => match source {
+                PlayerError::CleanClose | PlayerError::TransportError(_) => {
+                    FailureReason::Disconnected(slot)
+                },
+                PlayerError::ProtocolError(s) => FailureReason::ProtocolError(s),
+                PlayerError::Timeout => FailureReason::HandshakeTimeout,
+            },
+            Self::AcceptIncomplete { slot } => FailureReason::ProtocolError(format!(
+                "accept_players returned without filling slot {slot:?}"
+            )),
+            Self::Internal(s) => FailureReason::Internal(s),
+        }
+    }
+}
+
+async fn setup_players<D: Descriptor>(
+    matchup: &Matchup<D>,
+    cfg: &RunConfig,
+    handshake_sink: &EventSink,
+    cancel: &CancellationToken,
+) -> Result<SetupOutput, SetupError> {
+    let subprocess_count = matchup
+        .players
+        .iter()
+        .filter(|p| matches!(p, PlayerSpec::Subprocess { .. }))
+        .count();
+
+    let (mut tcp_slots, bot_procs): ([Option<TcpPlayer>; 2], Option<BotProcesses>) =
+        if subprocess_count > 0 {
+            let listener = TcpListener::bind("127.0.0.1:0")
+                .await
+                .map_err(SetupError::Bind)?;
+            let port = listener.local_addr().map_err(SetupError::Bind)?.port();
+            let mut bot_configs: Vec<BotConfig> = Vec::with_capacity(subprocess_count);
+            let mut expected: Vec<(PlayerSlot, String)> = Vec::with_capacity(subprocess_count);
+            for (idx, spec) in matchup.players.iter().enumerate() {
+                let slot = slot_for(idx);
+                if let PlayerSpec::Subprocess {
+                    agent_id,
+                    command,
+                    working_dir,
+                } = spec
+                {
+                    bot_configs.push(BotConfig {
+                        run_command: command.clone(),
+                        working_dir: working_dir.clone().unwrap_or_else(|| PathBuf::from(".")),
+                        agent_id: agent_id.clone(),
+                    });
+                    expected.push((slot, agent_id.clone()));
+                }
+            }
+            let procs = launch_bots(&bot_configs, port).map_err(SetupError::Launch)?;
+            let result = tokio::select! {
+                biased;
+                _ = cancel.cancelled() => return Err(SetupError::Cancelled),
+                r = accept_players(&listener, &expected, handshake_sink.clone(), cfg.handshake_timeout) => r,
+            };
+            let players = result.map_err(SetupError::Accept)?;
+            (players, Some(procs))
+        } else {
+            ([None, None], None)
+        };
+
+    let mut placed: [Option<Box<dyn Player>>; 2] = [None, None];
+    for (idx, spec) in matchup.players.iter().enumerate() {
+        let slot = slot_for(idx);
+        match spec {
+            PlayerSpec::Subprocess { .. } => {
+                let p = tcp_slots[idx]
+                    .take()
+                    .ok_or(SetupError::AcceptIncomplete { slot })?;
+                placed[idx] = Some(Box::new(p) as Box<dyn Player>);
+            },
+            PlayerSpec::Embedded {
+                agent_id,
+                name,
+                author,
+                factory,
+            } => {
+                let identity = PlayerIdentity {
+                    name: name.clone(),
+                    author: author.clone(),
+                    agent_id: agent_id.clone(),
+                    slot,
+                };
+                let bot = BoxedEmbeddedBot(factory());
+                let p = tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => return Err(SetupError::Cancelled),
+                    r = EmbeddedPlayer::accept(bot, identity, handshake_sink.clone()) => {
+                        r.map_err(|source| SetupError::EmbeddedAccept { slot, source })?
+                    }
+                };
+                placed[idx] = Some(Box::new(p) as Box<dyn Player>);
+            },
+        }
+    }
+
+    let p1 = placed[0]
+        .take()
+        .ok_or_else(|| SetupError::Internal("slot 0 empty after setup".into()))?;
+    let p2 = placed[1]
+        .take()
+        .ok_or_else(|| SetupError::Internal("slot 1 empty after setup".into()))?;
+    let identities = [p1.identity().clone(), p2.identity().clone()];
+    Ok(SetupOutput {
+        players: [p1, p2],
+        identities,
+        bot_procs,
+    })
+}
+
+fn slot_for(idx: usize) -> PlayerSlot {
+    match idx {
+        0 => PlayerSlot::Player1,
+        1 => PlayerSlot::Player2,
+        _ => unreachable!("Matchup carries exactly 2 player specs"),
+    }
+}
+
+fn failure_reason_from_match_error(err: &MatchError) -> FailureReason {
+    match err {
+        MatchError::SetupTimeout(_)
+        | MatchError::PreprocessingTimeout(_)
+        | MatchError::SyncTimeout(_)
+        | MatchError::ActionTimeout(_)
+        | MatchError::ReadyHashMismatch { .. }
+        | MatchError::ActionHashMismatch { .. }
+        | MatchError::PersistentDesync(_)
+        | MatchError::UnexpectedMessage { .. } => FailureReason::ProtocolError(err.to_string()),
+        MatchError::BotDisconnected(slot) => FailureReason::Disconnected(*slot),
+        MatchError::PlayerError { slot, source } => match source {
+            PlayerError::CleanClose | PlayerError::TransportError(_) => {
+                FailureReason::Disconnected(*slot)
+            },
+            PlayerError::ProtocolError(_) | PlayerError::Timeout => {
+                FailureReason::ProtocolError(err.to_string())
+            },
+        },
+        MatchError::Internal(s) => FailureReason::Internal(s.clone()),
+    }
+}

--- a/eval/orchestrator/src/sink.rs
+++ b/eval/orchestrator/src/sink.rs
@@ -55,6 +55,21 @@ pub trait MatchSink<D: Descriptor>: Send + Sync {
     async fn on_match_finished(&self, outcome: &MatchOutcome<D>) -> Result<(), SinkError>;
 
     async fn on_match_failed(&self, failure: &MatchFailure<D>) -> Result<(), SinkError>;
+
+    /// Called when a match's lifecycle was cut short before terminal
+    /// callbacks could fire (typically: a `Required` sink errored, so
+    /// terminal callbacks were skipped on the rest). Best-effort cleanup
+    /// only: errors are logged at `warn` and never mutate outcomes.
+    /// Default no-op so stateless sinks ignore it.
+    ///
+    /// Stateful sinks (e.g. replay buffers keyed by `MatchId`) implement it
+    /// to release per-match state. Conflating cleanup with terminal
+    /// `on_match_failed` would force a synthesized `MatchFailure` that
+    /// doesn't reflect what really happened to *this* sink (it never
+    /// failed; another sink did). Separate hook = honest semantics.
+    async fn on_match_abandoned(&self, _id: MatchId) -> Result<(), SinkError> {
+        Ok(())
+    }
 }
 
 /// Drops every callback. Useful for tests that don't need persistence and

--- a/eval/orchestrator/src/sinks/composite.rs
+++ b/eval/orchestrator/src/sinks/composite.rs
@@ -10,11 +10,27 @@
 //!
 //! The outcome is never mutated by the sink path. Losing an optional file
 //! is a telemetry concern; the match really did succeed.
+//!
+//! ## Demotion cleanup
+//!
+//! When a `Required` child errors anywhere (`on_match_event`,
+//! `on_match_finished`, `on_match_failed`, or `on_match_started` after the
+//! first child has already signalled OK), the composite calls
+//! [`MatchSink::on_match_abandoned`] on every child that previously received
+//! a successful `on_match_started`, *except* the broken sink itself. This
+//! lets stateful sinks (e.g. replay buffers keyed by `MatchId`) release
+//! per-match state when no terminal callback will fire.
+//!
+//! Per-match tracking lives in `match_states: Mutex<HashMap<MatchId, ...>>`.
+//! The mutex is `parking_lot` (sync) and held only across `HashMap` ops,
+//! never across an `await` of a child callback.
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use parking_lot::Mutex;
 use tracing::warn;
 
 use pyrat_host::match_host::MatchEvent;
@@ -25,10 +41,21 @@ use crate::id::MatchId;
 use crate::outcome::{MatchFailure, MatchOutcome};
 use crate::sink::{MatchSink, SinkError, SinkRole};
 
+/// Per-match composite state: which children received a successful
+/// `on_match_started`, in the order they were called. Used to drive
+/// `on_match_abandoned` if cleanup runs.
+struct MatchState {
+    seen_started: Vec<usize>,
+}
+
 /// Composes a list of `(role, sink)` children behind one `MatchSink`.
 pub struct CompositeSink<D: Descriptor> {
     children: Vec<(SinkRole, Arc<dyn MatchSink<D>>)>,
     optional_errors: AtomicU64,
+    /// Per-match state keyed by `MatchId`. Entries are inserted on a
+    /// successful `on_match_started`, removed on a clean terminal or on
+    /// demotion cleanup. Sync mutex; never held across `.await` of a child.
+    match_states: Mutex<HashMap<MatchId, MatchState>>,
 }
 
 impl<D: Descriptor> CompositeSink<D> {
@@ -45,26 +72,54 @@ impl<D: Descriptor> CompositeSink<D> {
         Self {
             children: ordered,
             optional_errors: AtomicU64::new(0),
+            match_states: Mutex::new(HashMap::new()),
         }
     }
 
     /// Total count of optional-sink errors logged across this composite's
-    /// lifetime. Useful for asserting in tests and for telemetry wiring.
+    /// lifetime. Includes errors from `on_match_abandoned` calls; every
+    /// abandoned-cleanup error is logged at `warn` regardless of the
+    /// originating sink's role.
     pub fn optional_error_count(&self) -> u64 {
         self.optional_errors.load(Ordering::Relaxed)
     }
 
-    /// Classify a single child's error by role: `Required` propagates,
-    /// `Optional` logs at `warn` and bumps the counter.
-    fn classify(&self, role: SinkRole, label: &'static str, err: SinkError) -> Option<SinkError> {
-        match role {
-            SinkRole::Required => Some(err),
-            SinkRole::Optional => {
-                self.optional_errors.fetch_add(1, Ordering::Relaxed);
-                warn!(callback = label, error = %err, "optional sink error");
-                None
-            },
+    fn record_optional_error(&self, callback: &'static str, err: &SinkError) {
+        self.optional_errors.fetch_add(1, Ordering::Relaxed);
+        warn!(callback = callback, error = %err, "optional sink error");
+    }
+
+    fn take_match_state(&self, id: MatchId) -> Option<MatchState> {
+        self.match_states.lock().remove(&id)
+    }
+
+    /// Call `on_match_abandoned` on each indexed child, skipping
+    /// `broken_idx`. Errors are logged + counted and never propagate.
+    async fn abandon_indices<I: IntoIterator<Item = usize>>(
+        &self,
+        id: MatchId,
+        indices: I,
+        broken_idx: Option<usize>,
+    ) {
+        for idx in indices {
+            if Some(idx) == broken_idx {
+                continue;
+            }
+            let child = &self.children[idx].1;
+            if let Err(e) = child.on_match_abandoned(id).await {
+                self.record_optional_error("on_match_abandoned", &e);
+            }
         }
+    }
+
+    /// Take the per-match state and abandon every recorded child except
+    /// the broken one.
+    async fn dispatch_abandoned(&self, id: MatchId, broken_idx: Option<usize>) {
+        let Some(state) = self.take_match_state(id) else {
+            return;
+        };
+        self.abandon_indices(id, state.seen_started, broken_idx)
+            .await;
     }
 }
 
@@ -75,50 +130,90 @@ impl<D: Descriptor> MatchSink<D> for CompositeSink<D> {
         descriptor: &D,
         players: &[PlayerIdentity; 2],
     ) -> Result<(), SinkError> {
-        for (role, child) in &self.children {
-            let Err(e) = child.on_match_started(descriptor, players).await else {
-                continue;
-            };
-            if let Some(propagate) = self.classify(*role, "on_match_started", e) {
-                return Err(propagate);
+        let id = descriptor.match_id();
+        let mut seen: Vec<usize> = Vec::new();
+        for (idx, (role, child)) in self.children.iter().enumerate() {
+            match child.on_match_started(descriptor, players).await {
+                Ok(()) => seen.push(idx),
+                Err(e) => match role {
+                    SinkRole::Required => {
+                        // Cleanup priors that already started successfully.
+                        // Optionals among them carry per-match state (e.g.
+                        // replay buffers); abandoned releases it. The broken
+                        // child wasn't recorded in `seen`, so no broken_idx
+                        // exclude needed.
+                        self.abandon_indices(id, seen, None).await;
+                        return Err(e);
+                    },
+                    SinkRole::Optional => {
+                        self.record_optional_error("on_match_started", &e);
+                    },
+                },
             }
         }
+        self.match_states
+            .lock()
+            .insert(id, MatchState { seen_started: seen });
         Ok(())
     }
 
     async fn on_match_event(&self, id: MatchId, event: &MatchEvent) -> Result<(), SinkError> {
-        for (role, child) in &self.children {
-            let Err(e) = child.on_match_event(id, event).await else {
-                continue;
-            };
-            if let Some(propagate) = self.classify(*role, "on_match_event", e) {
-                return Err(propagate);
+        for (idx, (role, child)) in self.children.iter().enumerate() {
+            match child.on_match_event(id, event).await {
+                Ok(()) => {},
+                Err(e) => match role {
+                    SinkRole::Required => {
+                        self.dispatch_abandoned(id, Some(idx)).await;
+                        return Err(e);
+                    },
+                    SinkRole::Optional => {
+                        self.record_optional_error("on_match_event", &e);
+                    },
+                },
             }
         }
         Ok(())
     }
 
     async fn on_match_finished(&self, outcome: &MatchOutcome<D>) -> Result<(), SinkError> {
-        for (role, child) in &self.children {
-            let Err(e) = child.on_match_finished(outcome).await else {
-                continue;
-            };
-            if let Some(propagate) = self.classify(*role, "on_match_finished", e) {
-                return Err(propagate);
+        let id = outcome.descriptor.match_id();
+        for (idx, (role, child)) in self.children.iter().enumerate() {
+            match child.on_match_finished(outcome).await {
+                Ok(()) => {},
+                Err(e) => match role {
+                    SinkRole::Required => {
+                        self.dispatch_abandoned(id, Some(idx)).await;
+                        return Err(e);
+                    },
+                    SinkRole::Optional => {
+                        self.record_optional_error("on_match_finished", &e);
+                    },
+                },
             }
         }
+        // Clean terminal: drop per-match state, no abandoned calls.
+        self.take_match_state(id);
         Ok(())
     }
 
     async fn on_match_failed(&self, failure: &MatchFailure<D>) -> Result<(), SinkError> {
-        for (role, child) in &self.children {
-            let Err(e) = child.on_match_failed(failure).await else {
-                continue;
-            };
-            if let Some(propagate) = self.classify(*role, "on_match_failed", e) {
-                return Err(propagate);
+        let id = failure.descriptor.match_id();
+        for (idx, (role, child)) in self.children.iter().enumerate() {
+            match child.on_match_failed(failure).await {
+                Ok(()) => {},
+                Err(e) => match role {
+                    SinkRole::Required => {
+                        self.dispatch_abandoned(id, Some(idx)).await;
+                        return Err(e);
+                    },
+                    SinkRole::Optional => {
+                        self.record_optional_error("on_match_failed", &e);
+                    },
+                },
             }
         }
+        // Clean terminal: drop per-match state.
+        self.take_match_state(id);
         Ok(())
     }
 }
@@ -328,5 +423,170 @@ mod tests {
 
         let _ = composite.on_match_failed(&failure(ad_hoc(3))).await;
         assert_eq!(*order.lock().unwrap(), vec!["required", "optional"]);
+    }
+
+    /// Stateful sink: counts `started` and `abandoned` calls. The abandoned
+    /// counter must increment exactly once per match when a Required sink
+    /// errors after this child saw a successful start.
+    struct StatefulRecorder {
+        started: Arc<AtomicU32>,
+        abandoned: Arc<AtomicU32>,
+    }
+
+    #[async_trait]
+    impl MatchSink<AdHocDescriptor> for StatefulRecorder {
+        async fn on_match_started(
+            &self,
+            _: &AdHocDescriptor,
+            _: &[PlayerIdentity; 2],
+        ) -> Result<(), SinkError> {
+            self.started.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        async fn on_match_event(&self, _: MatchId, _: &MatchEvent) -> Result<(), SinkError> {
+            Ok(())
+        }
+        async fn on_match_finished(
+            &self,
+            _: &MatchOutcome<AdHocDescriptor>,
+        ) -> Result<(), SinkError> {
+            Ok(())
+        }
+        async fn on_match_failed(
+            &self,
+            _: &MatchFailure<AdHocDescriptor>,
+        ) -> Result<(), SinkError> {
+            Ok(())
+        }
+        async fn on_match_abandoned(&self, _: MatchId) -> Result<(), SinkError> {
+            self.abandoned.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    /// Required-error during `on_match_event` calls `on_match_abandoned` on
+    /// every child that previously received a successful `on_match_started`,
+    /// except the broken one. Pins the demotion-cleanup contract for the
+    /// replay-buffer leak case.
+    #[tokio::test]
+    async fn required_error_during_event_calls_abandoned_on_started_priors() {
+        // Required sink that succeeds on `started` but errors on `event`.
+        struct EventErroringRequired {
+            started: Arc<AtomicU32>,
+            abandoned: Arc<AtomicU32>,
+        }
+        #[async_trait]
+        impl MatchSink<AdHocDescriptor> for EventErroringRequired {
+            async fn on_match_started(
+                &self,
+                _: &AdHocDescriptor,
+                _: &[PlayerIdentity; 2],
+            ) -> Result<(), SinkError> {
+                self.started.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+            async fn on_match_event(&self, _: MatchId, _: &MatchEvent) -> Result<(), SinkError> {
+                Err(SinkError {
+                    source: anyhow!("event boom"),
+                })
+            }
+            async fn on_match_finished(
+                &self,
+                _: &MatchOutcome<AdHocDescriptor>,
+            ) -> Result<(), SinkError> {
+                Ok(())
+            }
+            async fn on_match_failed(
+                &self,
+                _: &MatchFailure<AdHocDescriptor>,
+            ) -> Result<(), SinkError> {
+                Ok(())
+            }
+            async fn on_match_abandoned(&self, _: MatchId) -> Result<(), SinkError> {
+                self.abandoned.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+
+        let req_started = Arc::new(AtomicU32::new(0));
+        let req_abandoned = Arc::new(AtomicU32::new(0));
+        let opt_started = Arc::new(AtomicU32::new(0));
+        let opt_abandoned = Arc::new(AtomicU32::new(0));
+
+        let req: Arc<dyn MatchSink<AdHocDescriptor>> = Arc::new(EventErroringRequired {
+            started: req_started.clone(),
+            abandoned: req_abandoned.clone(),
+        });
+        let opt: Arc<dyn MatchSink<AdHocDescriptor>> = Arc::new(StatefulRecorder {
+            started: opt_started.clone(),
+            abandoned: opt_abandoned.clone(),
+        });
+        let composite =
+            CompositeSink::new(vec![(SinkRole::Required, req), (SinkRole::Optional, opt)]);
+
+        let desc = ad_hoc(7);
+        let players = [
+            PlayerIdentity {
+                name: "p1".into(),
+                author: "t".into(),
+                agent_id: "a/p1".into(),
+                slot: pyrat_host::wire::Player::Player1,
+            },
+            PlayerIdentity {
+                name: "p2".into(),
+                author: "t".into(),
+                agent_id: "a/p2".into(),
+                slot: pyrat_host::wire::Player::Player2,
+            },
+        ];
+        composite
+            .on_match_started(&desc, &players)
+            .await
+            .expect("started ok");
+        assert_eq!(req_started.load(Ordering::SeqCst), 1);
+        assert_eq!(opt_started.load(Ordering::SeqCst), 1);
+
+        let result = composite
+            .on_match_event(desc.match_id(), &MatchEvent::PreprocessingStarted)
+            .await;
+        assert!(result.is_err(), "required sink err propagates");
+        // The broken Required sink must NOT receive abandoned (calling
+        // methods on the broken sink remains forbidden).
+        assert_eq!(req_abandoned.load(Ordering::SeqCst), 0);
+        // The Optional sink saw a successful start, so it gets abandoned.
+        assert_eq!(opt_abandoned.load(Ordering::SeqCst), 1);
+    }
+
+    /// Clean terminal does NOT call abandoned on any child. Pins that we
+    /// only abandon when cleanup actually runs.
+    #[tokio::test]
+    async fn clean_terminal_does_not_call_abandoned() {
+        let started = Arc::new(AtomicU32::new(0));
+        let abandoned = Arc::new(AtomicU32::new(0));
+        let child: Arc<dyn MatchSink<AdHocDescriptor>> = Arc::new(StatefulRecorder {
+            started: started.clone(),
+            abandoned: abandoned.clone(),
+        });
+        let composite = CompositeSink::new(vec![(SinkRole::Optional, child)]);
+
+        let desc = ad_hoc(8);
+        let players = [
+            PlayerIdentity {
+                name: "p1".into(),
+                author: "t".into(),
+                agent_id: "a/p1".into(),
+                slot: pyrat_host::wire::Player::Player1,
+            },
+            PlayerIdentity {
+                name: "p2".into(),
+                author: "t".into(),
+                agent_id: "a/p2".into(),
+                slot: pyrat_host::wire::Player::Player2,
+            },
+        ];
+        composite.on_match_started(&desc, &players).await.unwrap();
+        composite.on_match_failed(&failure(desc)).await.unwrap();
+        assert_eq!(started.load(Ordering::SeqCst), 1);
+        assert_eq!(abandoned.load(Ordering::SeqCst), 0);
     }
 }

--- a/eval/orchestrator/src/sinks/composite.rs
+++ b/eval/orchestrator/src/sinks/composite.rs
@@ -216,6 +216,19 @@ impl<D: Descriptor> MatchSink<D> for CompositeSink<D> {
         self.take_match_state(id);
         Ok(())
     }
+
+    /// External abandoned call (e.g. from the run-loop's panic-recovery
+    /// path in `handle_joined`). Dispatch to every child that previously
+    /// received a successful `on_match_started`, so stateful children
+    /// release per-match buffers. `broken_idx: None` because the cause
+    /// here is task-level (panic / force-abort), not a specific child
+    /// returning Err — every recorded child gets the call. Always
+    /// returns `Ok` (errors logged + counted via the existing optional
+    /// path; outcomes never mutated).
+    async fn on_match_abandoned(&self, id: MatchId) -> Result<(), SinkError> {
+        self.dispatch_abandoned(id, None).await;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/eval/orchestrator/src/sinks/mod.rs
+++ b/eval/orchestrator/src/sinks/mod.rs
@@ -1,3 +1,4 @@
 //! Sink implementations. The trait itself lives in [`crate::sink`].
 
 pub mod composite;
+pub mod replay;

--- a/eval/orchestrator/src/sinks/replay.rs
+++ b/eval/orchestrator/src/sinks/replay.rs
@@ -35,7 +35,6 @@ use parking_lot::Mutex;
 use pyrat_host::match_host::MatchEvent;
 use pyrat_host::player::PlayerIdentity;
 use serde::{Deserialize, Serialize};
-use tracing::warn;
 
 use crate::descriptor::Descriptor;
 use crate::id::MatchId;
@@ -244,11 +243,11 @@ impl<D: Descriptor> MatchSink<D> for ReplaySink {
 
     async fn on_match_failed(&self, failure: &MatchFailure<D>) -> Result<(), SinkError> {
         // Drop the buffer without writing. No partial replays on failure.
-        let id = failure.descriptor.match_id();
-        if self.state.lock().remove(&id).is_none() {
-            // Defensive: nothing to drop.
-            warn!(match_id = %id, "replay sink: on_match_failed for unknown id");
-        }
+        // Missing buffer is normal: pre-MatchStarted failures (setup error,
+        // engine-state-build error) call `on_match_failed` durably without
+        // a prior `on_match_started`. Silent remove matches the
+        // `on_match_abandoned` shape below.
+        self.state.lock().remove(&failure.descriptor.match_id());
         Ok(())
     }
 

--- a/eval/orchestrator/src/sinks/replay.rs
+++ b/eval/orchestrator/src/sinks/replay.rs
@@ -1,0 +1,553 @@
+//! Forensic replay sink. Buffers events per match and flushes a JSON file
+//! when the match completes.
+//!
+//! Per-match state lives in `parking_lot::Mutex<HashMap<MatchId, …>>`. One
+//! `Arc<ReplaySink>` serves all concurrent matches: a single shared
+//! `Vec<ReplayEvent>` would interleave events from different matches.
+//! Mutex held only across `HashMap` ops; the JSON serialise + file write
+//! happens on the buffer that was removed under the lock, *outside* the
+//! lock.
+//!
+//! Lifecycle:
+//! - `on_match_started`: insert a fresh buffer keyed by `descriptor.match_id()`.
+//! - `on_match_event`: append `ReplayEvent::from(event)`. The first
+//!   `MatchEvent::MatchStarted { config }` populates `match_config` (the
+//!   wire-level `MatchConfig` is only available through the host event;
+//!   we don't have it at `on_match_started` time).
+//! - `on_match_finished`: synthesise terminal `ReplayEvent::MatchOver`
+//!   from `outcome.result` (the host's `MatchOver` is suppressed
+//!   upstream), flush the JSON, drop the buffer.
+//! - `on_match_failed` / `on_match_abandoned`: drop the buffer without
+//!   writing. **No partial replays.**
+//!
+//! Missing-buffer behaviour: if no entry exists for `id` (Optional
+//! `on_match_started` failed earlier and the match proceeded anyway), all
+//! later callbacks no-op silently. The earlier failure was already logged
+//! at `warn` by the composite; flooding the log with per-event warnings
+//! would be noise.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use parking_lot::Mutex;
+use pyrat_host::match_host::MatchEvent;
+use pyrat_host::player::PlayerIdentity;
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+use crate::descriptor::Descriptor;
+use crate::id::MatchId;
+use crate::outcome::{MatchFailure, MatchOutcome};
+use crate::replay_event::{ReplayEvent, ReplayMatchConfig, ReplayMatchResult};
+use crate::sink::{MatchSink, SinkError};
+
+/// JSON shape of one replay file. Wraps the per-match metadata around the
+/// flat event list.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReplayFile {
+    /// Free-form version string (e.g. `pyrat-orchestrator/0.1.0`).
+    pub engine_version: String,
+    /// `MatchConfig` extracted from the host's `MatchEvent::MatchStarted`.
+    /// `None` if the match failed before the host emitted `MatchStarted`
+    /// (early protocol fault), which never reaches a clean
+    /// `on_match_finished` flush, so production files always have it.
+    pub match_config: Option<ReplayMatchConfig>,
+    /// Seed pinned by the descriptor at submission.
+    pub seed: u64,
+    /// Every host event observed, in arrival order. The terminal entry is
+    /// always `ReplayEvent::MatchOver` (synthesised by the sink; the
+    /// host's `MatchOver` is suppressed upstream).
+    pub events: Vec<ReplayEvent>,
+    /// Final `MatchResult`, in DTO form.
+    pub result: ReplayMatchResult,
+}
+
+/// Persistence strategy for replay files. Dyn-friendly so callers can hand
+/// in an in-memory writer for tests, a directory writer in production, a
+/// rotating one for long-running services, etc.
+pub trait ReplayWriter: Send + Sync {
+    /// Persist the JSON payload for `id`. Errors propagate as
+    /// [`SinkError`].
+    fn write(&self, id: MatchId, payload: &str) -> std::io::Result<()>;
+}
+
+/// Writes one file per match into `dir`, named `match-{id}.json`. Pretty
+/// JSON for human inspection.
+pub struct DirectoryWriter {
+    dir: PathBuf,
+}
+
+impl DirectoryWriter {
+    /// Ensures `dir` exists once, up front, so the per-match write path
+    /// is one syscall instead of two.
+    pub fn new(dir: PathBuf) -> std::io::Result<Self> {
+        std::fs::create_dir_all(&dir)?;
+        Ok(Self { dir })
+    }
+}
+
+impl ReplayWriter for DirectoryWriter {
+    fn write(&self, id: MatchId, payload: &str) -> std::io::Result<()> {
+        let path = self.dir.join(format!("match-{}.json", id.0));
+        std::fs::write(path, payload)
+    }
+}
+
+/// In-memory writer for tests. Records every flush keyed by `MatchId`.
+pub struct MemoryWriter {
+    files: Mutex<HashMap<MatchId, String>>,
+}
+
+impl MemoryWriter {
+    pub fn new() -> Self {
+        Self {
+            files: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn count(&self) -> usize {
+        self.files.lock().len()
+    }
+
+    pub fn get(&self, id: MatchId) -> Option<String> {
+        self.files.lock().get(&id).cloned()
+    }
+
+    pub fn ids(&self) -> Vec<MatchId> {
+        let mut v: Vec<_> = self.files.lock().keys().copied().collect();
+        v.sort();
+        v
+    }
+}
+
+impl Default for MemoryWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReplayWriter for MemoryWriter {
+    fn write(&self, id: MatchId, payload: &str) -> std::io::Result<()> {
+        self.files.lock().insert(id, payload.to_owned());
+        Ok(())
+    }
+}
+
+struct ReplayBuffer {
+    events: Vec<ReplayEvent>,
+    match_config: Option<ReplayMatchConfig>,
+    seed: u64,
+}
+
+/// Per-match buffered replay sink. Optional in role: losing a replay file
+/// is a telemetry concern, never a durable-record concern.
+pub struct ReplaySink {
+    writer: Arc<dyn ReplayWriter>,
+    state: Mutex<HashMap<MatchId, ReplayBuffer>>,
+    engine_version: String,
+}
+
+impl ReplaySink {
+    pub fn new(writer: Arc<dyn ReplayWriter>) -> Self {
+        Self {
+            writer,
+            state: Mutex::new(HashMap::new()),
+            engine_version: format!("pyrat-orchestrator/{}", env!("CARGO_PKG_VERSION")),
+        }
+    }
+
+    /// Override the version string written into every replay file. Useful
+    /// for embedding application identity (e.g. `"pyrat-eval/0.1.0"`).
+    pub fn with_engine_version(mut self, version: impl Into<String>) -> Self {
+        self.engine_version = version.into();
+        self
+    }
+
+    /// True iff a buffer is currently held for this match. Test hook.
+    pub fn has_buffer(&self, id: MatchId) -> bool {
+        self.state.lock().contains_key(&id)
+    }
+
+    /// Number of buffers currently held. Test hook.
+    pub fn buffer_count(&self) -> usize {
+        self.state.lock().len()
+    }
+}
+
+#[async_trait]
+impl<D: Descriptor> MatchSink<D> for ReplaySink {
+    async fn on_match_started(
+        &self,
+        descriptor: &D,
+        _players: &[PlayerIdentity; 2],
+    ) -> Result<(), SinkError> {
+        let id = descriptor.match_id();
+        let buffer = ReplayBuffer {
+            events: Vec::new(),
+            match_config: None,
+            seed: descriptor.seed(),
+        };
+        self.state.lock().insert(id, buffer);
+        Ok(())
+    }
+
+    async fn on_match_event(&self, id: MatchId, event: &MatchEvent) -> Result<(), SinkError> {
+        let mut state = self.state.lock();
+        let Some(buf) = state.get_mut(&id) else {
+            return Ok(());
+        };
+        if let MatchEvent::MatchStarted { config } = event {
+            // Only the first `MatchStarted` populates `match_config`.
+            // Subsequent ones (shouldn't happen, but defensive) are
+            // ignored to keep the seed-derived header stable.
+            if buf.match_config.is_none() {
+                buf.match_config = Some(config.into());
+            }
+        }
+        buf.events.push(ReplayEvent::from(event));
+        Ok(())
+    }
+
+    async fn on_match_finished(&self, outcome: &MatchOutcome<D>) -> Result<(), SinkError> {
+        let id = outcome.descriptor.match_id();
+        let buf = match self.state.lock().remove(&id) {
+            Some(b) => b,
+            None => return Ok(()),
+        };
+        // Synthesise terminal MatchOver since the host's was suppressed.
+        let result_dto: ReplayMatchResult = (&outcome.result).into();
+        let mut events = buf.events;
+        events.push(ReplayEvent::MatchOver {
+            result: result_dto.clone(),
+        });
+        let file = ReplayFile {
+            engine_version: self.engine_version.clone(),
+            match_config: buf.match_config,
+            seed: buf.seed,
+            events,
+            result: result_dto,
+        };
+        let payload = serde_json::to_string_pretty(&file).map_err(|e| SinkError {
+            source: anyhow::anyhow!("serialise replay {id}: {e}"),
+        })?;
+        if let Err(e) = self.writer.write(id, &payload) {
+            // Optional sink error; never propagated as durable. The
+            // composite layer will log + count if this is wired Optional.
+            return Err(SinkError {
+                source: anyhow::anyhow!("write replay {id}: {e}"),
+            });
+        }
+        Ok(())
+    }
+
+    async fn on_match_failed(&self, failure: &MatchFailure<D>) -> Result<(), SinkError> {
+        // Drop the buffer without writing. No partial replays on failure.
+        let id = failure.descriptor.match_id();
+        if self.state.lock().remove(&id).is_none() {
+            // Defensive: nothing to drop.
+            warn!(match_id = %id, "replay sink: on_match_failed for unknown id");
+        }
+        Ok(())
+    }
+
+    async fn on_match_abandoned(&self, id: MatchId) -> Result<(), SinkError> {
+        // Same outcome as `on_match_failed`: drop the buffer, no write.
+        // Hook is separate so the cause stays honest (another sink errored,
+        // not this one).
+        self.state.lock().remove(&id);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::SystemTime;
+
+    use pyrat::{Coordinates, Direction};
+    use pyrat_host::match_host::MatchResult;
+    use pyrat_host::wire::{GameResult, Player as PlayerSlot};
+
+    use super::*;
+    use crate::descriptor::AdHocDescriptor;
+    use crate::outcome::{FailureReason, MatchFailure, MatchOutcome};
+
+    fn ad_hoc(id: u64, seed: u64) -> AdHocDescriptor {
+        AdHocDescriptor {
+            match_id: MatchId(id),
+            seed,
+            planned_at: SystemTime::UNIX_EPOCH,
+        }
+    }
+
+    fn identity(slot: PlayerSlot) -> PlayerIdentity {
+        PlayerIdentity {
+            name: "n".into(),
+            author: "a".into(),
+            agent_id: "id".into(),
+            slot,
+        }
+    }
+
+    fn outcome(desc: AdHocDescriptor) -> MatchOutcome<AdHocDescriptor> {
+        MatchOutcome {
+            descriptor: desc,
+            started_at: SystemTime::UNIX_EPOCH,
+            finished_at: SystemTime::UNIX_EPOCH,
+            result: MatchResult {
+                result: GameResult::Draw,
+                player1_score: 0.0,
+                player2_score: 0.0,
+                turns_played: 0,
+            },
+            players: [identity(PlayerSlot::Player1), identity(PlayerSlot::Player2)],
+        }
+    }
+
+    fn failure(desc: AdHocDescriptor) -> MatchFailure<AdHocDescriptor> {
+        MatchFailure {
+            descriptor: desc,
+            started_at: None,
+            failed_at: SystemTime::UNIX_EPOCH,
+            reason: FailureReason::Cancelled,
+            players: None,
+            durable_record: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn finished_writes_one_file_and_drops_buffer() {
+        let writer = Arc::new(MemoryWriter::new());
+        let sink = ReplaySink::new(writer.clone());
+        let desc = ad_hoc(1, 42);
+
+        sink.on_match_started(
+            &desc,
+            &[identity(PlayerSlot::Player1), identity(PlayerSlot::Player2)],
+        )
+        .await
+        .unwrap();
+        assert!(sink.has_buffer(MatchId(1)));
+
+        sink.on_match_finished(&outcome(desc)).await.unwrap();
+
+        assert!(!sink.has_buffer(MatchId(1)));
+        assert_eq!(writer.count(), 1);
+        let payload = writer.get(MatchId(1)).unwrap();
+        let parsed: ReplayFile = serde_json::from_str(&payload).unwrap();
+        assert_eq!(parsed.seed, 42);
+        // Last event must be the synthesised MatchOver.
+        assert!(matches!(
+            parsed.events.last(),
+            Some(ReplayEvent::MatchOver { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn failed_drops_buffer_without_writing() {
+        let writer = Arc::new(MemoryWriter::new());
+        let sink = ReplaySink::new(writer.clone());
+        let desc = ad_hoc(2, 7);
+
+        sink.on_match_started(
+            &desc,
+            &[identity(PlayerSlot::Player1), identity(PlayerSlot::Player2)],
+        )
+        .await
+        .unwrap();
+        sink.on_match_failed(&failure(desc)).await.unwrap();
+        assert!(!sink.has_buffer(MatchId(2)));
+        assert_eq!(writer.count(), 0, "no file should be written on failure");
+    }
+
+    #[tokio::test]
+    async fn abandoned_drops_buffer_without_writing() {
+        let writer = Arc::new(MemoryWriter::new());
+        let sink_inner = ReplaySink::new(writer.clone());
+        let sink: &dyn MatchSink<AdHocDescriptor> = &sink_inner;
+        let desc = ad_hoc(3, 8);
+
+        sink.on_match_started(
+            &desc,
+            &[identity(PlayerSlot::Player1), identity(PlayerSlot::Player2)],
+        )
+        .await
+        .unwrap();
+        sink.on_match_abandoned(MatchId(3)).await.unwrap();
+        assert!(!sink_inner.has_buffer(MatchId(3)));
+        assert_eq!(writer.count(), 0);
+    }
+
+    #[tokio::test]
+    async fn missing_buffer_callbacks_are_silent_noops() {
+        let writer = Arc::new(MemoryWriter::new());
+        let sink_inner = ReplaySink::new(writer.clone());
+        let sink: &dyn MatchSink<AdHocDescriptor> = &sink_inner;
+        // No on_match_started.
+        sink.on_match_event(MatchId(99), &MatchEvent::PreprocessingStarted)
+            .await
+            .unwrap();
+        sink.on_match_finished(&outcome(ad_hoc(99, 0)))
+            .await
+            .unwrap();
+        sink.on_match_abandoned(MatchId(99)).await.unwrap();
+        assert_eq!(writer.count(), 0);
+        assert_eq!(sink_inner.buffer_count(), 0);
+    }
+
+    /// Concurrent matches must keep their event streams separate. Pins the
+    /// per-match keyed-buffer invariant: a single shared `Vec<ReplayEvent>`
+    /// would interleave.
+    #[tokio::test]
+    async fn concurrent_matches_have_separate_buffers() {
+        let writer = Arc::new(MemoryWriter::new());
+        let sink_inner = ReplaySink::new(writer.clone());
+        // Bind to the trait-object form once: `on_match_event` doesn't
+        // take a `&D`, so otherwise the compiler can't infer which `D` to
+        // dispatch to (the impl is generic over every Descriptor).
+        let sink: &dyn MatchSink<AdHocDescriptor> = &sink_inner;
+
+        // Start three matches with distinguishable seeds.
+        for (id, seed) in [(10u64, 1u64), (11, 2), (12, 3)] {
+            let desc = ad_hoc(id, seed);
+            sink.on_match_started(
+                &desc,
+                &[identity(PlayerSlot::Player1), identity(PlayerSlot::Player2)],
+            )
+            .await
+            .unwrap();
+        }
+
+        // Interleave events: only id=10 sees a BotTimeout for player1; only
+        // id=11 sees BotTimeout for player2; id=12 sees no BotTimeout.
+        sink.on_match_event(
+            MatchId(10),
+            &MatchEvent::BotTimeout {
+                player: PlayerSlot::Player1,
+                turn: 1,
+            },
+        )
+        .await
+        .unwrap();
+        sink.on_match_event(
+            MatchId(11),
+            &MatchEvent::BotTimeout {
+                player: PlayerSlot::Player2,
+                turn: 2,
+            },
+        )
+        .await
+        .unwrap();
+        // Cross-traffic that should NOT show up in any buffer for that id.
+        sink.on_match_event(MatchId(10), &MatchEvent::PreprocessingStarted)
+            .await
+            .unwrap();
+
+        // Finish all three.
+        for id in [10u64, 11, 12] {
+            let seed = id - 9;
+            let desc = ad_hoc(id, seed);
+            sink.on_match_finished(&outcome(desc)).await.unwrap();
+        }
+
+        let payload10: ReplayFile =
+            serde_json::from_str(&writer.get(MatchId(10)).unwrap()).unwrap();
+        let payload11: ReplayFile =
+            serde_json::from_str(&writer.get(MatchId(11)).unwrap()).unwrap();
+        let payload12: ReplayFile =
+            serde_json::from_str(&writer.get(MatchId(12)).unwrap()).unwrap();
+
+        assert_eq!(payload10.seed, 1);
+        assert_eq!(payload11.seed, 2);
+        assert_eq!(payload12.seed, 3);
+
+        // id=10 saw BotTimeout(P1) and PreprocessingStarted (plus synthesised MatchOver).
+        let bot_timeout_count = payload10
+            .events
+            .iter()
+            .filter(|e| matches!(e, ReplayEvent::BotTimeout { player, .. } if *player == PlayerSlot::Player1.0))
+            .count();
+        assert_eq!(
+            bot_timeout_count, 1,
+            "id=10 should see exactly one P1 BotTimeout"
+        );
+        assert!(payload10
+            .events
+            .iter()
+            .any(|e| matches!(e, ReplayEvent::PreprocessingStarted)));
+        // id=10 should not see id=11's BotTimeout.
+        let p2_timeout_in_10 = payload10
+            .events
+            .iter()
+            .filter(|e| matches!(e, ReplayEvent::BotTimeout { player, .. } if *player == PlayerSlot::Player2.0))
+            .count();
+        assert_eq!(p2_timeout_in_10, 0, "id=10 must NOT see id=11's BotTimeout");
+
+        // id=11 saw exactly one BotTimeout(P2).
+        let p2_timeout_in_11 = payload11
+            .events
+            .iter()
+            .filter(|e| matches!(e, ReplayEvent::BotTimeout { player, .. } if *player == PlayerSlot::Player2.0))
+            .count();
+        assert_eq!(p2_timeout_in_11, 1);
+
+        // id=12 saw only the synthesised MatchOver.
+        assert_eq!(payload12.events.len(), 1);
+        assert!(matches!(payload12.events[0], ReplayEvent::MatchOver { .. }));
+    }
+
+    /// `MatchStarted { config }` populates the file's `match_config` once.
+    /// A second `MatchStarted` (defensive; shouldn't happen) doesn't
+    /// overwrite. Pins the seed-derived header against late host events.
+    #[tokio::test]
+    async fn match_config_captured_from_first_match_started() {
+        let writer = Arc::new(MemoryWriter::new());
+        let sink_inner = ReplaySink::new(writer.clone());
+        let sink: &dyn MatchSink<AdHocDescriptor> = &sink_inner;
+        let desc = ad_hoc(20, 99);
+
+        sink.on_match_started(
+            &desc,
+            &[identity(PlayerSlot::Player1), identity(PlayerSlot::Player2)],
+        )
+        .await
+        .unwrap();
+
+        let cfg = pyrat_protocol::MatchConfig {
+            width: 5,
+            height: 5,
+            max_turns: 100,
+            walls: vec![],
+            mud: vec![],
+            cheese: vec![Coordinates::new(2, 2)],
+            player1_start: Coordinates::new(0, 0),
+            player2_start: Coordinates::new(4, 4),
+            timing: pyrat_host::wire::TimingMode::Wait,
+            move_timeout_ms: 500,
+            preprocessing_timeout_ms: 1000,
+        };
+        sink.on_match_event(MatchId(20), &MatchEvent::MatchStarted { config: cfg })
+            .await
+            .unwrap();
+        // Append a later event so the file isn't all-MatchStarted.
+        sink.on_match_event(
+            MatchId(20),
+            &MatchEvent::BotProvisional {
+                sender: PlayerSlot::Player1,
+                turn: 1,
+                state_hash: 0xCAFE,
+                direction: Direction::Up,
+            },
+        )
+        .await
+        .unwrap();
+        sink.on_match_finished(&outcome(desc)).await.unwrap();
+
+        let parsed: ReplayFile = serde_json::from_str(&writer.get(MatchId(20)).unwrap()).unwrap();
+        assert!(parsed.match_config.is_some());
+        assert_eq!(parsed.match_config.as_ref().unwrap().width, 5);
+        assert_eq!(parsed.seed, 99);
+    }
+}

--- a/eval/orchestrator/tests/cancel_midmatch.rs
+++ b/eval/orchestrator/tests/cancel_midmatch.rs
@@ -1,0 +1,75 @@
+//! Cancel-mid-match: `Match::run` is dropped from the cancel arm; the
+//! per-match task emits `MatchFailed { Cancelled, durable_record: false }`.
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use pyrat_orchestrator::{
+    AdHocDescriptor, DriverEvent, FailureReason, NoOpSink, Orchestrator, OrchestratorConfig,
+};
+use tokio::time::timeout;
+
+use common::{embedded_matchup, mock_factory, slow_factory};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn cancel_after_match_started_yields_cancelled_failure() {
+    let cfg = OrchestratorConfig {
+        max_parallel: 1,
+        ..Default::default()
+    };
+    let sink: Arc<NoOpSink<AdHocDescriptor>> = Arc::new(NoOpSink::new());
+    let (orch, mut driver_rx) = Orchestrator::new(cfg, sink);
+
+    // Mock vs Slow: Slow blocks forever in `think` until the host signals
+    // stop. Forces the run-loop to sit in the playing phase when we cancel.
+    orch.submit(embedded_matchup(0, mock_factory(), slow_factory()))
+        .await
+        .expect("submit");
+
+    // Wait for MatchStarted so we know we're past setup.
+    let wait_started = async {
+        loop {
+            match driver_rx.recv().await.expect("driver_rx") {
+                DriverEvent::MatchStarted { .. } => break,
+                DriverEvent::MatchFinished { .. } => {
+                    panic!("match finished before we could cancel")
+                },
+                DriverEvent::MatchFailed { failure } => {
+                    panic!("match failed before we could cancel: {:?}", failure.reason)
+                },
+                _ => {},
+            }
+        }
+    };
+    timeout(Duration::from_secs(5), wait_started)
+        .await
+        .expect("MatchStarted in time");
+
+    // Now cancel and observe the terminal.
+    orch.abort();
+
+    let term = async {
+        loop {
+            match driver_rx.recv().await.expect("driver_rx after abort") {
+                DriverEvent::MatchFailed { failure } => break failure,
+                DriverEvent::MatchFinished { .. } => panic!("unexpected finish after cancel"),
+                _ => {},
+            }
+        }
+    };
+    let failure = timeout(Duration::from_secs(5), term)
+        .await
+        .expect("MatchFailed in time after cancel");
+
+    assert!(
+        matches!(failure.reason, FailureReason::Cancelled),
+        "expected Cancelled, got {:?}",
+        failure.reason
+    );
+    assert!(
+        !failure.durable_record,
+        "cancelled match must have durable_record=false"
+    );
+}

--- a/eval/orchestrator/tests/common/mod.rs
+++ b/eval/orchestrator/tests/common/mod.rs
@@ -1,22 +1,28 @@
 //! Shared fixtures for the orchestrator integration tests.
 //!
 //! Embedded test bots, deterministic small-game configs, matchup builders.
-//! Subprocess-path coverage stays in the host crate's integration tests
-//! and the headless e2e. Running real subprocesses from this crate would
-//! double the integration runtime for no incremental signal.
+//! Subprocess coverage in this crate is intentionally minimal — *one*
+//! test (`setup_failure_durable.rs`) confirms the launch setup-failure
+//! path; TCP accept/handshake and mid-match disconnect coverage stay in
+//! the host crate.
 
 #![allow(dead_code)]
 
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::SystemTime;
 
+use async_trait::async_trait;
+use parking_lot::Mutex;
 use pyrat::game::builder::GameConfig;
 use pyrat::{Coordinates, Direction, GameBuilder};
 use pyrat_bot_api::Options;
-use pyrat_host::player::{EmbeddedBot, EmbeddedCtx};
+use pyrat_host::match_host::MatchEvent;
+use pyrat_host::player::{EmbeddedBot, EmbeddedCtx, PlayerIdentity};
 use pyrat_host::wire::GameResult;
 use pyrat_orchestrator::{
-    AdHocDescriptor, EmbeddedBotFactory, MatchId, Matchup, PlayerSpec, Timing,
+    AdHocDescriptor, EmbeddedBotFactory, MatchFailure, MatchId, MatchOutcome, MatchSink, Matchup,
+    PlayerSpec, SinkError, Timing,
 };
 use pyrat_protocol::HashedTurnState;
 
@@ -100,6 +106,154 @@ pub fn embedded_matchup(
 
 pub fn mock_vs_mock(id: u64) -> Matchup<AdHocDescriptor> {
     embedded_matchup(id, mock_factory(), mock_factory())
+}
+
+/// Factory whose closure panics on invocation. The orchestrator calls the
+/// factory inside the per-match task body (`run_match.rs`'s
+/// `BoxedEmbeddedBot(factory())` site), so the panic propagates up through
+/// the per-match task and reaches `JoinSet::join_next_with_id` as
+/// `JoinError::is_panic() == true`. A panic inside `EmbeddedBot::think`
+/// would be caught by `EmbeddedPlayer`'s `spawn_blocking` and converted to
+/// `PlayerError`, which is *not* what we want to test for the
+/// `JoinError::is_panic()` mapping.
+pub fn panicking_factory() -> EmbeddedBotFactory {
+    Arc::new(|| panic!("test factory panic"))
+}
+
+/// Subprocess matchup whose subprocess slot points at a `working_dir`
+/// that does not exist. `launch_bots` calls
+/// `Command::current_dir(...).spawn()`, which fails at spawn time when
+/// the directory is missing — this is the deterministic trigger for the
+/// `SetupError::Launch -> FailureReason::SpawnFailed` path. Slot 1 is an
+/// embedded MockBot so we don't depend on a second subprocess fixture.
+pub fn subprocess_matchup_with_bad_workdir(id: u64) -> Matchup<AdHocDescriptor> {
+    Matchup {
+        descriptor: descriptor(id),
+        game_config: small_game_config(),
+        players: [
+            PlayerSpec::Subprocess {
+                agent_id: "test/bad-spawn".into(),
+                command: "echo unreachable".into(),
+                working_dir: Some(PathBuf::from("/this/path/does/not/exist/orchestrator-test")),
+            },
+            PlayerSpec::Embedded {
+                agent_id: "test/p2".into(),
+                name: "Player2Bot".into(),
+                author: "tests".into(),
+                factory: mock_factory(),
+            },
+        ],
+        timing: Timing::default(),
+    }
+}
+
+/// Records every sink callback for inspection in tests. `Required` or
+/// `Optional` is decided at composition time by the test using
+/// `CompositeSink`; this sink itself returns `Ok` from every method.
+#[derive(Default)]
+pub struct RecordingSink {
+    pub calls: Mutex<Vec<RecordedCall>>,
+}
+
+#[derive(Debug, Clone)]
+pub enum RecordedCall {
+    Started {
+        match_id: MatchId,
+    },
+    Event {
+        match_id: MatchId,
+        kind: &'static str,
+    },
+    Finished {
+        match_id: MatchId,
+    },
+    Failed {
+        match_id: MatchId,
+        durable_record: bool,
+        reason_debug: String,
+    },
+    Abandoned {
+        match_id: MatchId,
+    },
+}
+
+impl RecordingSink {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn snapshot(&self) -> Vec<RecordedCall> {
+        self.calls.lock().clone()
+    }
+
+    pub fn failures(&self) -> Vec<RecordedCall> {
+        self.calls
+            .lock()
+            .iter()
+            .filter(|c| matches!(c, RecordedCall::Failed { .. }))
+            .cloned()
+            .collect()
+    }
+}
+
+#[async_trait]
+impl MatchSink<AdHocDescriptor> for RecordingSink {
+    async fn on_match_started(
+        &self,
+        descriptor: &AdHocDescriptor,
+        _players: &[PlayerIdentity; 2],
+    ) -> Result<(), SinkError> {
+        self.calls.lock().push(RecordedCall::Started {
+            match_id: descriptor.match_id,
+        });
+        Ok(())
+    }
+
+    async fn on_match_event(&self, match_id: MatchId, event: &MatchEvent) -> Result<(), SinkError> {
+        self.calls.lock().push(RecordedCall::Event {
+            match_id,
+            kind: match event {
+                MatchEvent::BotIdentified { .. } => "BotIdentified",
+                MatchEvent::PreprocessingStarted => "PreprocessingStarted",
+                MatchEvent::SetupComplete => "SetupComplete",
+                MatchEvent::MatchStarted { .. } => "MatchStarted",
+                MatchEvent::TurnPlayed { .. } => "TurnPlayed",
+                MatchEvent::BotInfo { .. } => "BotInfo",
+                MatchEvent::BotProvisional { .. } => "BotProvisional",
+                MatchEvent::BotTimeout { .. } => "BotTimeout",
+                MatchEvent::MatchOver { .. } => "MatchOver",
+                _ => "Other",
+            },
+        });
+        Ok(())
+    }
+
+    async fn on_match_finished(
+        &self,
+        outcome: &MatchOutcome<AdHocDescriptor>,
+    ) -> Result<(), SinkError> {
+        self.calls.lock().push(RecordedCall::Finished {
+            match_id: outcome.descriptor.match_id,
+        });
+        Ok(())
+    }
+
+    async fn on_match_failed(
+        &self,
+        failure: &MatchFailure<AdHocDescriptor>,
+    ) -> Result<(), SinkError> {
+        self.calls.lock().push(RecordedCall::Failed {
+            match_id: failure.descriptor.match_id,
+            durable_record: failure.durable_record,
+            reason_debug: format!("{:?}", failure.reason),
+        });
+        Ok(())
+    }
+
+    async fn on_match_abandoned(&self, match_id: MatchId) -> Result<(), SinkError> {
+        self.calls.lock().push(RecordedCall::Abandoned { match_id });
+        Ok(())
+    }
 }
 
 pub fn _ensure_used(_: GameResult) {}

--- a/eval/orchestrator/tests/common/mod.rs
+++ b/eval/orchestrator/tests/common/mod.rs
@@ -1,0 +1,105 @@
+//! Shared fixtures for the orchestrator integration tests.
+//!
+//! Embedded test bots, deterministic small-game configs, matchup builders.
+//! Subprocess-path coverage stays in the host crate's integration tests
+//! and the headless e2e. Running real subprocesses from this crate would
+//! double the integration runtime for no incremental signal.
+
+#![allow(dead_code)]
+
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use pyrat::game::builder::GameConfig;
+use pyrat::{Coordinates, Direction, GameBuilder};
+use pyrat_bot_api::Options;
+use pyrat_host::player::{EmbeddedBot, EmbeddedCtx};
+use pyrat_host::wire::GameResult;
+use pyrat_orchestrator::{
+    AdHocDescriptor, EmbeddedBotFactory, MatchId, Matchup, PlayerSpec, Timing,
+};
+use pyrat_protocol::HashedTurnState;
+
+/// Always returns Stay. Plays a deterministic do-nothing match.
+pub struct MockBot;
+impl Options for MockBot {}
+impl EmbeddedBot for MockBot {
+    fn think(&mut self, _state: &HashedTurnState, _ctx: &EmbeddedCtx) -> Direction {
+        Direction::Stay
+    }
+}
+
+/// Spins inside `think` until the host signals stop. Triggers the
+/// cancellation drop path: when `Match::run` is dropped, players drop,
+/// dispatcher detects host_tx closure and flips `should_stop`, the bot
+/// returns Stay, dispatcher exits cleanly, spawn_blocking thread reaped.
+pub struct SlowBot;
+impl Options for SlowBot {}
+impl EmbeddedBot for SlowBot {
+    fn think(&mut self, _state: &HashedTurnState, ctx: &EmbeddedCtx) -> Direction {
+        while !ctx.should_stop() {
+            std::hint::spin_loop();
+        }
+        Direction::Stay
+    }
+}
+
+pub fn mock_factory() -> EmbeddedBotFactory {
+    Arc::new(|| Box::new(MockBot))
+}
+
+pub fn slow_factory() -> EmbeddedBotFactory {
+    Arc::new(|| Box::new(SlowBot))
+}
+
+/// 3x3 open maze, corner starts, single-cheese centre, 5-turn cap. Two
+/// MockBots staying put end in Draw with `turns_played == 5`.
+pub fn small_game_config() -> GameConfig {
+    GameBuilder::new(3, 3)
+        .with_max_turns(5)
+        .with_open_maze()
+        .with_custom_positions(Coordinates::new(0, 0), Coordinates::new(2, 2))
+        .with_custom_cheese(vec![Coordinates::new(1, 1)])
+        .build()
+}
+
+pub fn descriptor(id: u64) -> AdHocDescriptor {
+    AdHocDescriptor {
+        match_id: MatchId(id),
+        seed: 42,
+        planned_at: SystemTime::UNIX_EPOCH,
+    }
+}
+
+/// Two-embedded-bot matchup with given factories and identifying labels.
+pub fn embedded_matchup(
+    id: u64,
+    p1: EmbeddedBotFactory,
+    p2: EmbeddedBotFactory,
+) -> Matchup<AdHocDescriptor> {
+    Matchup {
+        descriptor: descriptor(id),
+        game_config: small_game_config(),
+        players: [
+            PlayerSpec::Embedded {
+                agent_id: "test/p1".into(),
+                name: "Player1Bot".into(),
+                author: "tests".into(),
+                factory: p1,
+            },
+            PlayerSpec::Embedded {
+                agent_id: "test/p2".into(),
+                name: "Player2Bot".into(),
+                author: "tests".into(),
+                factory: p2,
+            },
+        ],
+        timing: Timing::default(),
+    }
+}
+
+pub fn mock_vs_mock(id: u64) -> Matchup<AdHocDescriptor> {
+    embedded_matchup(id, mock_factory(), mock_factory())
+}
+
+pub fn _ensure_used(_: GameResult) {}

--- a/eval/orchestrator/tests/driver_drop_cancels.rs
+++ b/eval/orchestrator/tests/driver_drop_cancels.rs
@@ -1,0 +1,74 @@
+//! Driver-drop is fatal to the orchestrator. Pinned in `plan.md:129` and
+//! `executor.rs`'s module doc: when `driver_rx` is dropped, the next
+//! `publish_lifecycle` call cancels root, the run-loop unwinds, drains,
+//! and exits, and subsequent `submit()` calls return `ShutDown`.
+//!
+//! Test shape: tiny mpsc capacities so backpressure surfaces immediately,
+//! a slow_factory match so the per-match task is alive when we drop the
+//! receiver, then poll `submit()` until it returns `ShutDown` (the
+//! reliable signal that the run-loop has exited and `submit_rx` was
+//! dropped). We avoid asserting on `state().changed()` because
+//! `publish_lifecycle` returns on `DriverDropped` *before* mutating
+//! state, so no state tick fires from the drop itself.
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use pyrat_orchestrator::{
+    AdHocDescriptor, NoOpSink, Orchestrator, OrchestratorConfig, OrchestratorError,
+};
+use tokio::time::{sleep, timeout};
+
+use common::{embedded_matchup, mock_factory, mock_vs_mock, slow_factory};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dropped_driver_rx_makes_orchestrator_shut_down() {
+    let cfg = OrchestratorConfig {
+        max_parallel: 1,
+        submit_capacity: 1,
+        driver_events_capacity: 1,
+        ..Default::default()
+    };
+    let sink: Arc<NoOpSink<AdHocDescriptor>> = Arc::new(NoOpSink::new());
+    let (orch, driver_rx) = Orchestrator::new(cfg, sink);
+
+    // Submit a slow_factory match so a per-match task will be alive and
+    // attempting to publish lifecycle events when we drop the driver.
+    orch.submit(embedded_matchup(0, mock_factory(), slow_factory()))
+        .await
+        .expect("first submit");
+
+    // Give the per-match task a moment to publish MatchQueued (which
+    // drains the first slot of driver_events_capacity=1) so the next
+    // publish will block on send. Not strictly required for the test to
+    // pass — the polling loop below tolerates either ordering — but
+    // makes the failure mode clear: drop_driver triggers DriverDropped on
+    // the in-flight task's *next* publish.
+    sleep(Duration::from_millis(50)).await;
+    drop(driver_rx);
+
+    // Poll submit() until it returns ShutDown. Any new attempt sees
+    // either backpressure (run-loop hasn't exited yet) or ShutDown
+    // (run-loop exited and dropped submit_rx). The first state where
+    // submit_rx is gone is the reliable signal we want.
+    let became_shut_down = timeout(Duration::from_secs(5), async {
+        loop {
+            match orch.submit(mock_vs_mock(1)).await {
+                Ok(()) => {
+                    // Submit accepted before the run-loop noticed the
+                    // drop. Wait briefly and retry.
+                    sleep(Duration::from_millis(20)).await;
+                },
+                Err(OrchestratorError::ShutDown) => return,
+            }
+        }
+    })
+    .await;
+
+    assert!(
+        became_shut_down.is_ok(),
+        "submit() never returned ShutDown after driver_rx was dropped",
+    );
+}

--- a/eval/orchestrator/tests/embedded_identity.rs
+++ b/eval/orchestrator/tests/embedded_identity.rs
@@ -1,0 +1,100 @@
+//! `PlayerSpec::Embedded` must propagate `name` and `author` through to:
+//! - `MatchEvent::BotIdentified` on the broadcast (the host emits this).
+//! - `MatchOutcome.players[i].name` / `.author` (read from
+//!   `Player::identity()` after handshake).
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use pyrat_host::match_host::MatchEvent;
+use pyrat_host::wire::Player as PlayerSlot;
+use pyrat_orchestrator::{
+    AdHocDescriptor, DriverEvent, NoOpSink, Orchestrator, OrchestratorConfig, OrchestratorEvent,
+};
+use tokio::time::timeout;
+
+use common::{embedded_matchup, mock_factory};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn embedded_name_and_author_propagate_through_events_and_outcome() {
+    let cfg = OrchestratorConfig {
+        max_parallel: 1,
+        ..Default::default()
+    };
+    let sink: Arc<NoOpSink<AdHocDescriptor>> = Arc::new(NoOpSink::new());
+    let (orch, mut driver_rx) = Orchestrator::new(cfg, sink);
+    let mut events = orch.events();
+
+    orch.submit(embedded_matchup(0, mock_factory(), mock_factory()))
+        .await
+        .expect("submit");
+
+    let driver_task = tokio::spawn(async move {
+        loop {
+            match driver_rx.recv().await.expect("driver_rx") {
+                DriverEvent::MatchFinished { outcome } => break outcome,
+                DriverEvent::MatchFailed { failure } => {
+                    panic!("unexpected failure: {:?}", failure.reason)
+                },
+                _ => {},
+            }
+        }
+    });
+
+    // Collect broadcast events; assert BotIdentified for each slot carries
+    // the supplied name/author.
+    let mut bot_identified_p1 = None;
+    let mut bot_identified_p2 = None;
+    let collect = async {
+        loop {
+            match events.recv().await {
+                Ok(OrchestratorEvent::MatchEvent { event, .. }) => {
+                    if let MatchEvent::BotIdentified {
+                        player,
+                        name,
+                        author,
+                        agent_id,
+                    } = event
+                    {
+                        let slot = (name.clone(), author.clone(), agent_id.clone());
+                        match player {
+                            PlayerSlot::Player1 => bot_identified_p1 = Some(slot),
+                            PlayerSlot::Player2 => bot_identified_p2 = Some(slot),
+                            _ => {},
+                        }
+                    }
+                },
+                Ok(OrchestratorEvent::MatchFinished { .. })
+                | Ok(OrchestratorEvent::MatchFailed { .. }) => {
+                    break;
+                },
+                Ok(_) => {},
+                Err(_) => break,
+            }
+        }
+    };
+    timeout(Duration::from_secs(10), collect)
+        .await
+        .expect("events");
+    let outcome = driver_task.await.expect("driver task");
+
+    let (n1, a1, id1) = bot_identified_p1.expect("BotIdentified for Player1");
+    assert_eq!(n1, "Player1Bot");
+    assert_eq!(a1, "tests");
+    assert_eq!(id1, "test/p1");
+    let (n2, a2, id2) = bot_identified_p2.expect("BotIdentified for Player2");
+    assert_eq!(n2, "Player2Bot");
+    assert_eq!(a2, "tests");
+    assert_eq!(id2, "test/p2");
+
+    // Outcome.players carry the same identities (read from the player
+    // handles post-handshake).
+    assert_eq!(outcome.players[0].name, "Player1Bot");
+    assert_eq!(outcome.players[0].author, "tests");
+    assert_eq!(outcome.players[0].agent_id, "test/p1");
+    assert_eq!(outcome.players[1].name, "Player2Bot");
+    assert_eq!(outcome.players[1].author, "tests");
+    assert_eq!(outcome.players[1].agent_id, "test/p2");
+}

--- a/eval/orchestrator/tests/executor_basics.rs
+++ b/eval/orchestrator/tests/executor_basics.rs
@@ -1,0 +1,66 @@
+//! Executor smoke: many submissions, bounded parallelism, all complete.
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use pyrat_orchestrator::{
+    AdHocDescriptor, DriverEvent, NoOpSink, Orchestrator, OrchestratorConfig,
+};
+use tokio::time::timeout;
+
+use common::mock_vs_mock;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn five_matches_max_parallel_two_all_finish() {
+    let cfg = OrchestratorConfig {
+        max_parallel: 2,
+        ..Default::default()
+    };
+    let sink: Arc<NoOpSink<AdHocDescriptor>> = Arc::new(NoOpSink::new());
+    let (orch, mut driver_rx) = Orchestrator::new(cfg, sink);
+
+    for i in 0..5 {
+        orch.submit(mock_vs_mock(i)).await.expect("submit");
+    }
+
+    let mut finished = 0_u64;
+    let drain = async {
+        while finished < 5 {
+            match driver_rx.recv().await.expect("driver_rx") {
+                DriverEvent::MatchFinished { .. } => finished += 1,
+                DriverEvent::MatchFailed { failure } => {
+                    panic!("unexpected match failure: {:?}", failure.reason)
+                },
+                _ => {},
+            }
+        }
+    };
+    timeout(Duration::from_secs(20), drain)
+        .await
+        .expect("drain in time");
+
+    assert_eq!(finished, 5);
+
+    // The watch update happens *after* the lifecycle mpsc send by design,
+    // so wait for state to converge rather than read it eagerly.
+    let mut state_rx = orch.state();
+    let converge = async {
+        loop {
+            let s = state_rx.borrow_and_update().clone();
+            if s.finished == 5 && s.running.is_empty() && s.queued == 0 {
+                return s;
+            }
+            state_rx.changed().await.expect("state watch closed");
+        }
+    };
+    let final_state = timeout(Duration::from_secs(5), converge)
+        .await
+        .expect("state convergence");
+
+    assert_eq!(final_state.finished, 5);
+    assert_eq!(final_state.failed, 0);
+    assert!(final_state.running.is_empty());
+    assert_eq!(final_state.queued, 0);
+}

--- a/eval/orchestrator/tests/join_error_mapping.rs
+++ b/eval/orchestrator/tests/join_error_mapping.rs
@@ -1,0 +1,73 @@
+//! `JoinError::is_panic()` from a panicked per-match task synthesises
+//! `MatchFailed { reason: Panic, durable_record: false }`. Pins fix #4
+//! and the mapping row at `plan.md:337`.
+//!
+//! Trigger: an `EmbeddedBotFactory` whose closure panics on invocation.
+//! The factory is called inside `run_match`'s `BoxedEmbeddedBot(factory())`
+//! site (i.e. inside the per-match task body), so the panic propagates
+//! up through the per-match task and reaches `JoinSet::join_next_with_id`
+//! as `JoinError::is_panic() == true`. A panic inside `EmbeddedBot::think`
+//! would be caught by `EmbeddedPlayer`'s `spawn_blocking` and converted to
+//! `PlayerError`, which is *not* what we want to test for the panic-path
+//! mapping.
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use pyrat_orchestrator::{
+    AdHocDescriptor, DriverEvent, FailureReason, NoOpSink, Orchestrator, OrchestratorConfig,
+};
+use tokio::time::timeout;
+
+use common::{embedded_matchup, mock_factory, panicking_factory};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn factory_panic_synthesises_match_failed_panic() {
+    let cfg = OrchestratorConfig {
+        max_parallel: 1,
+        ..Default::default()
+    };
+    let sink: Arc<NoOpSink<AdHocDescriptor>> = Arc::new(NoOpSink::new());
+    let (orch, mut driver_rx) = Orchestrator::new(cfg, sink);
+
+    orch.submit(embedded_matchup(0, panicking_factory(), mock_factory()))
+        .await
+        .expect("submit");
+
+    let failure = timeout(Duration::from_secs(5), async {
+        loop {
+            match driver_rx.recv().await.expect("driver_rx") {
+                DriverEvent::MatchFailed { failure } => break failure,
+                DriverEvent::MatchFinished { .. } => panic!("unexpected finish"),
+                _ => {},
+            }
+        }
+    })
+    .await
+    .expect("MatchFailed in time");
+
+    assert!(
+        matches!(failure.reason, FailureReason::Panic),
+        "expected FailureReason::Panic, got {:?}",
+        failure.reason,
+    );
+    assert!(
+        !failure.durable_record,
+        "panic-stranded matches must have durable_record=false",
+    );
+    assert!(
+        failure.started_at.is_none(),
+        "synthesised panic terminal lacks started_at by design",
+    );
+    assert!(
+        failure.players.is_none(),
+        "synthesised panic terminal lacks players by design",
+    );
+
+    // Subsequent submits should still work — the run-loop didn't exit.
+    // (Drop driver_rx after this last submit would exit; we don't test
+    // that here.)
+    drop(driver_rx);
+}

--- a/eval/orchestrator/tests/match_over_suppression.rs
+++ b/eval/orchestrator/tests/match_over_suppression.rs
@@ -1,0 +1,100 @@
+//! Broadcast subscribers must never observe `MatchEvent::MatchOver`.
+//! The host's terminal is suppressed inside `run_match`; terminal signals
+//! on the broadcast are `MatchFinished` / `MatchFailed` only.
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use pyrat_host::match_host::MatchEvent;
+use pyrat_orchestrator::{
+    AdHocDescriptor, DriverEvent, NoOpSink, Orchestrator, OrchestratorConfig, OrchestratorEvent,
+};
+use tokio::time::timeout;
+
+use common::mock_vs_mock;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn broadcast_never_emits_match_over_per_turn_event() {
+    let cfg = OrchestratorConfig {
+        max_parallel: 1,
+        ..Default::default()
+    };
+    let sink: Arc<NoOpSink<AdHocDescriptor>> = Arc::new(NoOpSink::new());
+    let (orch, mut driver_rx) = Orchestrator::new(cfg, sink);
+
+    // Subscribe BEFORE submitting so no events are missed.
+    let mut events = orch.events();
+
+    orch.submit(mock_vs_mock(0)).await.expect("submit");
+
+    // Drain driver_rx in the background until MatchFinished, while the
+    // primary loop scans the broadcast for any MatchEvent::MatchOver.
+    let driver_task = tokio::spawn(async move {
+        loop {
+            match driver_rx.recv().await.expect("driver_rx") {
+                DriverEvent::MatchFinished { .. } | DriverEvent::MatchFailed { .. } => {
+                    break;
+                },
+                _ => {},
+            }
+        }
+    });
+
+    let mut collected: Vec<OrchestratorEvent<AdHocDescriptor>> = Vec::new();
+    let collect = async {
+        // Read until we see a terminal lifecycle event on the broadcast.
+        loop {
+            match events.recv().await {
+                Ok(ev) => {
+                    let is_terminal = matches!(
+                        ev,
+                        OrchestratorEvent::MatchFinished { .. }
+                            | OrchestratorEvent::MatchFailed { .. }
+                    );
+                    collected.push(ev);
+                    if is_terminal {
+                        break;
+                    }
+                },
+                Err(broadcast::error::RecvError::Lagged(_)) => {
+                    // Slow consumer; re-resync. Shouldn't happen in this
+                    // small match, but tolerate.
+                    continue;
+                },
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    };
+    use tokio::sync::broadcast;
+    timeout(Duration::from_secs(10), collect)
+        .await
+        .expect("collected events in time");
+    driver_task.await.expect("driver_task");
+
+    // Assertion: not a single OrchestratorEvent::MatchEvent variant
+    // wraps a MatchEvent::MatchOver.
+    for ev in &collected {
+        if let OrchestratorEvent::MatchEvent { event, .. } = ev {
+            assert!(
+                !matches!(event, MatchEvent::MatchOver { .. }),
+                "broadcast leaked MatchEvent::MatchOver; suppression broken"
+            );
+        }
+    }
+
+    // Sanity: there IS a terminal MatchFinished, and at least one
+    // non-MatchOver MatchEvent (BotIdentified or PreprocessingStarted etc.).
+    let saw_finished = collected
+        .iter()
+        .any(|e| matches!(e, OrchestratorEvent::MatchFinished { .. }));
+    assert!(saw_finished, "expected MatchFinished on broadcast");
+    let saw_some_per_turn = collected
+        .iter()
+        .any(|e| matches!(e, OrchestratorEvent::MatchEvent { .. }));
+    assert!(
+        saw_some_per_turn,
+        "expected at least one per-turn MatchEvent on broadcast"
+    );
+}

--- a/eval/orchestrator/tests/outcome_from_result.rs
+++ b/eval/orchestrator/tests/outcome_from_result.rs
@@ -1,0 +1,51 @@
+//! `MatchOutcome.result` must equal what `Match::run` returned. The match
+//! is deterministic (small open maze, two MockBots staying put, max_turns=5),
+//! so the result is `Draw` with both scores `0.0` and `turns_played == 5`.
+//!
+//! Pins the contract: outcome is built from `Match::run()`'s `MatchResult`,
+//! never from a buffered `MatchEvent::MatchOver`.
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use pyrat_host::wire::GameResult;
+use pyrat_orchestrator::{
+    AdHocDescriptor, DriverEvent, NoOpSink, Orchestrator, OrchestratorConfig,
+};
+use tokio::time::timeout;
+
+use common::mock_vs_mock;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn outcome_result_matches_deterministic_run() {
+    let cfg = OrchestratorConfig {
+        max_parallel: 1,
+        ..Default::default()
+    };
+    let sink: Arc<NoOpSink<AdHocDescriptor>> = Arc::new(NoOpSink::new());
+    let (orch, mut driver_rx) = Orchestrator::new(cfg, sink);
+
+    orch.submit(mock_vs_mock(0)).await.expect("submit");
+
+    let outcome = async {
+        loop {
+            match driver_rx.recv().await.expect("driver_rx") {
+                DriverEvent::MatchFinished { outcome } => break outcome,
+                DriverEvent::MatchFailed { failure } => {
+                    panic!("unexpected failure: {:?}", failure.reason)
+                },
+                _ => {},
+            }
+        }
+    };
+    let outcome = timeout(Duration::from_secs(10), outcome)
+        .await
+        .expect("finish in time");
+
+    assert_eq!(outcome.result.result, GameResult::Draw);
+    assert_eq!(outcome.result.player1_score, 0.0);
+    assert_eq!(outcome.result.player2_score, 0.0);
+    assert_eq!(outcome.result.turns_played, 5);
+}

--- a/eval/orchestrator/tests/panic_through_composite_releases_replay_buffer.rs
+++ b/eval/orchestrator/tests/panic_through_composite_releases_replay_buffer.rs
@@ -1,0 +1,108 @@
+//! When a per-match task panics *after* `sink.on_match_started` has
+//! populated state in stateful child sinks (e.g. `ReplaySink`), the
+//! run-loop's panic-recovery path calls `inner.sink.on_match_abandoned`.
+//! The top-level sink in real configurations is a `CompositeSink`, so
+//! the call must dispatch to recorded children — otherwise the trait
+//! default no-op leaks the per-match buffer.
+//!
+//! Test shape:
+//! - Required sink that succeeds on `on_match_started` but panics on
+//!   `on_match_event`. The panic propagates out of the per-match task as
+//!   `JoinError::is_panic() == true`.
+//! - Optional `ReplaySink` whose `on_match_started` populated a buffer.
+//! - Composite (Required, Optional) wired as `inner.sink`.
+//!
+//! After the panic, assert: `MatchFailed { Panic }` published; ReplaySink
+//! buffer for the match is empty (released via composite's
+//! `on_match_abandoned -> dispatch_abandoned -> child.on_match_abandoned`);
+//! no replay file written.
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use pyrat_host::match_host::MatchEvent;
+use pyrat_host::player::PlayerIdentity;
+use pyrat_orchestrator::{
+    AdHocDescriptor, CompositeSink, DriverEvent, FailureReason, MatchFailure, MatchId,
+    MatchOutcome, MatchSink, MemoryWriter, Orchestrator, OrchestratorConfig, ReplaySink, SinkError,
+    SinkRole,
+};
+use tokio::time::timeout;
+
+use common::mock_vs_mock;
+
+/// Required sink: Ok on started; on the *first* `on_match_event`,
+/// panic. Subsequent calls (defensive, won't be reached after panic)
+/// also Ok.
+struct PanicOnEventSink;
+
+#[async_trait]
+impl MatchSink<AdHocDescriptor> for PanicOnEventSink {
+    async fn on_match_started(
+        &self,
+        _: &AdHocDescriptor,
+        _: &[PlayerIdentity; 2],
+    ) -> Result<(), SinkError> {
+        Ok(())
+    }
+    async fn on_match_event(&self, _: MatchId, _: &MatchEvent) -> Result<(), SinkError> {
+        panic!("test sink panic during on_match_event");
+    }
+    async fn on_match_finished(&self, _: &MatchOutcome<AdHocDescriptor>) -> Result<(), SinkError> {
+        Ok(())
+    }
+    async fn on_match_failed(&self, _: &MatchFailure<AdHocDescriptor>) -> Result<(), SinkError> {
+        Ok(())
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn panic_after_started_releases_composite_replay_buffer() {
+    let cfg = OrchestratorConfig {
+        max_parallel: 1,
+        ..Default::default()
+    };
+
+    let writer = Arc::new(MemoryWriter::new());
+    let replay = Arc::new(ReplaySink::new(writer.clone()));
+    let replay_dyn: Arc<dyn MatchSink<AdHocDescriptor>> = replay.clone();
+    let bad_dyn: Arc<dyn MatchSink<AdHocDescriptor>> = Arc::new(PanicOnEventSink);
+
+    let composite: Arc<dyn MatchSink<AdHocDescriptor>> = Arc::new(CompositeSink::new(vec![
+        (SinkRole::Required, bad_dyn),
+        (SinkRole::Optional, replay_dyn),
+    ]));
+    let (orch, mut driver_rx) = Orchestrator::new(cfg, composite);
+
+    orch.submit(mock_vs_mock(0)).await.expect("submit");
+
+    let failure = timeout(Duration::from_secs(10), async {
+        loop {
+            match driver_rx.recv().await.expect("driver_rx") {
+                DriverEvent::MatchFailed { failure } => break failure,
+                DriverEvent::MatchFinished { .. } => panic!("unexpected finish"),
+                _ => {},
+            }
+        }
+    })
+    .await
+    .expect("MatchFailed in time");
+
+    assert!(
+        matches!(failure.reason, FailureReason::Panic),
+        "expected FailureReason::Panic, got {:?}",
+        failure.reason,
+    );
+
+    // The panic-recovery path must have routed through composite's
+    // on_match_abandoned to the ReplaySink. Buffer released, no file.
+    assert!(
+        !replay.has_buffer(MatchId(0)),
+        "replay sink buffer must be released after panic",
+    );
+    assert_eq!(replay.buffer_count(), 0);
+    assert_eq!(writer.count(), 0, "no replay file should be written");
+}

--- a/eval/orchestrator/tests/pre_match_sink_error.rs
+++ b/eval/orchestrator/tests/pre_match_sink_error.rs
@@ -1,0 +1,85 @@
+//! Required-sink failure on `on_match_started` aborts before
+//! `Match::new`. Player handles are explicitly closed (subprocess /
+//! dispatcher cleanup), terminal is `MatchFailed { SinkFlushError,
+//! durable_record: false, started_at: None }`.
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::anyhow;
+use async_trait::async_trait;
+use pyrat_host::match_host::MatchEvent;
+use pyrat_host::player::PlayerIdentity;
+use pyrat_orchestrator::{
+    AdHocDescriptor, CompositeSink, DriverEvent, FailureReason, MatchFailure, MatchId,
+    MatchOutcome, MatchSink, Orchestrator, OrchestratorConfig, SinkError, SinkRole,
+};
+use tokio::time::timeout;
+
+use common::mock_vs_mock;
+
+struct StartedFailureSink;
+
+#[async_trait]
+impl MatchSink<AdHocDescriptor> for StartedFailureSink {
+    async fn on_match_started(
+        &self,
+        _: &AdHocDescriptor,
+        _: &[PlayerIdentity; 2],
+    ) -> Result<(), SinkError> {
+        Err(SinkError {
+            source: anyhow!("started boom"),
+        })
+    }
+    async fn on_match_event(&self, _: MatchId, _: &MatchEvent) -> Result<(), SinkError> {
+        Ok(())
+    }
+    async fn on_match_finished(&self, _: &MatchOutcome<AdHocDescriptor>) -> Result<(), SinkError> {
+        Ok(())
+    }
+    async fn on_match_failed(&self, _: &MatchFailure<AdHocDescriptor>) -> Result<(), SinkError> {
+        Ok(())
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn required_sink_started_error_demotes_with_started_at_none() {
+    let cfg = OrchestratorConfig {
+        max_parallel: 1,
+        ..Default::default()
+    };
+    let bad: Arc<dyn MatchSink<AdHocDescriptor>> = Arc::new(StartedFailureSink);
+    let composite: Arc<dyn MatchSink<AdHocDescriptor>> =
+        Arc::new(CompositeSink::new(vec![(SinkRole::Required, bad)]));
+    let (orch, mut driver_rx) = Orchestrator::new(cfg, composite);
+
+    orch.submit(mock_vs_mock(0)).await.expect("submit");
+
+    let failure = async {
+        loop {
+            match driver_rx.recv().await.expect("driver_rx") {
+                DriverEvent::MatchFailed { failure } => break failure,
+                DriverEvent::MatchFinished { .. } => panic!("unexpected finish"),
+                _ => {},
+            }
+        }
+    };
+    let failure = timeout(Duration::from_secs(10), failure)
+        .await
+        .expect("MatchFailed in time");
+
+    assert!(
+        matches!(failure.reason, FailureReason::SinkFlushError(_)),
+        "expected SinkFlushError, got {:?}",
+        failure.reason
+    );
+    assert!(!failure.durable_record);
+    assert!(
+        failure.started_at.is_none(),
+        "started_at must be None when sink rejected the pre-Match callback"
+    );
+    // Player identities ARE known at this stage (post-handshake).
+    assert!(failure.players.is_some());
+}

--- a/eval/orchestrator/tests/replay_sink_abandoned_on_required_error.rs
+++ b/eval/orchestrator/tests/replay_sink_abandoned_on_required_error.rs
@@ -1,0 +1,115 @@
+//! End-to-end test: an Optional `ReplaySink` paired with an erroring
+//! `Required` sink must see `on_match_abandoned` so its per-match buffer
+//! is released. Pins the leak case the composite's demotion-cleanup path
+//! prevents.
+
+mod common;
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::anyhow;
+use async_trait::async_trait;
+use pyrat_host::match_host::MatchEvent;
+use pyrat_host::player::PlayerIdentity;
+use pyrat_orchestrator::{
+    AdHocDescriptor, CompositeSink, DriverEvent, FailureReason, MatchFailure, MatchId,
+    MatchOutcome, MatchSink, MemoryWriter, Orchestrator, OrchestratorConfig, ReplaySink, SinkError,
+    SinkRole,
+};
+use tokio::time::timeout;
+
+use common::mock_vs_mock;
+
+/// Required sink that errors on the very first event. Mimics a store that
+/// lost its DB handle mid-match.
+struct EventErrorSink {
+    events_seen: AtomicU64,
+}
+
+impl EventErrorSink {
+    fn new() -> Self {
+        Self {
+            events_seen: AtomicU64::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl MatchSink<AdHocDescriptor> for EventErrorSink {
+    async fn on_match_started(
+        &self,
+        _: &AdHocDescriptor,
+        _: &[PlayerIdentity; 2],
+    ) -> Result<(), SinkError> {
+        Ok(())
+    }
+    async fn on_match_event(&self, _: MatchId, _: &MatchEvent) -> Result<(), SinkError> {
+        let n = self.events_seen.fetch_add(1, Ordering::SeqCst) + 1;
+        if n == 1 {
+            return Err(SinkError {
+                source: anyhow!("event boom"),
+            });
+        }
+        Ok(())
+    }
+    async fn on_match_finished(&self, _: &MatchOutcome<AdHocDescriptor>) -> Result<(), SinkError> {
+        Ok(())
+    }
+    async fn on_match_failed(&self, _: &MatchFailure<AdHocDescriptor>) -> Result<(), SinkError> {
+        Ok(())
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn required_event_error_releases_replay_buffer_via_abandoned() {
+    let cfg = OrchestratorConfig {
+        max_parallel: 1,
+        ..Default::default()
+    };
+
+    let writer = Arc::new(MemoryWriter::new());
+    let replay = Arc::new(ReplaySink::new(writer.clone()));
+    let replay_dyn: Arc<dyn MatchSink<AdHocDescriptor>> = replay.clone();
+    let store_dyn: Arc<dyn MatchSink<AdHocDescriptor>> = Arc::new(EventErrorSink::new());
+
+    let composite: Arc<dyn MatchSink<AdHocDescriptor>> = Arc::new(CompositeSink::new(vec![
+        (SinkRole::Required, store_dyn),
+        (SinkRole::Optional, replay_dyn),
+    ]));
+    let (orch, mut driver_rx) = Orchestrator::new(cfg, composite);
+
+    orch.submit(mock_vs_mock(0)).await.expect("submit");
+
+    let failure = async {
+        loop {
+            match driver_rx.recv().await.expect("driver_rx") {
+                DriverEvent::MatchFailed { failure } => break failure,
+                DriverEvent::MatchFinished { .. } => {
+                    panic!("expected sink-flush failure, got finish")
+                },
+                _ => {},
+            }
+        }
+    };
+    let failure = timeout(Duration::from_secs(10), failure)
+        .await
+        .expect("MatchFailed in time");
+
+    assert!(
+        matches!(failure.reason, FailureReason::SinkFlushError(_)),
+        "expected SinkFlushError, got {:?}",
+        failure.reason
+    );
+
+    // Replay sink received `on_match_abandoned` → its per-match HashMap
+    // should be empty for this match (and overall), and no replay file
+    // was written.
+    assert!(
+        !replay.has_buffer(MatchId(0)),
+        "replay sink should have released the buffer for the failed match"
+    );
+    assert_eq!(replay.buffer_count(), 0);
+    assert_eq!(writer.count(), 0, "no replay file should be written");
+}

--- a/eval/orchestrator/tests/setup_failure_durable.rs
+++ b/eval/orchestrator/tests/setup_failure_durable.rs
@@ -1,0 +1,119 @@
+//! Setup failures must call `sink.on_match_failed` with
+//! `durable_record: true`. Pins fix #1 and the contract at
+//! `plan.md:160` (schema NULL-`started_at` for spawn-failures) and
+//! `plan.md:440` (the "honest invariant" lists kill-9 / required-flush /
+//! cancellation / panic as the only `durable_record: false` cases).
+//!
+//! Trigger: a `Subprocess` slot pointing at a nonexistent `working_dir`.
+//! `launch_bots` calls `Command::current_dir(...).spawn()`, which fails
+//! at spawn time when the directory is missing — the deterministic path
+//! to `SetupError::Launch -> FailureReason::SpawnFailed`. (A
+//! "nonexistent binary" command would launch successfully via `sh -c`
+//! and surface as `HandshakeTimeout` instead.)
+//!
+//! Scope: this is the *single* subprocess test in this crate; it
+//! exercises the launch setup-failure path. TCP accept/handshake and
+//! mid-match disconnect coverage stay in `pyrat-host`'s integration
+//! tests per the existing scope choice.
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use pyrat_orchestrator::{
+    AdHocDescriptor, CompositeSink, DriverEvent, FailureReason, MatchSink, Orchestrator,
+    OrchestratorConfig, SinkRole,
+};
+use tokio::time::timeout;
+
+use common::{subprocess_matchup_with_bad_workdir, RecordedCall, RecordingSink};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn subprocess_spawn_failure_calls_on_match_failed_durably() {
+    let cfg = OrchestratorConfig {
+        max_parallel: 1,
+        ..Default::default()
+    };
+    let recorder = Arc::new(RecordingSink::new());
+    let recorder_dyn: Arc<dyn MatchSink<AdHocDescriptor>> = recorder.clone();
+    let composite: Arc<dyn MatchSink<AdHocDescriptor>> =
+        Arc::new(CompositeSink::new(vec![(SinkRole::Required, recorder_dyn)]));
+    let (orch, mut driver_rx) = Orchestrator::new(cfg, composite);
+
+    orch.submit(subprocess_matchup_with_bad_workdir(0))
+        .await
+        .expect("submit");
+
+    let failure = timeout(Duration::from_secs(10), async {
+        loop {
+            match driver_rx.recv().await.expect("driver_rx") {
+                DriverEvent::MatchFailed { failure } => break failure,
+                DriverEvent::MatchFinished { .. } => panic!("unexpected finish"),
+                _ => {},
+            }
+        }
+    })
+    .await
+    .expect("MatchFailed in time");
+
+    assert!(
+        matches!(failure.reason, FailureReason::SpawnFailed),
+        "expected SpawnFailed, got {:?}",
+        failure.reason,
+    );
+    assert!(
+        failure.durable_record,
+        "setup failures must be durable per plan.md:440 honest invariant",
+    );
+    assert!(
+        failure.started_at.is_none(),
+        "spawn failure never started — started_at must be None",
+    );
+
+    // Sink saw exactly one on_match_failed call, and it carried the
+    // durable flag. No on_match_started precedes it (setup failed before
+    // we'd have called it). No on_match_finished.
+    let calls = recorder.snapshot();
+    let started_count = calls
+        .iter()
+        .filter(|c| matches!(c, RecordedCall::Started { .. }))
+        .count();
+    let finished_count = calls
+        .iter()
+        .filter(|c| matches!(c, RecordedCall::Finished { .. }))
+        .count();
+    let failed_calls: Vec<_> = calls
+        .iter()
+        .filter(|c| matches!(c, RecordedCall::Failed { .. }))
+        .collect();
+
+    assert_eq!(
+        started_count, 0,
+        "on_match_started must not fire for a setup failure",
+    );
+    assert_eq!(
+        finished_count, 0,
+        "on_match_finished must not fire for a setup failure",
+    );
+    assert_eq!(
+        failed_calls.len(),
+        1,
+        "expected exactly one on_match_failed call, got {failed_calls:?}",
+    );
+    if let RecordedCall::Failed {
+        durable_record,
+        reason_debug,
+        ..
+    } = failed_calls[0]
+    {
+        assert!(
+            *durable_record,
+            "on_match_failed durable_record must be true for setup failures",
+        );
+        assert!(
+            reason_debug.contains("SpawnFailed"),
+            "expected reason debug to contain SpawnFailed, got {reason_debug}",
+        );
+    }
+}

--- a/eval/orchestrator/tests/shutdown_awaits_drain.rs
+++ b/eval/orchestrator/tests/shutdown_awaits_drain.rs
@@ -1,0 +1,89 @@
+//! `Orchestrator::shutdown(self)` actually awaits the run-loop drain
+//! instead of aborting the task. Pins fix #3: the previous
+//! `AbortOnDropHandle` shape would let `shutdown()` resolve before the
+//! per-match task published its terminal `MatchFailed { Cancelled }`.
+//!
+//! Drain `driver_rx` concurrently from a background task — `shutdown`
+//! waits on the run-loop, the run-loop waits on per-match tasks to
+//! drain, and per-match tasks publish their terminal through
+//! `publish_lifecycle` which awaits `driver_tx.send`. Without a draining
+//! consumer the bounded mpsc backpressure-stalls the terminal publish
+//! and the test deadlocks.
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use pyrat_orchestrator::{
+    AdHocDescriptor, DriverEvent, FailureReason, NoOpSink, Orchestrator, OrchestratorConfig,
+};
+use tokio::time::timeout;
+
+use common::{embedded_matchup, mock_factory, slow_factory};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn shutdown_awaits_per_match_terminal_publication() {
+    let cfg = OrchestratorConfig {
+        max_parallel: 1,
+        ..Default::default()
+    };
+    let sink: Arc<NoOpSink<AdHocDescriptor>> = Arc::new(NoOpSink::new());
+    let (orch, mut driver_rx) = Orchestrator::new(cfg, sink);
+
+    orch.submit(embedded_matchup(0, mock_factory(), slow_factory()))
+        .await
+        .expect("submit");
+
+    // Background drain so `publish_lifecycle` from the per-match task
+    // doesn't block on a full `driver_tx.send`. Returns the collected
+    // events when the channel closes (run-loop drops `driver_tx` via
+    // dropping `inner` once the orchestrator drops, which can only
+    // happen after `shutdown` resolves).
+    let drain = tokio::spawn(async move {
+        let mut events = Vec::new();
+        while let Some(ev) = driver_rx.recv().await {
+            events.push(ev);
+        }
+        events
+    });
+
+    // Wait for the match to be in the playing phase before triggering
+    // shutdown — gives the per-match task something to actually cancel.
+    // Done by polling state until `running` is non-empty (or a brief
+    // timeout). Imperfect but sufficient: even if shutdown fires before
+    // playing starts, the test still pins the post-shutdown invariants.
+    let _ = timeout(Duration::from_secs(3), async {
+        let mut state_rx = orch.state();
+        loop {
+            if !state_rx.borrow().running.is_empty() {
+                return;
+            }
+            if state_rx.changed().await.is_err() {
+                return;
+            }
+        }
+    })
+    .await;
+
+    timeout(Duration::from_secs(10), orch.shutdown())
+        .await
+        .expect("shutdown completes within 10s");
+
+    let events = timeout(Duration::from_secs(5), drain)
+        .await
+        .expect("drain completes")
+        .expect("drain task");
+
+    let saw_cancelled_terminal = events.iter().any(|ev| {
+        matches!(
+            ev,
+            DriverEvent::MatchFailed { failure }
+                if matches!(failure.reason, FailureReason::Cancelled)
+        )
+    });
+    assert!(
+        saw_cancelled_terminal,
+        "expected MatchFailed {{ Cancelled }} in drained events; got {events:?}",
+    );
+}

--- a/eval/orchestrator/tests/sink_event_error.rs
+++ b/eval/orchestrator/tests/sink_event_error.rs
@@ -1,0 +1,128 @@
+//! Required-sink failure during `on_match_event` demotes to
+//! `MatchFailed { SinkFlushError, durable_record: false }`. The engine
+//! loop drains cleanly; broadcast forwarding stops; the failed sink is
+//! not called again.
+
+mod common;
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::anyhow;
+use async_trait::async_trait;
+use pyrat_host::match_host::MatchEvent;
+use pyrat_host::player::PlayerIdentity;
+use pyrat_orchestrator::{
+    AdHocDescriptor, CompositeSink, DriverEvent, FailureReason, MatchFailure, MatchId,
+    MatchOutcome, MatchSink, Orchestrator, OrchestratorConfig, SinkError, SinkRole,
+};
+use tokio::time::timeout;
+
+use common::mock_vs_mock;
+
+/// Sink that errors on `on_match_event` after the Nth call. Counts every
+/// callback so the test can assert the failed sink isn't re-invoked.
+struct ErrorAfterNthEvent {
+    error_after: u64,
+    events_seen: AtomicU64,
+    finished_calls: AtomicU64,
+    failed_calls: AtomicU64,
+    abandoned_calls: AtomicU64,
+}
+
+impl ErrorAfterNthEvent {
+    fn new(error_after: u64) -> Self {
+        Self {
+            error_after,
+            events_seen: AtomicU64::new(0),
+            finished_calls: AtomicU64::new(0),
+            failed_calls: AtomicU64::new(0),
+            abandoned_calls: AtomicU64::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl MatchSink<AdHocDescriptor> for ErrorAfterNthEvent {
+    async fn on_match_started(
+        &self,
+        _: &AdHocDescriptor,
+        _: &[PlayerIdentity; 2],
+    ) -> Result<(), SinkError> {
+        Ok(())
+    }
+    async fn on_match_event(&self, _: MatchId, _: &MatchEvent) -> Result<(), SinkError> {
+        let n = self.events_seen.fetch_add(1, Ordering::SeqCst) + 1;
+        if n >= self.error_after {
+            return Err(SinkError {
+                source: anyhow!("event boom (n={n})"),
+            });
+        }
+        Ok(())
+    }
+    async fn on_match_finished(&self, _: &MatchOutcome<AdHocDescriptor>) -> Result<(), SinkError> {
+        self.finished_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+    async fn on_match_failed(&self, _: &MatchFailure<AdHocDescriptor>) -> Result<(), SinkError> {
+        self.failed_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+    async fn on_match_abandoned(&self, _: MatchId) -> Result<(), SinkError> {
+        self.abandoned_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn required_sink_event_error_demotes_to_sink_flush_error() {
+    let cfg = OrchestratorConfig {
+        max_parallel: 1,
+        ..Default::default()
+    };
+    let bad = Arc::new(ErrorAfterNthEvent::new(1)); // error on the very first event
+    let bad_arc: Arc<dyn MatchSink<AdHocDescriptor>> = bad.clone();
+    let composite: Arc<CompositeSink<AdHocDescriptor>> =
+        Arc::new(CompositeSink::new(vec![(SinkRole::Required, bad_arc)]));
+    let sink: Arc<dyn MatchSink<AdHocDescriptor>> = composite;
+    let (orch, mut driver_rx) = Orchestrator::new(cfg, sink);
+
+    orch.submit(mock_vs_mock(0)).await.expect("submit");
+
+    let failure = async {
+        loop {
+            match driver_rx.recv().await.expect("driver_rx") {
+                DriverEvent::MatchFailed { failure } => break failure,
+                DriverEvent::MatchFinished { .. } => {
+                    panic!("expected failure, got MatchFinished")
+                },
+                _ => {},
+            }
+        }
+    };
+    let failure = timeout(Duration::from_secs(10), failure)
+        .await
+        .expect("MatchFailed in time");
+
+    assert!(
+        matches!(failure.reason, FailureReason::SinkFlushError(_)),
+        "expected SinkFlushError, got {:?}",
+        failure.reason
+    );
+    assert!(!failure.durable_record, "broken-sink path = no durable row");
+
+    // The failed sink must NOT have been called again on a terminal
+    // (composite skipped subsequent terminals; demotion happened inside
+    // `on_match_event`).
+    assert_eq!(
+        bad.finished_calls.load(Ordering::SeqCst),
+        0,
+        "broken sink was called for on_match_finished"
+    );
+    assert_eq!(
+        bad.failed_calls.load(Ordering::SeqCst),
+        0,
+        "broken sink was called for on_match_failed"
+    );
+}

--- a/eval/orchestrator/tests/sink_flush_error.rs
+++ b/eval/orchestrator/tests/sink_flush_error.rs
@@ -1,0 +1,100 @@
+//! Required-sink failure on `on_match_finished` demotes to
+//! `MatchFailed { SinkFlushError, durable_record: false }` instead of a
+//! clean `MatchFinished`.
+
+mod common;
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::anyhow;
+use async_trait::async_trait;
+use pyrat_host::match_host::MatchEvent;
+use pyrat_host::player::PlayerIdentity;
+use pyrat_orchestrator::{
+    AdHocDescriptor, CompositeSink, DriverEvent, FailureReason, MatchFailure, MatchId,
+    MatchOutcome, MatchSink, Orchestrator, OrchestratorConfig, SinkError, SinkRole,
+};
+use tokio::time::timeout;
+
+use common::mock_vs_mock;
+
+struct FlushErrorSink {
+    finished_calls: AtomicU64,
+}
+
+impl FlushErrorSink {
+    fn new() -> Self {
+        Self {
+            finished_calls: AtomicU64::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl MatchSink<AdHocDescriptor> for FlushErrorSink {
+    async fn on_match_started(
+        &self,
+        _: &AdHocDescriptor,
+        _: &[PlayerIdentity; 2],
+    ) -> Result<(), SinkError> {
+        Ok(())
+    }
+    async fn on_match_event(&self, _: MatchId, _: &MatchEvent) -> Result<(), SinkError> {
+        Ok(())
+    }
+    async fn on_match_finished(&self, _: &MatchOutcome<AdHocDescriptor>) -> Result<(), SinkError> {
+        self.finished_calls.fetch_add(1, Ordering::SeqCst);
+        Err(SinkError {
+            source: anyhow!("flush boom"),
+        })
+    }
+    async fn on_match_failed(&self, _: &MatchFailure<AdHocDescriptor>) -> Result<(), SinkError> {
+        Ok(())
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn required_sink_finished_error_demotes_to_sink_flush_error() {
+    let cfg = OrchestratorConfig {
+        max_parallel: 1,
+        ..Default::default()
+    };
+    let sink_inner = Arc::new(FlushErrorSink::new());
+    let composite_child: Arc<dyn MatchSink<AdHocDescriptor>> = sink_inner.clone();
+    let composite: Arc<dyn MatchSink<AdHocDescriptor>> = Arc::new(CompositeSink::new(vec![(
+        SinkRole::Required,
+        composite_child,
+    )]));
+    let (orch, mut driver_rx) = Orchestrator::new(cfg, composite);
+
+    orch.submit(mock_vs_mock(0)).await.expect("submit");
+
+    let failure = async {
+        loop {
+            match driver_rx.recv().await.expect("driver_rx") {
+                DriverEvent::MatchFailed { failure } => break failure,
+                DriverEvent::MatchFinished { .. } => {
+                    panic!("expected failure due to sink flush error")
+                },
+                _ => {},
+            }
+        }
+    };
+    let failure = timeout(Duration::from_secs(10), failure)
+        .await
+        .expect("MatchFailed in time");
+
+    assert!(
+        matches!(failure.reason, FailureReason::SinkFlushError(_)),
+        "expected SinkFlushError, got {:?}",
+        failure.reason
+    );
+    assert!(!failure.durable_record);
+    assert_eq!(
+        sink_inner.finished_calls.load(Ordering::SeqCst),
+        1,
+        "sink.on_match_finished should have been called exactly once"
+    );
+}


### PR DESCRIPTION
## Motivation

PR 2 landed the orchestrator skeleton: traits, descriptors, the public surface that `pyrat-eval` will plug into. No execution. This ships the live half: a concurrent executor that drives `Matchup<D>`s through `pyrat-host::Match::run`, a sink seam where stores claim durable rows and replay sinks write forensic JSON, and the lifecycle invariants every downstream consumer depends on.

The honest invariant from `plan.md:440` is the load-bearing idea: a match either has a durable record of its outcome, or it doesn't. Everything in this PR exists to keep that bit honest as failures cascade.

## Solution

### Two channels, two semantics

The orchestrator publishes lifecycle events (queued, started, finished, failed) over a bounded `mpsc::Sender<DriverEvent<D>>` and per-turn detail (host `MatchEvent`s) over a `broadcast`. The driver gets the lossless feed; live UIs subscribe to the lossy one and tolerate `Lagged`. State changes are serialized through a `parking_lot::Mutex` taken only across the synchronous publish step (state update + broadcast send), never across an `.await`.

```rust
let (orch, driver_rx) = Orchestrator::new(config, sink);
orch.submit(matchup).await?;
// Driver consumes lifecycle exclusively.
while let Some(ev) = driver_rx.recv().await { ... }
// Live UI subscribes separately, atomically with a state snapshot.
let (state, mut events) = orch.subscribe();
```

### Role-aware sinks

`MatchSink` callbacks fire as `on_match_started -> on_match_event* -> (on_match_finished | on_match_failed)`. `CompositeSink` partitions children at construction: every Required runs before any Optional, so an Optional replay sink can't write side-effects for a match the Required store later rejects. Required failures demote the terminal to `MatchFailed { reason: SinkFlushError, durable_record: false }`. Optional failures log at `warn` and bump a counter, outcome unchanged.

A separate `on_match_abandoned(match_id)` hook releases per-match state when terminal callbacks were skipped. Conflating cleanup with `on_match_failed` would force a synthesized failure that lies about which sink actually broke. Separate hook keeps the cause honest.

### Replay sink

Optional sink that buffers events per match (keyed by `MatchId` so concurrent matches don't interleave) and flushes one JSON file per clean terminal. The `ReplayEvent` DTO is a one-way mirror of `MatchEvent` flat enough for `serde_json` to handle: flatbuffers-generated wire types become primitives, `Direction` becomes `u8`, etc. `MatchEvent` is `#[non_exhaustive]`, so unknown variants fall through to a `ReplayEvent::Unknown` catch-all.

### Lifecycle invariants

Five lifecycle edges closed in the second commit on this branch.

**Durable setup failures.** Spawn / handshake / accept / engine-state-build failures emit `MatchFailed { durable_record: true, started_at: None }` and call `sink.on_match_failed`. Matches the schema at `plan.md:160` (`-- NULL for spawn-failures`). Only `Cancelled` and `Panic` keep `durable_record: false` for pre-MatchStarted failures, since those are lost or non-recordable per the honest invariant.

**Driver drop is fatal.** When the driver's `mpsc::Receiver<DriverEvent>` is dropped, `publish_lifecycle` cancels the root token instead of returning `Err` and being swallowed by every per-match call site. The run-loop sees `cancelled()`, drains, exits. Subsequent `submit()` calls return `ShutDown`.

**Shutdown awaits drain.** `Orchestrator::shutdown(self)` holds an owned `JoinHandle<()>` and `.await`s it instead of dropping an `AbortOnDropHandle` (which aborts immediately). Per-match terminals fire normally en route. Callers must keep `driver_rx` polled during shutdown so terminal publishes don't backpressure-stall.

**Panic recovery.** The run-loop tracks `in_flight: HashMap<task::Id, D>` and uses `join_next_with_id`. Panicked or force-aborted tasks route through a `handle_joined` helper that synthesizes `MatchFailed { Panic | Cancelled, durable_record: false }` and calls `sink.on_match_abandoned` so stateful sinks release per-match buffers. The post-`abort_all` straggler-drain after the 10s timeout uses the same helper.

**Composite abandoned routing.** `CompositeSink::on_match_abandoned` dispatches to recorded children. Without it, the panic-recovery cleanup hits the trait default no-op when the top-level sink is the typical Composite, and replay buffers leak. Pinned by `panic_through_composite_releases_replay_buffer.rs`, which fails without the override.

### What stays out

The "close the broadcast on driver drop" wording in `plan.md:129` is aspirational. `broadcast::Sender` lives on `inner` and only closes when the orchestrator drops. Cancelling matches stops further emission, which is the practical equivalent. Documented in the executor module doc; if a consumer ever needs deterministic broadcast closure, that's a follow-up.

## Test Plan

```
cargo test -p pyrat-orchestrator                                              # 23 lib + 14 integration
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings -A non-local-definitions
```

Integration tests covering the lifecycle edges:

- `driver_drop_cancels.rs`, `shutdown_awaits_drain.rs`, `setup_failure_durable.rs`, `join_error_mapping.rs`, `panic_through_composite_releases_replay_buffer.rs`
- Plus: `cancel_midmatch.rs`, `embedded_identity.rs`, `executor_basics.rs`, `match_over_suppression.rs`, `outcome_from_result.rs`, `pre_match_sink_error.rs`, `replay_sink_abandoned_on_required_error.rs`, `sink_event_error.rs`, `sink_flush_error.rs`

`setup_failure_durable.rs` is the single subprocess test in this crate, exercising the launch setup-failure path via a nonexistent `working_dir`. Mid-match disconnect and TCP accept/handshake coverage stay in `pyrat-host`'s integration tests.