### PR TITLE
Add tournament tables and typed API to pyrat-eval-store

### DIFF
--- a/eval/store/src/lib.rs
+++ b/eval/store/src/lib.rs
@@ -10,7 +10,7 @@ pub use elo::{
 pub use store::{head_to_head_from_attempts, head_to_head_from_results, EvalStore};
 pub use types::{
     AddTournamentPlayerError, AttemptKey, AttemptRecord, AttemptStatus, DeletePlayerError,
-    EvalError, GameConfigRecord, GameResultRecord, NewAttempt, NewGameResult, NewPlayer,
-    NewTournament, PlayerRecord, RecordAttemptError, RegisterPlayerError, ResultFilter,
+    EvalError, GameConfigRecord, GameResultRecord, NewAttempt, NewAttemptOutcome, NewGameResult,
+    NewPlayer, NewTournament, PlayerRecord, RecordAttemptError, RegisterPlayerError, ResultFilter,
     TournamentId, TournamentParticipant, TournamentRecord,
 };

--- a/eval/store/src/lib.rs
+++ b/eval/store/src/lib.rs
@@ -9,8 +9,8 @@ pub use elo::{
 };
 pub use store::{head_to_head_from_attempts, head_to_head_from_results, EvalStore};
 pub use types::{
-    AddTournamentPlayerError, AttemptKey, AttemptRecord, AttemptStatus, DeletePlayerError,
-    EvalError, GameConfigRecord, GameResultRecord, NewAttempt, NewAttemptOutcome, NewGameResult,
-    NewPlayer, NewTournament, PlayerRecord, RecordAttemptError, RegisterPlayerError, ResultFilter,
-    TournamentId, TournamentParticipant, TournamentRecord,
+    AddTournamentPlayerError, AttemptKey, AttemptOutcome, AttemptRecord, AttemptStatus,
+    DeletePlayerError, EvalError, GameConfigRecord, GameResultRecord, NewAttempt,
+    NewAttemptOutcome, NewGameResult, NewPlayer, NewTournament, PlayerRecord, RecordAttemptError,
+    RegisterPlayerError, ResultFilter, TournamentId, TournamentParticipant, TournamentRecord,
 };

--- a/eval/store/src/lib.rs
+++ b/eval/store/src/lib.rs
@@ -7,7 +7,7 @@ pub use elo::{
     compute_elo, compute_elo_with_uncertainty, elo_from_winrate, win_expectancy, EloError,
     EloOptions, EloRating, EloResult, EloUncertainty, HeadToHead,
 };
-pub use store::{head_to_head_from_attempts, head_to_head_from_results, EvalStore};
+pub use store::{head_to_head_from_attempt_records, head_to_head_from_results, EvalStore};
 pub use types::{
     AddTournamentPlayerError, AttemptKey, AttemptOutcome, AttemptRecord, AttemptStatus,
     DeletePlayerError, EvalError, GameConfigRecord, GameResultRecord, NewAttempt,

--- a/eval/store/src/lib.rs
+++ b/eval/store/src/lib.rs
@@ -7,7 +7,10 @@ pub use elo::{
     compute_elo, compute_elo_with_uncertainty, elo_from_winrate, win_expectancy, EloError,
     EloOptions, EloRating, EloResult, EloUncertainty, HeadToHead,
 };
-pub use store::{head_to_head_from_results, EvalStore};
+pub use store::{head_to_head_from_attempts, head_to_head_from_results, EvalStore};
 pub use types::{
-    EvalError, GameConfigRecord, GameResultRecord, NewGameResult, PlayerRecord, ResultFilter,
+    AddTournamentPlayerError, AttemptKey, AttemptRecord, AttemptStatus, DeletePlayerError,
+    EvalError, GameConfigRecord, GameResultRecord, NewAttempt, NewGameResult, NewPlayer,
+    NewTournament, PlayerRecord, RecordAttemptError, RegisterPlayerError, ResultFilter,
+    TournamentId, TournamentParticipant, TournamentRecord,
 };

--- a/eval/store/src/schema.rs
+++ b/eval/store/src/schema.rs
@@ -73,7 +73,7 @@ CREATE TABLE match_attempts (
     turns            INTEGER,
     failure_reason   TEXT,
     started_at       TEXT,
-    finished_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    finished_at      TEXT NOT NULL,
     UNIQUE (tournament_id, game_config_id, player1_id, player2_id, repetition_index, attempt_index),
     CHECK (status IN ('success', 'failure')),
     CHECK (

--- a/eval/store/src/schema.rs
+++ b/eval/store/src/schema.rs
@@ -2,7 +2,7 @@ use rusqlite::Connection;
 
 use crate::EvalError;
 
-const DDL: &str = "
+const MIGRATION_1: &str = "
 CREATE TABLE IF NOT EXISTS game_configs (
     id          TEXT PRIMARY KEY,
     config_json TEXT NOT NULL,
@@ -36,8 +36,78 @@ CREATE INDEX IF NOT EXISTS idx_results_config  ON game_results(game_config_id);
 CREATE INDEX IF NOT EXISTS idx_results_played  ON game_results(played_at);
 ";
 
-pub fn initialize(conn: &Connection) -> Result<(), EvalError> {
+const MIGRATION_2: &str = "
+ALTER TABLE players ADD COLUMN agent_id      TEXT;
+ALTER TABLE players ADD COLUMN version       TEXT;
+ALTER TABLE players ADD COLUMN command       TEXT;
+ALTER TABLE players ADD COLUMN metadata_json TEXT;
+
+CREATE TABLE tournaments (
+    id                       INTEGER PRIMARY KEY AUTOINCREMENT,
+    format                   TEXT    NOT NULL,
+    target_games_per_matchup INTEGER,
+    params_json              TEXT    NOT NULL,
+    created_at               TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE tournament_players (
+    tournament_id INTEGER NOT NULL REFERENCES tournaments(id) ON DELETE CASCADE,
+    player_id     TEXT    NOT NULL REFERENCES players(id) ON DELETE RESTRICT,
+    slot          INTEGER NOT NULL,
+    PRIMARY KEY (tournament_id, player_id),
+    UNIQUE (tournament_id, slot)
+);
+
+CREATE TABLE match_attempts (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    tournament_id    INTEGER NOT NULL REFERENCES tournaments(id) ON DELETE CASCADE,
+    game_config_id   TEXT    NOT NULL REFERENCES game_configs(id),
+    player1_id       TEXT    NOT NULL REFERENCES players(id) ON DELETE RESTRICT,
+    player2_id       TEXT    NOT NULL REFERENCES players(id) ON DELETE RESTRICT,
+    seed             INTEGER NOT NULL,
+    repetition_index INTEGER NOT NULL DEFAULT 0,
+    attempt_index    INTEGER NOT NULL,
+    status           TEXT    NOT NULL,
+    player1_score    REAL,
+    player2_score    REAL,
+    turns            INTEGER,
+    failure_reason   TEXT,
+    started_at       TEXT,
+    finished_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (tournament_id, game_config_id, player1_id, player2_id, repetition_index, attempt_index),
+    CHECK (status IN ('success', 'failure')),
+    CHECK (
+        (status = 'success' AND player1_score IS NOT NULL
+                            AND player2_score IS NOT NULL
+                            AND turns          IS NOT NULL
+                            AND failure_reason IS NULL
+                            AND started_at     IS NOT NULL)
+     OR (status = 'failure' AND failure_reason IS NOT NULL
+                            AND player1_score  IS NULL
+                            AND player2_score  IS NULL
+                            AND turns          IS NULL)
+    )
+);
+
+CREATE INDEX idx_attempts_tournament ON match_attempts(tournament_id);
+CREATE INDEX idx_attempts_matchup    ON match_attempts(tournament_id, player1_id, player2_id);
+";
+
+const MIGRATIONS: &[(u32, &str)] = &[(1, MIGRATION_1), (2, MIGRATION_2)];
+
+pub fn initialize(conn: &mut Connection) -> Result<(), EvalError> {
+    // PRAGMAs are per-connection. `foreign_keys` cannot be set inside a
+    // transaction, so apply both before the migration loop opens any.
     conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
-    conn.execute_batch(DDL)?;
+
+    let current: u32 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+    for &(version, sql) in MIGRATIONS {
+        if version > current {
+            let tx = conn.transaction()?;
+            tx.execute_batch(sql)?;
+            tx.execute_batch(&format!("PRAGMA user_version = {version}"))?;
+            tx.commit()?;
+        }
+    }
     Ok(())
 }

--- a/eval/store/src/store.rs
+++ b/eval/store/src/store.rs
@@ -7,9 +7,9 @@ use crate::elo::HeadToHead;
 use crate::schema;
 use crate::types::{
     AddTournamentPlayerError, AttemptRecord, AttemptStatus, DeletePlayerError, EvalError,
-    GameConfigRecord, GameResultRecord, NewAttempt, NewGameResult, NewPlayer, NewTournament,
-    PlayerRecord, RecordAttemptError, RegisterPlayerError, ResultFilter, TournamentId,
-    TournamentParticipant, TournamentRecord,
+    GameConfigRecord, GameResultRecord, NewAttempt, NewAttemptOutcome, NewGameResult, NewPlayer,
+    NewTournament, PlayerRecord, RecordAttemptError, RegisterPlayerError, ResultFilter,
+    TournamentId, TournamentParticipant, TournamentRecord,
 };
 
 /// SQLite-backed store for game results, players, tournaments, and match
@@ -384,18 +384,21 @@ impl EvalStore {
     /// in depth. Validates that `seed` fits in `i64` (SQLite INTEGER is
     /// signed) before binding.
     pub fn record_attempt(&self, attempt: &NewAttempt) -> Result<i64, RecordAttemptError> {
-        let key = attempt.key();
+        let NewAttempt {
+            key,
+            finished_at,
+            outcome,
+        } = attempt;
         if key.seed > i64::MAX as u64 {
             return Err(RecordAttemptError::SeedOutOfRange { value: key.seed });
         }
         let seed_i64 = key.seed as i64;
-        let (status, score1, score2, turns, failure_reason, started_at) = match attempt {
-            NewAttempt::Success {
+        let (status, score1, score2, turns, failure_reason, started_at) = match outcome {
+            NewAttemptOutcome::Success {
                 player1_score,
                 player2_score,
                 turns,
                 started_at,
-                ..
             } => (
                 AttemptStatus::Success.as_str(),
                 Some(*player1_score),
@@ -404,10 +407,9 @@ impl EvalStore {
                 None,
                 Some(started_at.as_str()),
             ),
-            NewAttempt::Failure {
+            NewAttemptOutcome::Failure {
                 failure_reason,
                 started_at,
-                ..
             } => (
                 AttemptStatus::Failure.as_str(),
                 None,
@@ -422,8 +424,8 @@ impl EvalStore {
                (tournament_id, game_config_id, player1_id, player2_id, seed,
                 repetition_index, attempt_index, status,
                 player1_score, player2_score, turns,
-                failure_reason, started_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+                failure_reason, started_at, finished_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             params![
                 key.tournament_id.0,
                 key.game_config_id,
@@ -438,6 +440,7 @@ impl EvalStore {
                 turns,
                 failure_reason,
                 started_at,
+                finished_at,
             ],
         )?;
         Ok(self.conn.last_insert_rowid())
@@ -657,7 +660,7 @@ mod tests {
         s1: f64,
         s2: f64,
     ) -> NewAttempt {
-        NewAttempt::Success {
+        NewAttempt {
             key: AttemptKey {
                 tournament_id: tid,
                 game_config_id: cid.into(),
@@ -667,10 +670,13 @@ mod tests {
                 repetition_index: 0,
                 attempt_index,
             },
-            player1_score: s1,
-            player2_score: s2,
-            turns: 100,
-            started_at: "2026-05-06 10:00:00".into(),
+            finished_at: "2026-05-06 10:05:00".into(),
+            outcome: NewAttemptOutcome::Success {
+                player1_score: s1,
+                player2_score: s2,
+                turns: 100,
+                started_at: "2026-05-06 10:00:00".into(),
+            },
         }
     }
 
@@ -682,7 +688,7 @@ mod tests {
         attempt_index: u32,
         started_at: Option<&str>,
     ) -> NewAttempt {
-        NewAttempt::Failure {
+        NewAttempt {
             key: AttemptKey {
                 tournament_id: tid,
                 game_config_id: cid.into(),
@@ -692,8 +698,11 @@ mod tests {
                 repetition_index: 0,
                 attempt_index,
             },
-            failure_reason: "bot crash".into(),
-            started_at: started_at.map(String::from),
+            finished_at: "2026-05-06 10:10:00".into(),
+            outcome: NewAttemptOutcome::Failure {
+                failure_reason: "bot crash".into(),
+                started_at: started_at.map(String::from),
+            },
         }
     }
 
@@ -1106,18 +1115,14 @@ mod tests {
         let (tid, cid) = setup_tournament(&store);
         // Out of range: rejected before binding.
         let mut bad = success_attempt(tid, &cid, "alice", "bob", 0, 8.0, 2.0);
-        if let NewAttempt::Success { key, .. } = &mut bad {
-            key.seed = u64::MAX;
-        }
+        bad.key.seed = u64::MAX;
         match store.record_attempt(&bad) {
             Err(RecordAttemptError::SeedOutOfRange { value }) => assert_eq!(value, u64::MAX),
             other => panic!("expected SeedOutOfRange, got {other:?}"),
         }
         // i64::MAX round-trips exactly.
         let mut at_max = success_attempt(tid, &cid, "alice", "bob", 1, 5.0, 5.0);
-        if let NewAttempt::Success { key, .. } = &mut at_max {
-            key.seed = i64::MAX as u64;
-        }
+        at_max.key.seed = i64::MAX as u64;
         store.record_attempt(&at_max).unwrap();
         let attempts = store.get_attempts(tid, None).unwrap();
         assert_eq!(attempts.len(), 1);
@@ -1133,9 +1138,11 @@ mod tests {
             "INSERT INTO match_attempts
               (tournament_id, game_config_id, player1_id, player2_id, seed,
                repetition_index, attempt_index, status,
-               player1_score, player2_score, turns, failure_reason, started_at)
+               player1_score, player2_score, turns, failure_reason, started_at,
+               finished_at)
              VALUES (?1, ?2, 'alice', 'bob', 1, 0, 0, 'success',
-                     NULL, 5.0, 100, NULL, '2026-01-01 00:00:00')",
+                     NULL, 5.0, 100, NULL, '2026-01-01 00:00:00',
+                     '2026-01-01 00:05:00')",
             params![tid.0, cid],
         );
         assert!(
@@ -1147,9 +1154,11 @@ mod tests {
             "INSERT INTO match_attempts
               (tournament_id, game_config_id, player1_id, player2_id, seed,
                repetition_index, attempt_index, status,
-               player1_score, player2_score, turns, failure_reason, started_at)
+               player1_score, player2_score, turns, failure_reason, started_at,
+               finished_at)
              VALUES (?1, ?2, 'alice', 'bob', 1, 0, 1, 'success',
-                     5.0, 5.0, 100, NULL, NULL)",
+                     5.0, 5.0, 100, NULL, NULL,
+                     '2026-01-01 00:05:00')",
             params![tid.0, cid],
         );
         assert!(
@@ -1166,9 +1175,11 @@ mod tests {
             "INSERT INTO match_attempts
               (tournament_id, game_config_id, player1_id, player2_id, seed,
                repetition_index, attempt_index, status,
-               player1_score, player2_score, turns, failure_reason, started_at)
+               player1_score, player2_score, turns, failure_reason, started_at,
+               finished_at)
              VALUES (?1, ?2, 'alice', 'bob', 1, 0, 0, 'failure',
-                     5.0, NULL, NULL, 'crash', NULL)",
+                     5.0, NULL, NULL, 'crash', NULL,
+                     '2026-01-01 00:05:00')",
             params![tid.0, cid],
         );
         assert!(res.is_err(), "failure row with score must fail CHECK");
@@ -1177,9 +1188,11 @@ mod tests {
             "INSERT INTO match_attempts
               (tournament_id, game_config_id, player1_id, player2_id, seed,
                repetition_index, attempt_index, status,
-               player1_score, player2_score, turns, failure_reason, started_at)
+               player1_score, player2_score, turns, failure_reason, started_at,
+               finished_at)
              VALUES (?1, ?2, 'alice', 'bob', 1, 0, 1, 'failure',
-                     NULL, NULL, NULL, NULL, NULL)",
+                     NULL, NULL, NULL, NULL, NULL,
+                     '2026-01-01 00:05:00')",
             params![tid.0, cid],
         );
         assert!(

--- a/eval/store/src/store.rs
+++ b/eval/store/src/store.rs
@@ -473,6 +473,17 @@ impl EvalStore {
         };
         Ok(rows)
     }
+
+    /// Load this tournament's success attempts and aggregate into pairwise
+    /// head-to-head records. The standard Elo input for a tournament; a
+    /// thin wrapper over [`get_attempts`] + [`head_to_head_from_attempt_records`].
+    pub fn head_to_head_from_attempts(
+        &self,
+        tournament_id: TournamentId,
+    ) -> Result<Vec<HeadToHead>, EvalError> {
+        let attempts = self.get_attempts(tournament_id, Some(AttemptStatus::Success))?;
+        Ok(head_to_head_from_attempt_records(&attempts))
+    }
 }
 
 fn read_player_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<PlayerRecord> {
@@ -572,9 +583,13 @@ pub fn head_to_head_from_results(results: &[GameResultRecord]) -> Vec<HeadToHead
 }
 
 /// Same shape as [`head_to_head_from_results`], but over tournament attempt
-/// rows. Failure rows are skipped — Elo is computed from successful matches
-/// only. Variant-dispatch on `outcome` makes the success-only access total.
-pub fn head_to_head_from_attempts(attempts: &[AttemptRecord]) -> Vec<HeadToHead> {
+/// rows already loaded into memory. Failure rows are skipped — Elo is computed
+/// from successful matches only. Variant-dispatch on `outcome` makes the
+/// success-only access total.
+///
+/// For "load and aggregate from the store" in one call, see
+/// [`EvalStore::head_to_head_from_attempts`].
+pub fn head_to_head_from_attempt_records(attempts: &[AttemptRecord]) -> Vec<HeadToHead> {
     aggregate_pairs(attempts.iter().filter_map(|a| match &a.outcome {
         AttemptOutcome::Success {
             player1_score,
@@ -1260,11 +1275,16 @@ mod tests {
             .record_attempt(&failure_attempt(tid, &cid, "alice", "bob", 1, None))
             .unwrap();
 
+        // Free-fn path: caller already holds the records.
         let attempts = store.get_attempts(tid, None).unwrap();
-        let h = head_to_head_from_attempts(&attempts);
+        let h = head_to_head_from_attempt_records(&attempts);
         assert_eq!(h.len(), 1);
         // alice (player_a) won the only success; failure ignored.
         assert_eq!(h[0].wins_a + h[0].wins_b + h[0].draws, 1);
+
+        // Store-method path: same result, one call.
+        let h2 = store.head_to_head_from_attempts(tid).unwrap();
+        assert_eq!(h2, h);
     }
 
     #[test]

--- a/eval/store/src/store.rs
+++ b/eval/store/src/store.rs
@@ -1,21 +1,31 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OptionalExtension};
 
 use crate::elo::HeadToHead;
 use crate::schema;
 use crate::types::{
-    EvalError, GameConfigRecord, GameResultRecord, NewGameResult, PlayerRecord, ResultFilter,
+    AddTournamentPlayerError, AttemptRecord, AttemptStatus, DeletePlayerError, EvalError,
+    GameConfigRecord, GameResultRecord, NewAttempt, NewGameResult, NewPlayer, NewTournament,
+    PlayerRecord, RecordAttemptError, RegisterPlayerError, ResultFilter, TournamentId,
+    TournamentParticipant, TournamentRecord,
 };
 
+/// SQLite-backed store for game results, players, tournaments, and match
+/// attempts.
+///
+/// Holds a single `rusqlite::Connection`. `Connection: !Sync` is enforced by
+/// the compiler, so `Arc<EvalStore>` shared across threads will not compile.
+/// Concurrent consumers (e.g. the orchestrator running matches in parallel)
+/// must wrap in `Arc<Mutex<_>>` or open a fresh connection per thread.
 pub struct EvalStore {
     conn: Connection,
 }
 
 impl EvalStore {
-    fn from_connection(conn: Connection) -> Result<Self, EvalError> {
-        schema::initialize(&conn)?;
+    fn from_connection(mut conn: Connection) -> Result<Self, EvalError> {
+        schema::initialize(&mut conn)?;
         Ok(Self { conn })
     }
 
@@ -29,12 +39,83 @@ impl EvalStore {
         Self::from_connection(Connection::open_in_memory()?)
     }
 
-    /// Insert a player if it doesn't already exist.
+    /// Insert a player if it doesn't already exist. Back-compat path; does not
+    /// populate the identity columns. Tournament use should call
+    /// [`EvalStore::register_player`] instead.
     pub fn ensure_player(&self, id: &str, display_name: &str) -> Result<(), EvalError> {
         self.conn.execute(
             "INSERT OR IGNORE INTO players (id, display_name) VALUES (?1, ?2)",
             params![id, display_name],
         )?;
+        Ok(())
+    }
+
+    /// Insert-or-error-on-conflict for tournament-context players. A player
+    /// is a specific rated *version* of a bot — silent re-pointing of an id
+    /// would retroactively rewrite tournament identity, so conflicts surface.
+    ///
+    /// Behavior:
+    /// - No row with `id`: insert with all provided fields.
+    /// - Row exists with NULL identity columns: fill them in (back-compat for
+    ///   rows created via `ensure_player`).
+    /// - Row exists with conflicting non-NULL identity column: return
+    ///   [`RegisterPlayerError::IdentityConflict`] listing the conflicting
+    ///   field names.
+    /// - Row exists with identical identity: no-op success.
+    pub fn register_player(&self, p: &NewPlayer) -> Result<(), RegisterPlayerError> {
+        let existing = self
+            .conn
+            .query_row(
+                "SELECT agent_id, version, command, metadata_json
+                 FROM players WHERE id = ?1",
+                params![p.id],
+                |row| {
+                    Ok(ExistingIdentity {
+                        agent_id: row.get(0)?,
+                        version: row.get(1)?,
+                        command: row.get(2)?,
+                        metadata_json: row.get(3)?,
+                    })
+                },
+            )
+            .optional()?;
+
+        match existing {
+            None => {
+                self.conn.execute(
+                    "INSERT INTO players (id, display_name, agent_id, version, command, metadata_json)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                    params![p.id, p.display_name, p.agent_id, p.version, p.command, p.metadata_json],
+                )?;
+            },
+            Some(ex) => {
+                let mut conflicts = Vec::new();
+                check_conflict(&mut conflicts, "agent_id", &ex.agent_id, &p.agent_id);
+                check_conflict(&mut conflicts, "version", &ex.version, &p.version);
+                check_conflict(&mut conflicts, "command", &ex.command, &p.command);
+                check_conflict(
+                    &mut conflicts,
+                    "metadata_json",
+                    &ex.metadata_json,
+                    &p.metadata_json,
+                );
+                if !conflicts.is_empty() {
+                    return Err(RegisterPlayerError::IdentityConflict {
+                        id: p.id.clone(),
+                        fields: conflicts,
+                    });
+                }
+                self.conn.execute(
+                    "UPDATE players
+                       SET agent_id      = COALESCE(agent_id, ?1),
+                           version       = COALESCE(version, ?2),
+                           command       = COALESCE(command, ?3),
+                           metadata_json = COALESCE(metadata_json, ?4)
+                     WHERE id = ?5",
+                    params![p.agent_id, p.version, p.command, p.metadata_json, p.id],
+                )?;
+            },
+        }
         Ok(())
     }
 
@@ -120,18 +201,26 @@ impl EvalStore {
 
     /// List all players.
     pub fn get_players(&self) -> Result<Vec<PlayerRecord>, EvalError> {
-        let mut stmt = self
-            .conn
-            .prepare("SELECT id, display_name, created_at FROM players ORDER BY id")?;
-        let rows = stmt.query_map([], |row| {
-            Ok(PlayerRecord {
-                id: row.get(0)?,
-                display_name: row.get(1)?,
-                created_at: row.get(2)?,
-            })
-        })?;
-
+        let mut stmt = self.conn.prepare(
+            "SELECT id, display_name, created_at, agent_id, version, command, metadata_json
+               FROM players ORDER BY id",
+        )?;
+        let rows = stmt.query_map([], read_player_row)?;
         rows.collect::<Result<Vec<_>, _>>().map_err(EvalError::from)
+    }
+
+    /// Single-row read by id. Used for resume paths that need identity back
+    /// out without scanning the full pool.
+    pub fn get_player(&self, id: &str) -> Result<Option<PlayerRecord>, EvalError> {
+        self.conn
+            .query_row(
+                "SELECT id, display_name, created_at, agent_id, version, command, metadata_json
+                   FROM players WHERE id = ?1",
+                params![id],
+                read_player_row,
+            )
+            .optional()
+            .map_err(EvalError::from)
     }
 
     /// List all game configs with their IDs.
@@ -154,49 +243,362 @@ impl EvalStore {
             .collect()
     }
 
-    /// Delete a player and cascade to their game results.
-    /// Returns true if the player existed.
-    pub fn delete_player(&self, id: &str) -> Result<bool, EvalError> {
+    /// Delete a player and cascade to their `game_results`. Errors with
+    /// [`DeletePlayerError::InTournamentHistory`] if the player is referenced
+    /// by `tournament_players` or `match_attempts`.
+    ///
+    /// Returns `Ok(true)` if the player existed and was deleted, `Ok(false)`
+    /// if no such player. The pre-check + delete sequence is on a single
+    /// connection (rusqlite's `Connection: !Sync` rules out concurrent races).
+    pub fn delete_player(&self, id: &str) -> Result<bool, DeletePlayerError> {
+        let blocking = self.tournaments_referencing_player(id)?;
+        if !blocking.is_empty() {
+            return Err(DeletePlayerError::InTournamentHistory {
+                tournament_ids: blocking,
+            });
+        }
         let deleted = self
             .conn
             .execute("DELETE FROM players WHERE id = ?1", params![id])?;
         Ok(deleted > 0)
     }
+
+    fn tournaments_referencing_player(&self, id: &str) -> Result<Vec<TournamentId>, EvalError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT tournament_id FROM tournament_players WHERE player_id = ?1
+             UNION
+             SELECT tournament_id FROM match_attempts
+                    WHERE player1_id = ?1 OR player2_id = ?1
+             ORDER BY tournament_id",
+        )?;
+        let rows = stmt.query_map(params![id], |row| {
+            let id: i64 = row.get(0)?;
+            Ok(TournamentId(id))
+        })?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(EvalError::from)
+    }
+
+    pub fn create_tournament(&self, t: &NewTournament) -> Result<TournamentId, EvalError> {
+        self.conn.execute(
+            "INSERT INTO tournaments (format, target_games_per_matchup, params_json)
+             VALUES (?1, ?2, ?3)",
+            params![t.format, t.target_games_per_matchup, t.params_json],
+        )?;
+        Ok(TournamentId(self.conn.last_insert_rowid()))
+    }
+
+    pub fn get_tournament(&self, id: TournamentId) -> Result<Option<TournamentRecord>, EvalError> {
+        self.conn
+            .query_row(
+                "SELECT id, format, target_games_per_matchup, params_json, created_at
+                   FROM tournaments WHERE id = ?1",
+                params![id.0],
+                read_tournament_row,
+            )
+            .optional()
+            .map_err(EvalError::from)
+    }
+
+    pub fn list_tournaments(&self) -> Result<Vec<TournamentRecord>, EvalError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, format, target_games_per_matchup, params_json, created_at
+               FROM tournaments ORDER BY id",
+        )?;
+        let rows = stmt.query_map([], read_tournament_row)?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(EvalError::from)
+    }
+
+    /// Delete a tournament. Cascades to `tournament_players` and
+    /// `match_attempts` via FK. Players and `game_results` survive.
+    /// Returns `true` if the tournament existed.
+    pub fn delete_tournament(&self, id: TournamentId) -> Result<bool, EvalError> {
+        let deleted = self
+            .conn
+            .execute("DELETE FROM tournaments WHERE id = ?1", params![id.0])?;
+        Ok(deleted > 0)
+    }
+
+    /// Insert a tournament participant. Distinguishes `(tournament_id,
+    /// player_id)` PK conflict from `(tournament_id, slot)` UNIQUE conflict
+    /// via pre-check so callers get typed errors instead of a generic SQL
+    /// constraint violation.
+    pub fn add_tournament_player(
+        &self,
+        tournament_id: TournamentId,
+        player_id: &str,
+        slot: i64,
+    ) -> Result<(), AddTournamentPlayerError> {
+        let already_in: bool = self.conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM tournament_players
+                            WHERE tournament_id = ?1 AND player_id = ?2)",
+            params![tournament_id.0, player_id],
+            |row| row.get(0),
+        )?;
+        if already_in {
+            return Err(AddTournamentPlayerError::PlayerAlreadyInTournament {
+                tournament_id,
+                player_id: player_id.to_string(),
+            });
+        }
+        let slot_taken: bool = self.conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM tournament_players
+                            WHERE tournament_id = ?1 AND slot = ?2)",
+            params![tournament_id.0, slot],
+            |row| row.get(0),
+        )?;
+        if slot_taken {
+            return Err(AddTournamentPlayerError::SlotTaken {
+                tournament_id,
+                slot,
+            });
+        }
+        self.conn.execute(
+            "INSERT INTO tournament_players (tournament_id, player_id, slot)
+             VALUES (?1, ?2, ?3)",
+            params![tournament_id.0, player_id, slot],
+        )?;
+        Ok(())
+    }
+
+    pub fn get_tournament_players(
+        &self,
+        tournament_id: TournamentId,
+    ) -> Result<Vec<TournamentParticipant>, EvalError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT tournament_id, player_id, slot
+               FROM tournament_players WHERE tournament_id = ?1
+              ORDER BY slot",
+        )?;
+        let rows = stmt.query_map(params![tournament_id.0], |row| {
+            Ok(TournamentParticipant {
+                tournament_id: TournamentId(row.get(0)?),
+                player_id: row.get(1)?,
+                slot: row.get(2)?,
+            })
+        })?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(EvalError::from)
+    }
+
+    /// Insert a match attempt row. The [`NewAttempt`] enum makes the
+    /// success/failure shape a type-level guarantee; the DB CHECK is defense
+    /// in depth. Validates that `seed` fits in `i64` (SQLite INTEGER is
+    /// signed) before binding.
+    pub fn record_attempt(&self, attempt: &NewAttempt) -> Result<i64, RecordAttemptError> {
+        let key = attempt.key();
+        if key.seed > i64::MAX as u64 {
+            return Err(RecordAttemptError::SeedOutOfRange { value: key.seed });
+        }
+        let seed_i64 = key.seed as i64;
+        let (status, score1, score2, turns, failure_reason, started_at) = match attempt {
+            NewAttempt::Success {
+                player1_score,
+                player2_score,
+                turns,
+                started_at,
+                ..
+            } => (
+                AttemptStatus::Success.as_str(),
+                Some(*player1_score),
+                Some(*player2_score),
+                Some(*turns),
+                None,
+                Some(started_at.as_str()),
+            ),
+            NewAttempt::Failure {
+                failure_reason,
+                started_at,
+                ..
+            } => (
+                AttemptStatus::Failure.as_str(),
+                None,
+                None,
+                None,
+                Some(failure_reason.as_str()),
+                started_at.as_deref(),
+            ),
+        };
+        self.conn.execute(
+            "INSERT INTO match_attempts
+               (tournament_id, game_config_id, player1_id, player2_id, seed,
+                repetition_index, attempt_index, status,
+                player1_score, player2_score, turns,
+                failure_reason, started_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+            params![
+                key.tournament_id.0,
+                key.game_config_id,
+                key.player1_id,
+                key.player2_id,
+                seed_i64,
+                key.repetition_index,
+                key.attempt_index,
+                status,
+                score1,
+                score2,
+                turns,
+                failure_reason,
+                started_at,
+            ],
+        )?;
+        Ok(self.conn.last_insert_rowid())
+    }
+
+    pub fn get_attempts(
+        &self,
+        tournament_id: TournamentId,
+        status_filter: Option<AttemptStatus>,
+    ) -> Result<Vec<AttemptRecord>, EvalError> {
+        let mut sql = String::from(
+            "SELECT id, tournament_id, game_config_id, player1_id, player2_id, seed,
+                    repetition_index, attempt_index, status,
+                    player1_score, player2_score, turns,
+                    failure_reason, started_at, finished_at
+               FROM match_attempts WHERE tournament_id = ?1",
+        );
+        if status_filter.is_some() {
+            sql.push_str(" AND status = ?2");
+        }
+        sql.push_str(" ORDER BY id");
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = if let Some(s) = status_filter {
+            stmt.query_map(params![tournament_id.0, s.as_str()], read_attempt_row)?
+                .collect::<Result<Vec<_>, _>>()?
+        } else {
+            stmt.query_map(params![tournament_id.0], read_attempt_row)?
+                .collect::<Result<Vec<_>, _>>()?
+        };
+        Ok(rows)
+    }
+}
+
+fn read_player_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<PlayerRecord> {
+    Ok(PlayerRecord {
+        id: row.get(0)?,
+        display_name: row.get(1)?,
+        created_at: row.get(2)?,
+        agent_id: row.get(3)?,
+        version: row.get(4)?,
+        command: row.get(5)?,
+        metadata_json: row.get(6)?,
+    })
+}
+
+fn read_tournament_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TournamentRecord> {
+    Ok(TournamentRecord {
+        id: TournamentId(row.get(0)?),
+        format: row.get(1)?,
+        target_games_per_matchup: row.get(2)?,
+        params_json: row.get(3)?,
+        created_at: row.get(4)?,
+    })
+}
+
+fn read_attempt_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AttemptRecord> {
+    let seed_i64: i64 = row.get(5)?;
+    let status_str: String = row.get(8)?;
+    let status = AttemptStatus::from_str(&status_str).ok_or_else(|| {
+        rusqlite::Error::FromSqlConversionFailure(
+            8,
+            rusqlite::types::Type::Text,
+            format!("invalid attempt status: {status_str}").into(),
+        )
+    })?;
+    Ok(AttemptRecord {
+        id: row.get(0)?,
+        tournament_id: TournamentId(row.get(1)?),
+        game_config_id: row.get(2)?,
+        player1_id: row.get(3)?,
+        player2_id: row.get(4)?,
+        seed: seed_i64 as u64,
+        repetition_index: row.get(6)?,
+        attempt_index: row.get(7)?,
+        status,
+        player1_score: row.get(9)?,
+        player2_score: row.get(10)?,
+        turns: row.get(11)?,
+        failure_reason: row.get(12)?,
+        started_at: row.get(13)?,
+        finished_at: row.get(14)?,
+    })
+}
+
+fn check_conflict(
+    out: &mut Vec<String>,
+    field: &str,
+    existing: &Option<String>,
+    new: &Option<String>,
+) {
+    if let (Some(e), Some(n)) = (existing, new) {
+        if e != n {
+            out.push(field.to_string());
+        }
+    }
+}
+
+struct ExistingIdentity {
+    agent_id: Option<String>,
+    version: Option<String>,
+    command: Option<String>,
+    metadata_json: Option<String>,
 }
 
 /// Aggregate game results into head-to-head records.
 /// Groups by (player1, player2) pair, classifies win/loss/draw from scores.
 pub fn head_to_head_from_results(results: &[GameResultRecord]) -> Vec<HeadToHead> {
-    let mut map: HashMap<(String, String), (u32, u32, u32)> = HashMap::new();
+    aggregate_pairs(results.iter().map(|r| {
+        (
+            &r.player1_id,
+            &r.player2_id,
+            r.player1_score,
+            r.player2_score,
+        )
+    }))
+}
 
-    for r in results {
-        // Canonical ordering: smaller ID first
-        let (a, b, a_score, b_score) = if r.player1_id <= r.player2_id {
-            (
-                &r.player1_id,
-                &r.player2_id,
-                r.player1_score,
-                r.player2_score,
-            )
+/// Same shape as [`head_to_head_from_results`], but over tournament attempt
+/// rows. Failure rows are skipped — Elo is computed from successful matches
+/// only.
+///
+/// The `expect` on each score is gated by the `match_attempts` CHECK
+/// constraint, which guarantees success rows have non-NULL scores. A row
+/// reaching this code with `status = Success` and a NULL score means the
+/// CHECK was disabled or the DB was hand-edited.
+pub fn head_to_head_from_attempts(attempts: &[AttemptRecord]) -> Vec<HeadToHead> {
+    aggregate_pairs(attempts.iter().filter_map(|a| {
+        if a.status == AttemptStatus::Success {
+            Some((
+                &a.player1_id,
+                &a.player2_id,
+                a.player1_score.expect("success rows have scores"),
+                a.player2_score.expect("success rows have scores"),
+            ))
         } else {
-            (
-                &r.player2_id,
-                &r.player1_id,
-                r.player2_score,
-                r.player1_score,
-            )
-        };
+            None
+        }
+    }))
+}
 
+fn aggregate_pairs<'a, I>(iter: I) -> Vec<HeadToHead>
+where
+    I: IntoIterator<Item = (&'a String, &'a String, f64, f64)>,
+{
+    let mut map: HashMap<(String, String), (u32, u32, u32)> = HashMap::new();
+    for (p1, p2, s1, s2) in iter {
+        let (a, b, a_score, b_score) = if p1 <= p2 {
+            (p1, p2, s1, s2)
+        } else {
+            (p2, p1, s2, s1)
+        };
         let entry = map.entry((a.clone(), b.clone())).or_insert((0, 0, 0));
         if (a_score - b_score).abs() < 1e-9 {
-            entry.2 += 1; // draw
+            entry.2 += 1;
         } else if a_score > b_score {
-            entry.0 += 1; // a wins
+            entry.0 += 1;
         } else {
-            entry.1 += 1; // b wins
+            entry.1 += 1;
         }
     }
-
     let mut records: Vec<HeadToHead> = map
         .into_iter()
         .map(|((a, b), (wa, wb, d))| HeadToHead::with_draws(a, b, wa, wb, d))
@@ -209,6 +611,7 @@ pub fn head_to_head_from_results(results: &[GameResultRecord]) -> Vec<HeadToHead
 mod tests {
     use super::*;
     use crate::elo::compute_elo;
+    use crate::types::AttemptKey;
 
     fn sample_config() -> GameConfigRecord {
         GameConfigRecord {
@@ -228,6 +631,70 @@ mod tests {
     fn setup_players(store: &EvalStore) {
         store.ensure_player("alice", "Alice").unwrap();
         store.ensure_player("bob", "Bob").unwrap();
+    }
+
+    fn setup_tournament(store: &EvalStore) -> (TournamentId, String) {
+        setup_players(store);
+        let config_id = store.ensure_game_config(&sample_config()).unwrap();
+        let tid = store
+            .create_tournament(&NewTournament {
+                format: "round-robin".into(),
+                target_games_per_matchup: Some(10),
+                params_json: "{}".into(),
+            })
+            .unwrap();
+        store.add_tournament_player(tid, "alice", 0).unwrap();
+        store.add_tournament_player(tid, "bob", 1).unwrap();
+        (tid, config_id)
+    }
+
+    fn success_attempt(
+        tid: TournamentId,
+        cid: &str,
+        p1: &str,
+        p2: &str,
+        attempt_index: u32,
+        s1: f64,
+        s2: f64,
+    ) -> NewAttempt {
+        NewAttempt::Success {
+            key: AttemptKey {
+                tournament_id: tid,
+                game_config_id: cid.into(),
+                player1_id: p1.into(),
+                player2_id: p2.into(),
+                seed: 1234,
+                repetition_index: 0,
+                attempt_index,
+            },
+            player1_score: s1,
+            player2_score: s2,
+            turns: 100,
+            started_at: "2026-05-06 10:00:00".into(),
+        }
+    }
+
+    fn failure_attempt(
+        tid: TournamentId,
+        cid: &str,
+        p1: &str,
+        p2: &str,
+        attempt_index: u32,
+        started_at: Option<&str>,
+    ) -> NewAttempt {
+        NewAttempt::Failure {
+            key: AttemptKey {
+                tournament_id: tid,
+                game_config_id: cid.into(),
+                player1_id: p1.into(),
+                player2_id: p2.into(),
+                seed: 5678,
+                repetition_index: 0,
+                attempt_index,
+            },
+            failure_reason: "bot crash".into(),
+            started_at: started_at.map(String::from),
+        }
     }
 
     #[test]
@@ -301,7 +768,6 @@ mod tests {
         store.ensure_player("carol", "Carol").unwrap();
         let config_id = store.ensure_game_config(&sample_config()).unwrap();
 
-        // alice vs bob
         store
             .record_result(&NewGameResult {
                 game_config_id: config_id.clone(),
@@ -313,7 +779,6 @@ mod tests {
             })
             .unwrap();
 
-        // carol vs bob
         store
             .record_result(&NewGameResult {
                 game_config_id: config_id.clone(),
@@ -385,7 +850,6 @@ mod tests {
         setup_players(&store);
         let config_id = store.ensure_game_config(&sample_config()).unwrap();
 
-        // Insert with explicit timestamps
         store.conn.execute(
             "INSERT INTO game_results (game_config_id, player1_id, player2_id, player1_score, player2_score, turns, played_at)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
@@ -470,7 +934,6 @@ mod tests {
     fn foreign_key_enforcement() {
         let store = EvalStore::open_in_memory().unwrap();
 
-        // Bad config ref
         let err = store.record_result(&NewGameResult {
             game_config_id: "nonexistent".into(),
             player1_id: "alice".into(),
@@ -481,7 +944,6 @@ mod tests {
         });
         assert!(err.is_err());
 
-        // Bad player ref (valid config, bad player)
         let config_id = store.ensure_game_config(&sample_config()).unwrap();
         let err = store.record_result(&NewGameResult {
             game_config_id: config_id,
@@ -499,13 +961,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("eval.db");
 
-        // Create and populate
         {
             let store = EvalStore::open(&path).unwrap();
             store.ensure_player("alice", "Alice").unwrap();
         }
 
-        // Reopen and verify
         {
             let store = EvalStore::open(&path).unwrap();
             let players = store.get_players().unwrap();
@@ -514,9 +974,511 @@ mod tests {
         }
     }
 
-    // ---------------------------------------------------------------
-    // head_to_head_from_results
-    // ---------------------------------------------------------------
+    fn user_version(store: &EvalStore) -> u32 {
+        store
+            .conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .unwrap()
+    }
+
+    #[test]
+    fn migration_fresh_db_ends_at_user_version_2() {
+        let store = EvalStore::open_in_memory().unwrap();
+        assert_eq!(user_version(&store), 2);
+
+        let tables: Vec<String> = store
+            .conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        for expected in [
+            "game_configs",
+            "game_results",
+            "match_attempts",
+            "players",
+            "tournament_players",
+            "tournaments",
+        ] {
+            assert!(
+                tables.contains(&expected.to_string()),
+                "missing table: {expected}; have {tables:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn migration_upgrades_handbuilt_v0_db() {
+        // Build a connection that has migration-1 tables but `user_version=0`,
+        // mimicking a DB created before the migration runner existed.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        conn.execute_batch(
+            "CREATE TABLE players (id TEXT PRIMARY KEY, display_name TEXT NOT NULL,
+                                   created_at TEXT NOT NULL DEFAULT (datetime('now')));
+             CREATE TABLE game_configs (id TEXT PRIMARY KEY, config_json TEXT NOT NULL);
+             CREATE TABLE game_results (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                game_config_id TEXT NOT NULL REFERENCES game_configs(id),
+                player1_id TEXT NOT NULL REFERENCES players(id) ON DELETE CASCADE,
+                player2_id TEXT NOT NULL REFERENCES players(id) ON DELETE CASCADE,
+                player1_score REAL NOT NULL, player2_score REAL NOT NULL,
+                turns INTEGER NOT NULL,
+                played_at TEXT NOT NULL DEFAULT (datetime('now'))
+             );",
+        )
+        .unwrap();
+        // user_version is 0 by default — explicitly assert.
+        let v: u32 = conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(v, 0);
+
+        let store = EvalStore::from_connection(conn).unwrap();
+        assert_eq!(user_version(&store), 2);
+
+        // Migration 1 (CREATE IF NOT EXISTS) is a no-op; migration 2 adds
+        // the new tables and columns. Confirm the v2 surface is present.
+        let cols: Vec<String> = store
+            .conn
+            .prepare("SELECT name FROM pragma_table_info('players')")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        for expected in ["agent_id", "version", "command", "metadata_json"] {
+            assert!(
+                cols.contains(&expected.to_string()),
+                "migration 2 should have added {expected} column to players: have {cols:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn migration_idempotent_on_second_run() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        schema::initialize(&mut conn).unwrap();
+        let v: u32 = conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(v, 2);
+        // Second run on the same connection: each migration's `version > current`
+        // guard makes the loop a no-op. Must not error.
+        schema::initialize(&mut conn).unwrap();
+        let v: u32 = conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(v, 2);
+    }
+
+    #[test]
+    fn pragma_foreign_keys_is_on_per_connection() {
+        let store = EvalStore::open_in_memory().unwrap();
+        let fk: i64 = store
+            .conn
+            .query_row("PRAGMA foreign_keys", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(fk, 1);
+    }
+
+    #[test]
+    fn duplicate_attempt_key_violates_unique() {
+        let store = EvalStore::open_in_memory().unwrap();
+        let (tid, cid) = setup_tournament(&store);
+        store
+            .record_attempt(&success_attempt(tid, &cid, "alice", "bob", 0, 8.0, 2.0))
+            .unwrap();
+        let dup = store.record_attempt(&success_attempt(tid, &cid, "alice", "bob", 0, 1.0, 9.0));
+        assert!(matches!(
+            dup,
+            Err(RecordAttemptError::Db(EvalError::Db(
+                rusqlite::Error::SqliteFailure(_, _)
+            )))
+        ));
+    }
+
+    #[test]
+    fn record_attempt_seed_bound() {
+        let store = EvalStore::open_in_memory().unwrap();
+        let (tid, cid) = setup_tournament(&store);
+        // Out of range: rejected before binding.
+        let mut bad = success_attempt(tid, &cid, "alice", "bob", 0, 8.0, 2.0);
+        if let NewAttempt::Success { key, .. } = &mut bad {
+            key.seed = u64::MAX;
+        }
+        match store.record_attempt(&bad) {
+            Err(RecordAttemptError::SeedOutOfRange { value }) => assert_eq!(value, u64::MAX),
+            other => panic!("expected SeedOutOfRange, got {other:?}"),
+        }
+        // i64::MAX round-trips exactly.
+        let mut at_max = success_attempt(tid, &cid, "alice", "bob", 1, 5.0, 5.0);
+        if let NewAttempt::Success { key, .. } = &mut at_max {
+            key.seed = i64::MAX as u64;
+        }
+        store.record_attempt(&at_max).unwrap();
+        let attempts = store.get_attempts(tid, None).unwrap();
+        assert_eq!(attempts.len(), 1);
+        assert_eq!(attempts[0].seed, i64::MAX as u64);
+    }
+
+    #[test]
+    fn check_rejects_malformed_success_row() {
+        // Bypass the typed API; DB CHECK is the last line of defense.
+        let store = EvalStore::open_in_memory().unwrap();
+        let (tid, cid) = setup_tournament(&store);
+        let res = store.conn.execute(
+            "INSERT INTO match_attempts
+              (tournament_id, game_config_id, player1_id, player2_id, seed,
+               repetition_index, attempt_index, status,
+               player1_score, player2_score, turns, failure_reason, started_at)
+             VALUES (?1, ?2, 'alice', 'bob', 1, 0, 0, 'success',
+                     NULL, 5.0, 100, NULL, '2026-01-01 00:00:00')",
+            params![tid.0, cid],
+        );
+        assert!(
+            res.is_err(),
+            "success row missing player1_score must fail CHECK"
+        );
+
+        let res = store.conn.execute(
+            "INSERT INTO match_attempts
+              (tournament_id, game_config_id, player1_id, player2_id, seed,
+               repetition_index, attempt_index, status,
+               player1_score, player2_score, turns, failure_reason, started_at)
+             VALUES (?1, ?2, 'alice', 'bob', 1, 0, 1, 'success',
+                     5.0, 5.0, 100, NULL, NULL)",
+            params![tid.0, cid],
+        );
+        assert!(
+            res.is_err(),
+            "success row with NULL started_at must fail CHECK"
+        );
+    }
+
+    #[test]
+    fn check_rejects_malformed_failure_row() {
+        let store = EvalStore::open_in_memory().unwrap();
+        let (tid, cid) = setup_tournament(&store);
+        let res = store.conn.execute(
+            "INSERT INTO match_attempts
+              (tournament_id, game_config_id, player1_id, player2_id, seed,
+               repetition_index, attempt_index, status,
+               player1_score, player2_score, turns, failure_reason, started_at)
+             VALUES (?1, ?2, 'alice', 'bob', 1, 0, 0, 'failure',
+                     5.0, NULL, NULL, 'crash', NULL)",
+            params![tid.0, cid],
+        );
+        assert!(res.is_err(), "failure row with score must fail CHECK");
+
+        let res = store.conn.execute(
+            "INSERT INTO match_attempts
+              (tournament_id, game_config_id, player1_id, player2_id, seed,
+               repetition_index, attempt_index, status,
+               player1_score, player2_score, turns, failure_reason, started_at)
+             VALUES (?1, ?2, 'alice', 'bob', 1, 0, 1, 'failure',
+                     NULL, NULL, NULL, NULL, NULL)",
+            params![tid.0, cid],
+        );
+        assert!(
+            res.is_err(),
+            "failure row missing failure_reason must fail CHECK"
+        );
+    }
+
+    #[test]
+    fn get_attempts_returns_mixed_status() {
+        let store = EvalStore::open_in_memory().unwrap();
+        let (tid, cid) = setup_tournament(&store);
+        store
+            .record_attempt(&success_attempt(tid, &cid, "alice", "bob", 0, 8.0, 2.0))
+            .unwrap();
+        store
+            .record_attempt(&failure_attempt(
+                tid,
+                &cid,
+                "alice",
+                "bob",
+                1,
+                Some("2026-05-06 11:00:00"),
+            ))
+            .unwrap();
+
+        let all = store.get_attempts(tid, None).unwrap();
+        assert_eq!(all.len(), 2);
+        let success_count = all
+            .iter()
+            .filter(|a| a.status == AttemptStatus::Success)
+            .count();
+        let failure_count = all
+            .iter()
+            .filter(|a| a.status == AttemptStatus::Failure)
+            .count();
+        assert_eq!(success_count, 1);
+        assert_eq!(failure_count, 1);
+
+        let succ = store
+            .get_attempts(tid, Some(AttemptStatus::Success))
+            .unwrap();
+        assert_eq!(succ.len(), 1);
+        let fail = store
+            .get_attempts(tid, Some(AttemptStatus::Failure))
+            .unwrap();
+        assert_eq!(fail.len(), 1);
+    }
+
+    #[test]
+    fn h2h_from_attempts_skips_failures() {
+        let store = EvalStore::open_in_memory().unwrap();
+        let (tid, cid) = setup_tournament(&store);
+        store
+            .record_attempt(&success_attempt(tid, &cid, "alice", "bob", 0, 8.0, 2.0))
+            .unwrap();
+        store
+            .record_attempt(&failure_attempt(tid, &cid, "alice", "bob", 1, None))
+            .unwrap();
+
+        let attempts = store.get_attempts(tid, None).unwrap();
+        let h = head_to_head_from_attempts(&attempts);
+        assert_eq!(h.len(), 1);
+        // alice (player_a) won the only success; failure ignored.
+        assert_eq!(h[0].wins_a + h[0].wins_b + h[0].draws, 1);
+    }
+
+    #[test]
+    fn spawn_failure_attempt_roundtrips() {
+        let store = EvalStore::open_in_memory().unwrap();
+        let (tid, cid) = setup_tournament(&store);
+        store
+            .record_attempt(&failure_attempt(tid, &cid, "alice", "bob", 0, None))
+            .unwrap();
+
+        let attempts = store.get_attempts(tid, None).unwrap();
+        assert_eq!(attempts.len(), 1);
+        let a = &attempts[0];
+        assert_eq!(a.status, AttemptStatus::Failure);
+        assert!(a.player1_score.is_none());
+        assert!(a.player2_score.is_none());
+        assert!(a.turns.is_none());
+        assert!(a.started_at.is_none());
+        assert_eq!(a.failure_reason.as_deref(), Some("bot crash"));
+    }
+
+    #[test]
+    fn add_tournament_player_distinct_conflict_errors() {
+        let store = EvalStore::open_in_memory().unwrap();
+        setup_players(&store);
+        store.ensure_player("carol", "Carol").unwrap();
+        let tid = store
+            .create_tournament(&NewTournament {
+                format: "round-robin".into(),
+                target_games_per_matchup: None,
+                params_json: "{}".into(),
+            })
+            .unwrap();
+        store.add_tournament_player(tid, "alice", 0).unwrap();
+
+        // Same player twice → PlayerAlreadyInTournament.
+        match store.add_tournament_player(tid, "alice", 5) {
+            Err(AddTournamentPlayerError::PlayerAlreadyInTournament { player_id, .. }) => {
+                assert_eq!(player_id, "alice")
+            },
+            other => panic!("expected PlayerAlreadyInTournament, got {other:?}"),
+        }
+
+        // Different player, same slot → SlotTaken.
+        match store.add_tournament_player(tid, "carol", 0) {
+            Err(AddTournamentPlayerError::SlotTaken { slot, .. }) => assert_eq!(slot, 0),
+            other => panic!("expected SlotTaken, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn delete_player_blocked_by_tournament_history() {
+        let store = EvalStore::open_in_memory().unwrap();
+        let (tid, cid) = setup_tournament(&store);
+        store
+            .record_attempt(&success_attempt(tid, &cid, "alice", "bob", 0, 8.0, 2.0))
+            .unwrap();
+
+        match store.delete_player("alice") {
+            Err(DeletePlayerError::InTournamentHistory { tournament_ids }) => {
+                assert_eq!(tournament_ids, vec![tid]);
+            },
+            other => panic!("expected InTournamentHistory, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn delete_player_succeeds_when_only_ad_hoc_results() {
+        let store = EvalStore::open_in_memory().unwrap();
+        setup_players(&store);
+        let cid = store.ensure_game_config(&sample_config()).unwrap();
+        store
+            .record_result(&NewGameResult {
+                game_config_id: cid,
+                player1_id: "alice".into(),
+                player2_id: "bob".into(),
+                player1_score: 5.0,
+                player2_score: 5.0,
+                turns: 100,
+            })
+            .unwrap();
+
+        // No tournament rows; deletion succeeds and cascades game_results.
+        assert!(store.delete_player("alice").unwrap());
+        let results = store.get_results(&ResultFilter::default()).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn delete_tournament_cascades_children_only() {
+        let store = EvalStore::open_in_memory().unwrap();
+        let (tid, cid) = setup_tournament(&store);
+        store
+            .record_attempt(&success_attempt(tid, &cid, "alice", "bob", 0, 8.0, 2.0))
+            .unwrap();
+
+        // Add an unrelated tournament so we can prove only the targeted one
+        // is touched.
+        let other = store
+            .create_tournament(&NewTournament {
+                format: "gauntlet".into(),
+                target_games_per_matchup: None,
+                params_json: "{}".into(),
+            })
+            .unwrap();
+        store.add_tournament_player(other, "alice", 0).unwrap();
+        store.add_tournament_player(other, "bob", 1).unwrap();
+        store
+            .record_attempt(&success_attempt(other, &cid, "alice", "bob", 0, 6.0, 4.0))
+            .unwrap();
+
+        // Also a stray ad-hoc row to confirm it survives.
+        store
+            .record_result(&NewGameResult {
+                game_config_id: cid.clone(),
+                player1_id: "alice".into(),
+                player2_id: "bob".into(),
+                player1_score: 3.0,
+                player2_score: 7.0,
+                turns: 50,
+            })
+            .unwrap();
+
+        assert!(store.delete_tournament(tid).unwrap());
+
+        // Targeted tournament: rows gone.
+        assert!(store.get_attempts(tid, None).unwrap().is_empty());
+        assert!(store.get_tournament_players(tid).unwrap().is_empty());
+        assert!(store.get_tournament(tid).unwrap().is_none());
+
+        // Other tournament + ad-hoc rows + players: untouched.
+        assert_eq!(store.get_attempts(other, None).unwrap().len(), 1);
+        assert_eq!(store.get_tournament_players(other).unwrap().len(), 2);
+        assert_eq!(
+            store.get_results(&ResultFilter::default()).unwrap().len(),
+            1
+        );
+        assert_eq!(store.get_players().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn delete_tournament_unblocks_delete_player() {
+        let store = EvalStore::open_in_memory().unwrap();
+        let (tid, cid) = setup_tournament(&store);
+        store
+            .record_attempt(&success_attempt(tid, &cid, "alice", "bob", 0, 8.0, 2.0))
+            .unwrap();
+
+        assert!(store.delete_player("alice").is_err());
+        store.delete_tournament(tid).unwrap();
+        assert!(store.delete_player("alice").unwrap());
+    }
+
+    #[test]
+    fn register_player_conflict_fill_idempotent() {
+        let store = EvalStore::open_in_memory().unwrap();
+
+        // Conflict path: insert with version=1, attempt to re-insert with
+        // version=2 → IdentityConflict listing version.
+        store
+            .register_player(&NewPlayer {
+                id: "pyrat/greedy".into(),
+                display_name: "Greedy".into(),
+                agent_id: Some("pyrat/greedy".into()),
+                version: Some("1".into()),
+                command: Some("cargo run".into()),
+                metadata_json: None,
+            })
+            .unwrap();
+        match store.register_player(&NewPlayer {
+            id: "pyrat/greedy".into(),
+            display_name: "Greedy".into(),
+            agent_id: Some("pyrat/greedy".into()),
+            version: Some("2".into()),
+            command: Some("cargo run".into()),
+            metadata_json: None,
+        }) {
+            Err(RegisterPlayerError::IdentityConflict { id, fields }) => {
+                assert_eq!(id, "pyrat/greedy");
+                assert_eq!(fields, vec!["version".to_string()]);
+            },
+            other => panic!("expected IdentityConflict, got {other:?}"),
+        }
+
+        // Idempotent path: identical re-insert is a no-op success.
+        store
+            .register_player(&NewPlayer {
+                id: "pyrat/greedy".into(),
+                display_name: "Greedy".into(),
+                agent_id: Some("pyrat/greedy".into()),
+                version: Some("1".into()),
+                command: Some("cargo run".into()),
+                metadata_json: None,
+            })
+            .unwrap();
+
+        // NULL-fill path: ensure_player creates a row without identity columns;
+        // register_player fills them in.
+        store.ensure_player("legacy", "Legacy").unwrap();
+        store
+            .register_player(&NewPlayer {
+                id: "legacy".into(),
+                display_name: "Legacy".into(),
+                agent_id: Some("pyrat/legacy".into()),
+                version: Some("1".into()),
+                command: None,
+                metadata_json: Some(r#"{"note":"backfill"}"#.into()),
+            })
+            .unwrap();
+        let p = store.get_player("legacy").unwrap().unwrap();
+        assert_eq!(p.agent_id.as_deref(), Some("pyrat/legacy"));
+        assert_eq!(p.version.as_deref(), Some("1"));
+        assert!(p.command.is_none()); // wasn't supplied, stays NULL
+        assert_eq!(p.metadata_json.as_deref(), Some(r#"{"note":"backfill"}"#));
+    }
+
+    #[test]
+    fn get_player_returns_some_or_none() {
+        let store = EvalStore::open_in_memory().unwrap();
+        store
+            .register_player(&NewPlayer {
+                id: "alice".into(),
+                display_name: "Alice".into(),
+                agent_id: Some("pyrat/alice".into()),
+                version: None,
+                command: None,
+                metadata_json: None,
+            })
+            .unwrap();
+        let p = store.get_player("alice").unwrap().unwrap();
+        assert_eq!(p.id, "alice");
+        assert_eq!(p.agent_id.as_deref(), Some("pyrat/alice"));
+        assert!(store.get_player("ghost").unwrap().is_none());
+    }
 
     fn game(id: i64, p1: &str, p2: &str, s1: f64, s2: f64) -> GameResultRecord {
         GameResultRecord {

--- a/eval/store/src/store.rs
+++ b/eval/store/src/store.rs
@@ -6,10 +6,10 @@ use rusqlite::{params, Connection, OptionalExtension};
 use crate::elo::HeadToHead;
 use crate::schema;
 use crate::types::{
-    AddTournamentPlayerError, AttemptRecord, AttemptStatus, DeletePlayerError, EvalError,
-    GameConfigRecord, GameResultRecord, NewAttempt, NewAttemptOutcome, NewGameResult, NewPlayer,
-    NewTournament, PlayerRecord, RecordAttemptError, RegisterPlayerError, ResultFilter,
-    TournamentId, TournamentParticipant, TournamentRecord,
+    AddTournamentPlayerError, AttemptKey, AttemptOutcome, AttemptRecord, AttemptStatus,
+    DeletePlayerError, EvalError, GameConfigRecord, GameResultRecord, NewAttempt,
+    NewAttemptOutcome, NewGameResult, NewPlayer, NewTournament, PlayerRecord, RecordAttemptError,
+    RegisterPlayerError, ResultFilter, TournamentId, TournamentParticipant, TournamentRecord,
 };
 
 /// SQLite-backed store for game results, players, tournaments, and match
@@ -507,8 +507,7 @@ fn read_attempt_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AttemptRecord> 
             format!("invalid attempt status: {status_str}").into(),
         )
     })?;
-    Ok(AttemptRecord {
-        id: row.get(0)?,
+    let key = AttemptKey {
         tournament_id: TournamentId(row.get(1)?),
         game_config_id: row.get(2)?,
         player1_id: row.get(3)?,
@@ -516,13 +515,26 @@ fn read_attempt_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AttemptRecord> 
         seed: seed_i64 as u64,
         repetition_index: row.get(6)?,
         attempt_index: row.get(7)?,
-        status,
-        player1_score: row.get(9)?,
-        player2_score: row.get(10)?,
-        turns: row.get(11)?,
-        failure_reason: row.get(12)?,
-        started_at: row.get(13)?,
+    };
+    // The `match_attempts` CHECK guarantees the column shape per status,
+    // so the unwraps below cannot fire on a healthy DB.
+    let outcome = match status {
+        AttemptStatus::Success => AttemptOutcome::Success {
+            player1_score: row.get(9)?,
+            player2_score: row.get(10)?,
+            turns: row.get(11)?,
+            started_at: row.get(13)?,
+        },
+        AttemptStatus::Failure => AttemptOutcome::Failure {
+            failure_reason: row.get(12)?,
+            started_at: row.get(13)?,
+        },
+    };
+    Ok(AttemptRecord {
+        id: row.get(0)?,
+        key,
         finished_at: row.get(14)?,
+        outcome,
     })
 }
 
@@ -561,24 +573,20 @@ pub fn head_to_head_from_results(results: &[GameResultRecord]) -> Vec<HeadToHead
 
 /// Same shape as [`head_to_head_from_results`], but over tournament attempt
 /// rows. Failure rows are skipped — Elo is computed from successful matches
-/// only.
-///
-/// The `expect` on each score is gated by the `match_attempts` CHECK
-/// constraint, which guarantees success rows have non-NULL scores. A row
-/// reaching this code with `status = Success` and a NULL score means the
-/// CHECK was disabled or the DB was hand-edited.
+/// only. Variant-dispatch on `outcome` makes the success-only access total.
 pub fn head_to_head_from_attempts(attempts: &[AttemptRecord]) -> Vec<HeadToHead> {
-    aggregate_pairs(attempts.iter().filter_map(|a| {
-        if a.status == AttemptStatus::Success {
-            Some((
-                &a.player1_id,
-                &a.player2_id,
-                a.player1_score.expect("success rows have scores"),
-                a.player2_score.expect("success rows have scores"),
-            ))
-        } else {
-            None
-        }
+    aggregate_pairs(attempts.iter().filter_map(|a| match &a.outcome {
+        AttemptOutcome::Success {
+            player1_score,
+            player2_score,
+            ..
+        } => Some((
+            &a.key.player1_id,
+            &a.key.player2_id,
+            *player1_score,
+            *player2_score,
+        )),
+        AttemptOutcome::Failure { .. } => None,
     }))
 }
 
@@ -614,7 +622,6 @@ where
 mod tests {
     use super::*;
     use crate::elo::compute_elo;
-    use crate::types::AttemptKey;
 
     fn sample_config() -> GameConfigRecord {
         GameConfigRecord {
@@ -1126,7 +1133,7 @@ mod tests {
         store.record_attempt(&at_max).unwrap();
         let attempts = store.get_attempts(tid, None).unwrap();
         assert_eq!(attempts.len(), 1);
-        assert_eq!(attempts[0].seed, i64::MAX as u64);
+        assert_eq!(attempts[0].key.seed, i64::MAX as u64);
     }
 
     #[test]
@@ -1223,11 +1230,11 @@ mod tests {
         assert_eq!(all.len(), 2);
         let success_count = all
             .iter()
-            .filter(|a| a.status == AttemptStatus::Success)
+            .filter(|a| a.status() == AttemptStatus::Success)
             .count();
         let failure_count = all
             .iter()
-            .filter(|a| a.status == AttemptStatus::Failure)
+            .filter(|a| a.status() == AttemptStatus::Failure)
             .count();
         assert_eq!(success_count, 1);
         assert_eq!(failure_count, 1);
@@ -1271,12 +1278,17 @@ mod tests {
         let attempts = store.get_attempts(tid, None).unwrap();
         assert_eq!(attempts.len(), 1);
         let a = &attempts[0];
-        assert_eq!(a.status, AttemptStatus::Failure);
-        assert!(a.player1_score.is_none());
-        assert!(a.player2_score.is_none());
-        assert!(a.turns.is_none());
-        assert!(a.started_at.is_none());
-        assert_eq!(a.failure_reason.as_deref(), Some("bot crash"));
+        assert_eq!(a.status(), AttemptStatus::Failure);
+        match &a.outcome {
+            AttemptOutcome::Failure {
+                failure_reason,
+                started_at,
+            } => {
+                assert!(started_at.is_none(), "spawn-failure has no started_at");
+                assert_eq!(failure_reason.as_str(), "bot crash");
+            },
+            other => panic!("expected Failure outcome, got {other:?}"),
+        }
     }
 
     #[test]

--- a/eval/store/src/store.rs
+++ b/eval/store/src/store.rs
@@ -419,7 +419,7 @@ impl EvalStore {
                 started_at.as_deref(),
             ),
         };
-        self.conn.execute(
+        let result = self.conn.execute(
             "INSERT INTO match_attempts
                (tournament_id, game_config_id, player1_id, player2_id, seed,
                 repetition_index, attempt_index, status,
@@ -442,8 +442,19 @@ impl EvalStore {
                 started_at,
                 finished_at,
             ],
-        )?;
-        Ok(self.conn.last_insert_rowid())
+        );
+        match result {
+            Ok(_) => Ok(self.conn.last_insert_rowid()),
+            // The only UNIQUE constraint on `match_attempts` is the matchup
+            // key tuple; surface it as a typed error so the planner can
+            // distinguish retry-collision from a generic DB blip.
+            Err(rusqlite::Error::SqliteFailure(e, _))
+                if e.extended_code == rusqlite::ffi::SQLITE_CONSTRAINT_UNIQUE =>
+            {
+                Err(RecordAttemptError::AttemptAlreadyExists { key: key.clone() })
+            },
+            Err(e) => Err(e.into()),
+        }
     }
 
     pub fn get_attempts(
@@ -1123,12 +1134,15 @@ mod tests {
             .record_attempt(&success_attempt(tid, &cid, "alice", "bob", 0, 8.0, 2.0))
             .unwrap();
         let dup = store.record_attempt(&success_attempt(tid, &cid, "alice", "bob", 0, 1.0, 9.0));
-        assert!(matches!(
-            dup,
-            Err(RecordAttemptError::Db(EvalError::Db(
-                rusqlite::Error::SqliteFailure(_, _)
-            )))
-        ));
+        match dup {
+            Err(RecordAttemptError::AttemptAlreadyExists { key }) => {
+                assert_eq!(key.player1_id, "alice");
+                assert_eq!(key.player2_id, "bob");
+                assert_eq!(key.attempt_index, 0);
+                assert_eq!(key.repetition_index, 0);
+            },
+            other => panic!("expected AttemptAlreadyExists, got {other:?}"),
+        }
     }
 
     #[test]

--- a/eval/store/src/store.rs
+++ b/eval/store/src/store.rs
@@ -1127,6 +1127,46 @@ mod tests {
     }
 
     #[test]
+    fn match_attempts_fk_enforced() {
+        // Stronger than `pragma_foreign_keys_is_on_per_connection`: prove an
+        // FK action on the new `match_attempts` table actually fires, not
+        // just that the PRAGMA echoes back as 1.
+        let store = EvalStore::open_in_memory().unwrap();
+        let (_tid, cid) = setup_tournament(&store);
+        let res = store.conn.execute(
+            "INSERT INTO match_attempts
+              (tournament_id, game_config_id, player1_id, player2_id, seed,
+               repetition_index, attempt_index, status,
+               player1_score, player2_score, turns,
+               failure_reason, started_at, finished_at)
+             VALUES (?1, ?2, 'alice', 'bob', 1, 0, 0, 'success',
+                     5.0, 5.0, 100, NULL, '2026-01-01 00:00:00',
+                     '2026-01-01 00:05:00')",
+            params![99999, cid], // 99999 = no such tournament
+        );
+        assert!(
+            matches!(res, Err(rusqlite::Error::SqliteFailure(e, _)) if e.extended_code == rusqlite::ffi::SQLITE_CONSTRAINT_FOREIGNKEY),
+            "expected FOREIGNKEY violation, got {res:?}"
+        );
+    }
+
+    #[test]
+    fn tournament_players_fk_enforced() {
+        let store = EvalStore::open_in_memory().unwrap();
+        setup_players(&store);
+        // No tournament 99999 → tournament_id FK should fire.
+        let res = store.conn.execute(
+            "INSERT INTO tournament_players (tournament_id, player_id, slot)
+             VALUES (?1, ?2, 0)",
+            params![99999, "alice"],
+        );
+        assert!(
+            matches!(res, Err(rusqlite::Error::SqliteFailure(e, _)) if e.extended_code == rusqlite::ffi::SQLITE_CONSTRAINT_FOREIGNKEY),
+            "expected FOREIGNKEY violation, got {res:?}"
+        );
+    }
+
+    #[test]
     fn duplicate_attempt_key_violates_unique() {
         let store = EvalStore::open_in_memory().unwrap();
         let (tid, cid) = setup_tournament(&store);
@@ -1163,6 +1203,22 @@ mod tests {
         let attempts = store.get_attempts(tid, None).unwrap();
         assert_eq!(attempts.len(), 1);
         assert_eq!(attempts[0].key.seed, i64::MAX as u64);
+    }
+
+    #[test]
+    fn record_attempt_preserves_finished_at() {
+        // The orchestrator passes a real terminal timestamp from
+        // MatchOutcome.finished_at; the store must round-trip it bit-for-bit
+        // rather than overwriting with `datetime('now')`.
+        let store = EvalStore::open_in_memory().unwrap();
+        let (tid, cid) = setup_tournament(&store);
+        let mut attempt = success_attempt(tid, &cid, "alice", "bob", 0, 8.0, 2.0);
+        attempt.finished_at = "2026-05-06 12:34:56".into();
+        store.record_attempt(&attempt).unwrap();
+
+        let attempts = store.get_attempts(tid, None).unwrap();
+        assert_eq!(attempts.len(), 1);
+        assert_eq!(attempts[0].finished_at, "2026-05-06 12:34:56");
     }
 
     #[test]
@@ -1293,8 +1349,13 @@ mod tests {
         let attempts = store.get_attempts(tid, None).unwrap();
         let h = head_to_head_from_attempt_records(&attempts);
         assert_eq!(h.len(), 1);
-        // alice (player_a) won the only success; failure ignored.
-        assert_eq!(h[0].wins_a + h[0].wins_b + h[0].draws, 1);
+        // alice (player_a) won the only success 8.0–2.0; failure ignored.
+        // Bind each count so a regression that mis-classifies failures (e.g.
+        // counting them as draws) is caught — `wins_a + wins_b + draws == 1`
+        // would silently pass.
+        assert_eq!(h[0].wins_a, 1);
+        assert_eq!(h[0].wins_b, 0);
+        assert_eq!(h[0].draws, 0);
 
         // Store-method path: same result, one call.
         let h2 = store.head_to_head_from_attempts(tid).unwrap();
@@ -1452,7 +1513,14 @@ mod tests {
             .record_attempt(&success_attempt(tid, &cid, "alice", "bob", 0, 8.0, 2.0))
             .unwrap();
 
-        assert!(store.delete_player("alice").is_err());
+        // Bind the typed variant so a regression that swallows the FK
+        // discrimination into a generic Db error is caught.
+        match store.delete_player("alice") {
+            Err(DeletePlayerError::InTournamentHistory { tournament_ids }) => {
+                assert_eq!(tournament_ids, vec![tid]);
+            },
+            other => panic!("expected InTournamentHistory, got {other:?}"),
+        }
         store.delete_tournament(tid).unwrap();
         assert!(store.delete_player("alice").unwrap());
     }

--- a/eval/store/src/store.rs
+++ b/eval/store/src/store.rs
@@ -538,8 +538,9 @@ fn read_attempt_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AttemptRecord> 
         repetition_index: row.get(6)?,
         attempt_index: row.get(7)?,
     };
-    // The `match_attempts` CHECK guarantees the column shape per status,
-    // so the unwraps below cannot fire on a healthy DB.
+    // The `match_attempts` CHECK guarantees these reads are non-NULL on
+    // success rows; on a hand-edited DB a NULL would surface as
+    // `InvalidColumnType` from `row.get`, not a panic.
     let outcome = match status {
         AttemptStatus::Success => AttemptOutcome::Success {
             player1_score: row.get(9)?,
@@ -593,12 +594,9 @@ pub fn head_to_head_from_results(results: &[GameResultRecord]) -> Vec<HeadToHead
     }))
 }
 
-/// Same shape as [`head_to_head_from_results`], but over tournament attempt
-/// rows already loaded into memory. Failure rows are skipped — Elo is computed
-/// from successful matches only. Variant-dispatch on `outcome` makes the
-/// success-only access total.
-///
-/// For "load and aggregate from the store" in one call, see
+/// Same shape as [`head_to_head_from_results`], but over already-loaded
+/// attempt records. Failure rows are skipped (Elo is computed from successful
+/// matches only). For "load and aggregate from the store" in one call, see
 /// [`EvalStore::head_to_head_from_attempts`].
 pub fn head_to_head_from_attempt_records(attempts: &[AttemptRecord]) -> Vec<HeadToHead> {
     aggregate_pairs(attempts.iter().filter_map(|a| match &a.outcome {
@@ -684,6 +682,25 @@ mod tests {
         (tid, config_id)
     }
 
+    fn attempt_key(
+        tid: TournamentId,
+        cid: &str,
+        p1: &str,
+        p2: &str,
+        seed: u64,
+        attempt_index: u32,
+    ) -> AttemptKey {
+        AttemptKey {
+            tournament_id: tid,
+            game_config_id: cid.into(),
+            player1_id: p1.into(),
+            player2_id: p2.into(),
+            seed,
+            repetition_index: 0,
+            attempt_index,
+        }
+    }
+
     fn success_attempt(
         tid: TournamentId,
         cid: &str,
@@ -694,15 +711,7 @@ mod tests {
         s2: f64,
     ) -> NewAttempt {
         NewAttempt {
-            key: AttemptKey {
-                tournament_id: tid,
-                game_config_id: cid.into(),
-                player1_id: p1.into(),
-                player2_id: p2.into(),
-                seed: 1234,
-                repetition_index: 0,
-                attempt_index,
-            },
+            key: attempt_key(tid, cid, p1, p2, 1234, attempt_index),
             finished_at: "2026-05-06 10:05:00".into(),
             outcome: NewAttemptOutcome::Success {
                 player1_score: s1,
@@ -722,15 +731,7 @@ mod tests {
         started_at: Option<&str>,
     ) -> NewAttempt {
         NewAttempt {
-            key: AttemptKey {
-                tournament_id: tid,
-                game_config_id: cid.into(),
-                player1_id: p1.into(),
-                player2_id: p2.into(),
-                seed: 5678,
-                repetition_index: 0,
-                attempt_index,
-            },
+            key: attempt_key(tid, cid, p1, p2, 5678, attempt_index),
             finished_at: "2026-05-06 10:10:00".into(),
             outcome: NewAttemptOutcome::Failure {
                 failure_reason: "bot crash".into(),
@@ -1315,11 +1316,11 @@ mod tests {
         assert_eq!(all.len(), 2);
         let success_count = all
             .iter()
-            .filter(|a| a.status() == AttemptStatus::Success)
+            .filter(|a| matches!(a.outcome, AttemptOutcome::Success { .. }))
             .count();
         let failure_count = all
             .iter()
-            .filter(|a| a.status() == AttemptStatus::Failure)
+            .filter(|a| matches!(a.outcome, AttemptOutcome::Failure { .. }))
             .count();
         assert_eq!(success_count, 1);
         assert_eq!(failure_count, 1);
@@ -1372,9 +1373,7 @@ mod tests {
 
         let attempts = store.get_attempts(tid, None).unwrap();
         assert_eq!(attempts.len(), 1);
-        let a = &attempts[0];
-        assert_eq!(a.status(), AttemptStatus::Failure);
-        match &a.outcome {
+        match &attempts[0].outcome {
             AttemptOutcome::Failure {
                 failure_reason,
                 started_at,

--- a/eval/store/src/types.rs
+++ b/eval/store/src/types.rs
@@ -38,6 +38,25 @@ pub struct PlayerRecord {
     pub id: String,
     pub display_name: String,
     pub created_at: String,
+    /// Stable bot identifier from `bot.toml`. NULL on rows created via
+    /// `ensure_player`; populated via `register_player`.
+    pub agent_id: Option<String>,
+    pub version: Option<String>,
+    pub command: Option<String>,
+    /// Free-form planner/runner metadata as JSON. Opaque to the store.
+    pub metadata_json: Option<String>,
+}
+
+/// Identity-bearing player insert. Use this for tournament participants;
+/// `ensure_player(id, name)` remains for ad-hoc / back-compat callers.
+#[derive(Debug, Clone)]
+pub struct NewPlayer {
+    pub id: String,
+    pub display_name: String,
+    pub agent_id: Option<String>,
+    pub version: Option<String>,
+    pub command: Option<String>,
+    pub metadata_json: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -71,6 +90,120 @@ pub struct ResultFilter {
     pub before: Option<String>,
 }
 
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default,
+)]
+pub struct TournamentId(pub i64);
+
+#[derive(Debug, Clone)]
+pub struct TournamentRecord {
+    pub id: TournamentId,
+    pub format: String,
+    pub target_games_per_matchup: Option<u32>,
+    /// Opaque planner-defined config. The store does not validate this field.
+    pub params_json: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewTournament {
+    pub format: String,
+    pub target_games_per_matchup: Option<u32>,
+    pub params_json: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct TournamentParticipant {
+    pub tournament_id: TournamentId,
+    pub player_id: String,
+    pub slot: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AttemptStatus {
+    Success,
+    Failure,
+}
+
+impl AttemptStatus {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            AttemptStatus::Success => "success",
+            AttemptStatus::Failure => "failure",
+        }
+    }
+
+    pub(crate) fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "success" => Some(AttemptStatus::Success),
+            "failure" => Some(AttemptStatus::Failure),
+            _ => None,
+        }
+    }
+}
+
+/// Common identifying fields shared by both attempt variants.
+#[derive(Debug, Clone)]
+pub struct AttemptKey {
+    pub tournament_id: TournamentId,
+    pub game_config_id: String,
+    pub player1_id: String,
+    pub player2_id: String,
+    pub seed: u64,
+    pub repetition_index: u32,
+    /// Per-matchup-key retry counter chosen by the session (next free integer).
+    pub attempt_index: u32,
+}
+
+/// Input for `record_attempt`. Variant choice is the type-level guarantee
+/// that scores/turns are always set on success and never on failure.
+/// The DB has matching CHECK constraints as defense in depth.
+#[derive(Debug, Clone)]
+pub enum NewAttempt {
+    Success {
+        key: AttemptKey,
+        player1_score: f64,
+        player2_score: f64,
+        turns: u32,
+        /// SQLite datetime string (`datetime('now')` format).
+        started_at: String,
+    },
+    Failure {
+        key: AttemptKey,
+        failure_reason: String,
+        /// `None` for spawn-failures (the bot never started). `Some` for
+        /// post-start failures (timeout, crash, etc.).
+        started_at: Option<String>,
+    },
+}
+
+impl NewAttempt {
+    pub fn key(&self) -> &AttemptKey {
+        match self {
+            NewAttempt::Success { key, .. } | NewAttempt::Failure { key, .. } => key,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AttemptRecord {
+    pub id: i64,
+    pub tournament_id: TournamentId,
+    pub game_config_id: String,
+    pub player1_id: String,
+    pub player2_id: String,
+    pub seed: u64,
+    pub repetition_index: u32,
+    pub attempt_index: u32,
+    pub status: AttemptStatus,
+    pub player1_score: Option<f64>,
+    pub player2_score: Option<f64>,
+    pub turns: Option<u32>,
+    pub failure_reason: Option<String>,
+    pub started_at: Option<String>,
+    pub finished_at: String,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum EvalError {
     #[error("database error: {0}")]
@@ -78,4 +211,82 @@ pub enum EvalError {
 
     #[error("json error: {0}")]
     Json(#[from] serde_json::Error),
+}
+
+/// Tournament-context player insert errors.
+#[derive(Debug, thiserror::Error)]
+pub enum RegisterPlayerError {
+    #[error(transparent)]
+    Db(#[from] EvalError),
+
+    /// A row with this `id` exists but has different non-NULL identity fields.
+    /// The user must either bump the player id or delete the existing row.
+    #[error("player {id} already exists with conflicting identity fields: {fields:?}")]
+    IdentityConflict { id: String, fields: Vec<String> },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DeletePlayerError {
+    #[error(transparent)]
+    Db(#[from] EvalError),
+
+    /// The player is referenced by tournament rows. Delete the listed
+    /// tournaments first, or bump the player id.
+    #[error("player is referenced by tournament history (tournaments: {tournament_ids:?})")]
+    InTournamentHistory { tournament_ids: Vec<TournamentId> },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AddTournamentPlayerError {
+    #[error(transparent)]
+    Db(#[from] EvalError),
+
+    /// The player is already a participant in this tournament.
+    #[error("player {player_id} already in tournament {tournament_id:?}")]
+    PlayerAlreadyInTournament {
+        tournament_id: TournamentId,
+        player_id: String,
+    },
+
+    /// Slot is taken by a different player in this tournament.
+    #[error("slot {slot} already occupied in tournament {tournament_id:?}")]
+    SlotTaken {
+        tournament_id: TournamentId,
+        slot: i64,
+    },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RecordAttemptError {
+    #[error(transparent)]
+    Db(#[from] EvalError),
+
+    /// SQLite stores INTEGER as signed i64. Planner-derived seeds must be
+    /// masked to fit; this is a defense-in-depth check at the store boundary.
+    #[error("seed {value} exceeds i64::MAX (cannot store as SQLite INTEGER)")]
+    SeedOutOfRange { value: u64 },
+}
+
+impl From<rusqlite::Error> for RegisterPlayerError {
+    fn from(e: rusqlite::Error) -> Self {
+        RegisterPlayerError::Db(EvalError::Db(e))
+    }
+}
+
+impl From<rusqlite::Error> for DeletePlayerError {
+    fn from(e: rusqlite::Error) -> Self {
+        DeletePlayerError::Db(EvalError::Db(e))
+    }
+}
+
+impl From<rusqlite::Error> for AddTournamentPlayerError {
+    fn from(e: rusqlite::Error) -> Self {
+        AddTournamentPlayerError::Db(EvalError::Db(e))
+    }
+}
+
+impl From<rusqlite::Error> for RecordAttemptError {
+    fn from(e: rusqlite::Error) -> Self {
+        RecordAttemptError::Db(EvalError::Db(e))
+    }
 }

--- a/eval/store/src/types.rs
+++ b/eval/store/src/types.rs
@@ -155,13 +155,21 @@ pub struct AttemptKey {
     pub attempt_index: u32,
 }
 
-/// Input for `record_attempt`. Variant choice is the type-level guarantee
-/// that scores/turns are always set on success and never on failure.
-/// The DB has matching CHECK constraints as defense in depth.
+/// Input for `record_attempt`. The `outcome` variant is the type-level
+/// guarantee that scores/turns are always set on success and never on failure;
+/// the DB CHECK constraint mirrors this as defense in depth.
 #[derive(Debug, Clone)]
-pub enum NewAttempt {
+pub struct NewAttempt {
+    pub key: AttemptKey,
+    /// Caller-supplied terminal timestamp. SQLite datetime string format
+    /// (e.g. `"2026-05-06 12:34:56"`).
+    pub finished_at: String,
+    pub outcome: NewAttemptOutcome,
+}
+
+#[derive(Debug, Clone)]
+pub enum NewAttemptOutcome {
     Success {
-        key: AttemptKey,
         player1_score: f64,
         player2_score: f64,
         turns: u32,
@@ -169,20 +177,11 @@ pub enum NewAttempt {
         started_at: String,
     },
     Failure {
-        key: AttemptKey,
         failure_reason: String,
         /// `None` for spawn-failures (the bot never started). `Some` for
         /// post-start failures (timeout, crash, etc.).
         started_at: Option<String>,
     },
-}
-
-impl NewAttempt {
-    pub fn key(&self) -> &AttemptKey {
-        match self {
-            NewAttempt::Success { key, .. } | NewAttempt::Failure { key, .. } => key,
-        }
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/eval/store/src/types.rs
+++ b/eval/store/src/types.rs
@@ -187,20 +187,40 @@ pub enum NewAttemptOutcome {
 #[derive(Debug, Clone)]
 pub struct AttemptRecord {
     pub id: i64,
-    pub tournament_id: TournamentId,
-    pub game_config_id: String,
-    pub player1_id: String,
-    pub player2_id: String,
-    pub seed: u64,
-    pub repetition_index: u32,
-    pub attempt_index: u32,
-    pub status: AttemptStatus,
-    pub player1_score: Option<f64>,
-    pub player2_score: Option<f64>,
-    pub turns: Option<u32>,
-    pub failure_reason: Option<String>,
-    pub started_at: Option<String>,
+    pub key: AttemptKey,
     pub finished_at: String,
+    pub outcome: AttemptOutcome,
+}
+
+/// Read-side mirror of [`NewAttemptOutcome`]. Variant-typed reads remove
+/// the `Option<f64>` soup that the previous flat struct carried, and the
+/// `match_attempts` CHECK constraint guarantees the variant fields are
+/// non-NULL on success and NULL on failure.
+#[derive(Debug, Clone)]
+pub enum AttemptOutcome {
+    Success {
+        player1_score: f64,
+        player2_score: f64,
+        turns: u32,
+        started_at: String,
+    },
+    Failure {
+        failure_reason: String,
+        /// `None` for spawn-failures (the bot never started). `Some` for
+        /// post-start failures (timeout, crash, etc.).
+        started_at: Option<String>,
+    },
+}
+
+impl AttemptRecord {
+    /// Convenience accessor over `outcome`. Lets callers filter / count by
+    /// status without destructuring the enum.
+    pub fn status(&self) -> AttemptStatus {
+        match self.outcome {
+            AttemptOutcome::Success { .. } => AttemptStatus::Success,
+            AttemptOutcome::Failure { .. } => AttemptStatus::Failure,
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/eval/store/src/types.rs
+++ b/eval/store/src/types.rs
@@ -284,6 +284,13 @@ pub enum RecordAttemptError {
     /// masked to fit; this is a defense-in-depth check at the store boundary.
     #[error("seed {value} exceeds i64::MAX (cannot store as SQLite INTEGER)")]
     SeedOutOfRange { value: u64 },
+
+    /// An attempt with this `(tournament, game_config, p1, p2,
+    /// repetition_index, attempt_index)` already exists. Typically signals a
+    /// planner bug (wrong `attempt_index`) or a resume race; the caller can
+    /// pick the next free index from the in-memory matchup history and retry.
+    #[error("attempt already exists for this matchup key")]
+    AttemptAlreadyExists { key: AttemptKey },
 }
 
 impl From<rusqlite::Error> for RegisterPlayerError {

--- a/eval/store/src/types.rs
+++ b/eval/store/src/types.rs
@@ -212,17 +212,6 @@ pub enum AttemptOutcome {
     },
 }
 
-impl AttemptRecord {
-    /// Convenience accessor over `outcome`. Lets callers filter / count by
-    /// status without destructuring the enum.
-    pub fn status(&self) -> AttemptStatus {
-        match self.outcome {
-            AttemptOutcome::Success { .. } => AttemptStatus::Success,
-            AttemptOutcome::Failure { .. } => AttemptStatus::Failure,
-        }
-    }
-}
-
 #[derive(Debug, thiserror::Error)]
 pub enum EvalError {
     #[error("database error: {0}")]


### PR DESCRIPTION
## Motivation

The orchestrator's session and planner (next PR) needs to durably record tournament-context match outcomes, distinguish retry-collisions from connection blips, and recover deterministically across restarts. Today's `pyrat-eval-store` only has ad-hoc `game_results`. Tournaments need their own ledger with stricter invariants.

Building the planner against an opaque or under-constrained store means re-deriving the same rules upstream (and getting them wrong somewhere). The goal is to land the boring invariants now, so the planner can build on top without coordinating.

## Solution

### Schema migration v2

The store now runs through a `PRAGMA user_version`-driven migration loop, each migration in its own transaction. Migration 1 is the existing schema (with `IF NOT EXISTS` so it's a no-op on existing DBs). Migration 2 adds the tournament tables.

New tables: `tournaments`, `tournament_players`, `match_attempts`. The `match_attempts` row is self-describing via a symmetric CHECK:

```sql
CHECK (
    (status = 'success' AND player1_score IS NOT NULL
                        AND player2_score IS NOT NULL
                        AND turns          IS NOT NULL
                        AND failure_reason IS NULL
                        AND started_at     IS NOT NULL)
 OR (status = 'failure' AND failure_reason IS NOT NULL
                        AND player1_score  IS NULL
                        AND player2_score  IS NULL
                        AND turns          IS NULL)
)
```

FK semantics differ by ledger. `game_results.player{1,2}_id` keeps `ON DELETE CASCADE`. Tournament-context refs to players (`tournament_players.player_id`, `match_attempts.player{1,2}_id`) are `ON DELETE RESTRICT`. The escape hatch is `delete_tournament(id)`, which cascades the children. Players survive both paths.

`PRAGMA foreign_keys=ON` is set per-connection. Rusqlite's default is OFF; without this the FK actions are silently inert.

### Typed write and read API

Write side and read side share the same shape. The `outcome` enum carries the variant-specific fields; `key` and `finished_at` live on the outer struct.

```rust
pub struct NewAttempt {
    pub key: AttemptKey,
    pub finished_at: String,
    pub outcome: NewAttemptOutcome,
}

pub enum NewAttemptOutcome {
    Success { player1_score, player2_score, turns, started_at },
    Failure { failure_reason, started_at: Option<String> },
}

pub struct AttemptRecord {
    pub id: i64,
    pub key: AttemptKey,
    pub finished_at: String,
    pub outcome: AttemptOutcome,
}
```

`finished_at` is caller-supplied. The orchestrator sink will pass `MatchOutcome.finished_at` and `MatchFailure.failed_at`; the column no longer overrides with `datetime('now')`.

Variant-typed reads remove the `Option<f64>` soup the previous flat `AttemptRecord` carried. `head_to_head_from_attempts` is now total: no `.expect("success rows have scores")`, just a `match &a.outcome`.

### Typed errors with caller-actionable payloads

```rust
RegisterPlayerError::IdentityConflict { id, fields: Vec<String> }
DeletePlayerError::InTournamentHistory { tournament_ids: Vec<TournamentId> }
AddTournamentPlayerError::PlayerAlreadyInTournament { tournament_id, player_id }
AddTournamentPlayerError::SlotTaken { tournament_id, slot }
RecordAttemptError::SeedOutOfRange { value: u64 }
RecordAttemptError::AttemptAlreadyExists { key: AttemptKey }
```

Each variant is something the caller can act on. `IdentityConflict` lists the conflicting field names so the user can decide whether to bump the player id or update the row. `InTournamentHistory` lists the blocking tournament ids. `AttemptAlreadyExists` is a typed remap of `SQLITE_CONSTRAINT_UNIQUE`, so the planner can distinguish "I picked the wrong attempt_index" from "the connection blipped" without parsing nested rusqlite enums.

A player is a specific rated *version* of a bot. Silent re-pointing of an id (the upsert temptation) would retroactively rewrite all prior tournament rows for that id, so `register_player` is insert-or-error-on-conflict. `ensure_player(id, name)` stays as the back-compat path for ad-hoc callers; tournament code uses `register_player`.

### Two H2H entry points

```rust
// Standard public path: load + aggregate in one call.
EvalStore::head_to_head_from_attempts(tournament_id) -> Result<Vec<HeadToHead>, EvalError>

// For callers already holding the records (planner's in-memory MatchupHistory).
head_to_head_from_attempt_records(&[AttemptRecord]) -> Vec<HeadToHead>
```

Both filter to `status='success'`. Failures are skipped because Elo is computed from successful matches only.

## Test Plan

```
cargo test -p pyrat-eval-store          # 89 tests pass (52 elo + 37 store)
cargo fmt --all -- --check              # clean
cargo clippy -p pyrat-eval-store --all-targets -- -D warnings  # clean
```

New behavioral coverage worth calling out:

- `match_attempts_fk_enforced` and `tournament_players_fk_enforced`: prove the FK actions fire on the new tables (stronger than the PRAGMA echo).
- `record_attempt_preserves_finished_at`: caller-supplied timestamp round-trips bit-for-bit.
- `check_rejects_malformed_success_row` and `_failure_row`: bypass the typed API and confirm the DB CHECK is the last line of defense.
- `migration_fresh_db_ends_at_user_version_2`, `migration_upgrades_handbuilt_v0_db`, `migration_idempotent_on_second_run`: migration runner correctness on fresh, hand-built v0, and rerun cases.
- `add_tournament_player_distinct_conflict_errors`: PK vs UNIQUE conflicts surface as distinct typed variants.
- `delete_tournament_unblocks_delete_player`: the RESTRICT escape hatch works as documented.
- `register_player_conflict_fill_idempotent`: all three paths (conflict, no-op, NULL-fill on a row created via `ensure_player`).