### PR TITLE
Add pyrat-eval session crate: planner, store sink, run loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3009,6 +3009,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyrat-eval"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "parking_lot",
+ "pyrat-bot-api",
+ "pyrat-eval-store",
+ "pyrat-host",
+ "pyrat-orchestrator",
+ "pyrat-protocol",
+ "pyrat-rust",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "pyrat-eval-store"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["engine", "engine/extension", "server/headless", "server/host", "server/protocol", "server/wire", "interface", "sdk/bot-api", "sdk/python", "sdk/rust", "sdk/rust/derive", "gui/src-tauri", "tools/bot-check", "eval/store", "eval/orchestrator"]
+members = ["engine", "engine/extension", "server/headless", "server/host", "server/protocol", "server/wire", "interface", "sdk/bot-api", "sdk/python", "sdk/rust", "sdk/rust/derive", "gui/src-tauri", "tools/bot-check", "eval/store", "eval/orchestrator", "eval/session"]
 resolver = "2"
 
 [workspace.lints.clippy]

--- a/eval/session/Cargo.toml
+++ b/eval/session/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "pyrat-eval"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+pyrat-orchestrator = { path = "../orchestrator" }
+pyrat-eval-store = { path = "../store" }
+pyrat-host = { path = "../../server/host" }
+pyrat-rust = { path = "../../engine", default-features = false }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
+tokio-util = { version = "0.7", features = ["rt"] }
+async-trait = "0.1"
+thiserror = "2"
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+parking_lot = "0.12"
+sha2 = "0.10"
+tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
+tempfile = "3"
+pyrat-bot-api = { path = "../../sdk/bot-api" }
+pyrat-protocol = { path = "../../server/protocol" }

--- a/eval/session/src/descriptor.rs
+++ b/eval/session/src/descriptor.rs
@@ -1,0 +1,75 @@
+//! Per-match identity for tournament-context evaluation.
+//!
+//! `EvalMatchDescriptor` is the eval-layer descriptor: it carries the
+//! tournament id, the planner's matchup identity, and the attempt index.
+//! Sinks correlate durable rows by these fields. The orchestrator only
+//! reads `match_id` and `seed` (via the `Descriptor` trait).
+
+use std::time::SystemTime;
+
+use pyrat_eval_store::TournamentId;
+use pyrat_orchestrator::{Descriptor, MatchId};
+use serde::{Deserialize, Serialize};
+
+/// Identity for one tournament-context match.
+///
+/// Every field is durable: a row in `match_attempts` is keyed by
+/// `(tournament_id, game_config_id, player1_id, player2_id, repetition_index,
+/// attempt_index)`, with `seed` recorded for forensics. Resume reconstructs
+/// state by reading these rows back.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EvalMatchDescriptor {
+    pub match_id: MatchId,
+    pub tournament_id: TournamentId,
+    pub game_config_id: String,
+    pub player1_id: String,
+    pub player2_id: String,
+    pub seed: u64,
+    pub repetition_index: u32,
+    pub attempt_index: u32,
+    pub planned_at: SystemTime,
+}
+
+impl Descriptor for EvalMatchDescriptor {
+    fn match_id(&self) -> MatchId {
+        self.match_id
+    }
+
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> EvalMatchDescriptor {
+        EvalMatchDescriptor {
+            match_id: MatchId(42),
+            tournament_id: TournamentId(7),
+            game_config_id: "abc123".into(),
+            player1_id: "pyrat/greedy".into(),
+            player2_id: "pyrat/search".into(),
+            seed: 0x0123_4567_89AB_CDEF,
+            repetition_index: 1,
+            attempt_index: 2,
+            planned_at: SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000),
+        }
+    }
+
+    #[test]
+    fn roundtrips_through_serde_json() {
+        let desc = sample();
+        let s = serde_json::to_string(&desc).unwrap();
+        let back: EvalMatchDescriptor = serde_json::from_str(&s).unwrap();
+        assert_eq!(desc, back);
+    }
+
+    #[test]
+    fn descriptor_trait_returns_stored_match_id_and_seed() {
+        let desc = sample();
+        assert_eq!(desc.match_id(), MatchId(42));
+        assert_eq!(desc.seed(), 0x0123_4567_89AB_CDEF);
+    }
+}

--- a/eval/session/src/lib.rs
+++ b/eval/session/src/lib.rs
@@ -1,0 +1,39 @@
+//! Domain layer that wires planner + orchestrator + store.
+//!
+//! Three responsibilities:
+//! - **Planner trait + impls** — round-robin, gauntlet. Decides which
+//!   matchups to issue based on `TournamentState.history`. Never touches the
+//!   store.
+//! - **Store sink** — `MatchSink<EvalMatchDescriptor>` that writes
+//!   `match_attempts` rows on terminal callbacks. Skips writes for
+//!   `failure.durable_record == false` (kill-9 / sink flush failure) so
+//!   runtime state stays byte-equivalent to the durable record.
+//! - **Session** — drives the orchestrator-planner loop, owns the lossless
+//!   `DriverEvent` mpsc, exposes `state()` (eval-layer watch over
+//!   `TournamentState`) and `live_events()` (pass-through to the orchestrator
+//!   broadcast for per-turn UI consumers).
+
+pub mod descriptor;
+pub mod mapping;
+pub mod observation;
+pub mod plan;
+pub mod session;
+pub mod state;
+pub mod store_sink;
+
+pub use descriptor::EvalMatchDescriptor;
+pub use mapping::{
+    failure_reason_string, failure_to_new_attempt, format_sqlite_datetime, game_config_to_record,
+    outcome_to_new_attempt, MappingError,
+};
+pub use observation::Observation;
+pub use plan::{
+    matchup_seed, GauntletPlanner, GauntletPlannerConfig, Planner, ResolvedPlayer,
+    RoundRobinPlanner, RoundRobinPlannerConfig,
+};
+pub use session::{EvalSession, SessionError, SessionEvent, SessionMode, TournamentSpec};
+pub use state::{
+    GameConfigId, MatchupAttempt, MatchupHistory, MatchupKey, MatchupOutcome, PlayerId,
+    TournamentState,
+};
+pub use store_sink::{StoreSink, StoreSinkError};

--- a/eval/session/src/lib.rs
+++ b/eval/session/src/lib.rs
@@ -31,7 +31,9 @@ pub use plan::{
     matchup_seed, GauntletPlanner, GauntletPlannerConfig, Planner, ResolvedPlayer,
     RoundRobinPlanner, RoundRobinPlannerConfig,
 };
-pub use session::{EvalSession, SessionError, SessionEvent, SessionMode, TournamentSpec};
+pub use session::{
+    CreatedTournament, EvalSession, SessionError, SessionEvent, SessionMode, TournamentSpec,
+};
 pub use state::{
     GameConfigId, MatchupAttempt, MatchupHistory, MatchupKey, MatchupOutcome, PlayerId,
     TournamentState,

--- a/eval/session/src/lib.rs
+++ b/eval/session/src/lib.rs
@@ -32,7 +32,8 @@ pub use plan::{
     RoundRobinPlanner, RoundRobinPlannerConfig,
 };
 pub use session::{
-    CreatedTournament, EvalSession, SessionError, SessionEvent, SessionMode, TournamentSpec,
+    CreatedTournament, EvalSession, SessionConfig, SessionError, SessionEvent, SessionMode,
+    TournamentSpec,
 };
 pub use state::{
     GameConfigId, MatchupAttempt, MatchupHistory, MatchupKey, MatchupOutcome, PlayerId,

--- a/eval/session/src/mapping.rs
+++ b/eval/session/src/mapping.rs
@@ -120,10 +120,12 @@ pub fn failure_reason_string(reason: &FailureReason) -> String {
         FailureReason::Cancelled => "cancelled".into(),
         FailureReason::SinkFlushError(s) => format!("sink_flush_error: {s}"),
         FailureReason::Internal(s) => format!("internal: {s}"),
-        // FailureReason is `#[non_exhaustive]`. Future variants land here as
-        // an explicit "unknown" rather than a panic so lifecycle records
-        // never get blocked on an upstream addition.
-        _ => "unknown".into(),
+        // FailureReason is `#[non_exhaustive]`. Future variants land here
+        // as a Debug repr (rather than a flat "unknown") so two new
+        // variants stay distinguishable for triage. The string is less
+        // stable to grep against — accept that tradeoff in exchange for
+        // preserving variant identity.
+        _ => format!("unknown: {reason:?}"),
     }
 }
 
@@ -165,7 +167,10 @@ fn days_to_ymd(days: u64) -> (i64, u32, u32) {
 /// Compose a tournament_id-scoped `NewAttempt` for a synthetic / test row.
 /// Not used in the live session path (which uses
 /// [`outcome_to_new_attempt`] / [`failure_to_new_attempt`]); useful inside
-/// tests that need to plant rows directly into the store.
+/// tests that need to plant rows directly into the store. `pub` so
+/// integration tests (external crates) can call it; `#[doc(hidden)]` to
+/// keep it out of generated docs and the apparent public API.
+#[doc(hidden)]
 #[allow(clippy::too_many_arguments)]
 pub fn synthetic_attempt(
     tournament_id: TournamentId,

--- a/eval/session/src/mapping.rs
+++ b/eval/session/src/mapping.rs
@@ -1,0 +1,326 @@
+//! Type-conversion glue between the orchestrator/host shapes and the store
+//! shapes. Centralised here so the smear-risk fields (timestamps, scores,
+//! failure reasons, game-config flattening) live in one place.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use pyrat::game::builder::{CheeseStrategy, GameConfig, MazeStrategy};
+use pyrat_eval_store::{
+    AttemptKey, GameConfigRecord, NewAttempt, NewAttemptOutcome, RecordAttemptError, TournamentId,
+};
+use pyrat_orchestrator::{FailureReason, MatchFailure, MatchOutcome};
+
+use crate::descriptor::EvalMatchDescriptor;
+
+/// Errors when an orchestrator-side value can't be projected to a store
+/// shape. Currently the only non-trivial case is `GameConfig` carrying a
+/// strategy variant the store schema cannot represent (custom walls or
+/// custom cheese positions).
+#[derive(Debug, thiserror::Error)]
+pub enum MappingError {
+    #[error("game config uses fixed-walls maze strategy; eval-store schema only represents random mazes")]
+    FixedMazeUnsupported,
+
+    #[error("game config uses fixed-positions cheese strategy; eval-store schema only represents random cheese")]
+    FixedCheeseUnsupported,
+
+    #[error("record_attempt failed: {0}")]
+    RecordAttempt(#[from] RecordAttemptError),
+}
+
+/// Project a runtime `GameConfig` to its durable record shape.
+///
+/// The store schema only represents random-mazes + random-cheese
+/// configurations; fixed (custom) layouts return an error. Custom layouts
+/// can be supported later by extending `GameConfigRecord` (e.g. a
+/// `wall_layout_hash` field), out of scope for v1.
+pub fn game_config_to_record(cfg: &GameConfig) -> Result<GameConfigRecord, MappingError> {
+    let (wall_density, mud_density, mud_range, connected, symmetric) = match cfg.maze() {
+        MazeStrategy::Random(p) => (
+            f64::from(p.wall_density),
+            f64::from(p.mud_density),
+            u32::from(p.mud_range),
+            p.connected,
+            p.symmetric,
+        ),
+        MazeStrategy::Fixed { .. } => return Err(MappingError::FixedMazeUnsupported),
+    };
+    let (cheese_count, cheese_symmetric) = match cfg.cheese() {
+        CheeseStrategy::Random { count, symmetric } => (u32::from(*count), *symmetric),
+        CheeseStrategy::Fixed(_) => return Err(MappingError::FixedCheeseUnsupported),
+    };
+    Ok(GameConfigRecord {
+        width: u32::from(cfg.width()),
+        height: u32::from(cfg.height()),
+        max_turns: u32::from(cfg.max_turns()),
+        wall_density,
+        mud_density,
+        mud_range,
+        connected,
+        symmetric,
+        cheese_count,
+        cheese_symmetric,
+    })
+}
+
+/// Project a successful `MatchOutcome` to a `NewAttempt` ready for
+/// `record_attempt`.
+pub fn outcome_to_new_attempt(outcome: &MatchOutcome<EvalMatchDescriptor>) -> NewAttempt {
+    let desc = &outcome.descriptor;
+    NewAttempt {
+        key: attempt_key(desc),
+        finished_at: format_sqlite_datetime(outcome.finished_at),
+        outcome: NewAttemptOutcome::Success {
+            player1_score: f64::from(outcome.result.player1_score),
+            player2_score: f64::from(outcome.result.player2_score),
+            turns: u32::from(outcome.result.turns_played),
+            started_at: format_sqlite_datetime(outcome.started_at),
+        },
+    }
+}
+
+/// Project a `MatchFailure` to a `NewAttempt`. Caller is responsible for
+/// only invoking this when `failure.durable_record == true`.
+pub fn failure_to_new_attempt(failure: &MatchFailure<EvalMatchDescriptor>) -> NewAttempt {
+    let desc = &failure.descriptor;
+    NewAttempt {
+        key: attempt_key(desc),
+        finished_at: format_sqlite_datetime(failure.failed_at),
+        outcome: NewAttemptOutcome::Failure {
+            failure_reason: failure_reason_string(&failure.reason),
+            started_at: failure.started_at.map(format_sqlite_datetime),
+        },
+    }
+}
+
+fn attempt_key(desc: &EvalMatchDescriptor) -> AttemptKey {
+    AttemptKey {
+        tournament_id: desc.tournament_id,
+        game_config_id: desc.game_config_id.clone(),
+        player1_id: desc.player1_id.clone(),
+        player2_id: desc.player2_id.clone(),
+        seed: desc.seed,
+        repetition_index: desc.repetition_index,
+        attempt_index: desc.attempt_index,
+    }
+}
+
+/// Stable string label for a `FailureReason`. Stored in `match_attempts.failure_reason`.
+///
+/// Format: `"<category>"` for unit variants, `"<category>: <payload>"` for
+/// payload-bearing ones. Stable across releases — planners may grep this
+/// column to triage.
+pub fn failure_reason_string(reason: &FailureReason) -> String {
+    match reason {
+        FailureReason::SpawnFailed => "spawn_failed".into(),
+        FailureReason::HandshakeTimeout => "handshake_timeout".into(),
+        FailureReason::Disconnected(slot) => format!("disconnected: {slot:?}"),
+        FailureReason::ProtocolError(s) => format!("protocol_error: {s}"),
+        FailureReason::Panic => "panic".into(),
+        FailureReason::Cancelled => "cancelled".into(),
+        FailureReason::SinkFlushError(s) => format!("sink_flush_error: {s}"),
+        FailureReason::Internal(s) => format!("internal: {s}"),
+        // FailureReason is `#[non_exhaustive]`. Future variants land here as
+        // an explicit "unknown" rather than a panic so lifecycle records
+        // never get blocked on an upstream addition.
+        _ => "unknown".into(),
+    }
+}
+
+/// SQLite-friendly UTC datetime: `"YYYY-MM-DD HH:MM:SS"`.
+///
+/// Mirrors what `datetime('now')` produces server-side. Computed inline
+/// (Howard Hinnant's days→date algorithm) to avoid pulling in `time` /
+/// `chrono`. Pre-1970 timestamps clamp to UNIX_EPOCH.
+pub fn format_sqlite_datetime(t: SystemTime) -> String {
+    let secs = t
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let days = secs / 86_400;
+    let secs_today = secs % 86_400;
+    let hour = secs_today / 3600;
+    let minute = (secs_today % 3600) / 60;
+    let second = secs_today % 60;
+    let (year, month, day) = days_to_ymd(days);
+    format!("{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02}")
+}
+
+/// Howard Hinnant's `civil_from_days` for 1970-01-01-based day counts.
+/// <https://howardhinnant.github.io/date_algorithms.html#civil_from_days>
+fn days_to_ymd(days: u64) -> (i64, u32, u32) {
+    let z = days as i64 + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y_within = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year = if month <= 2 { y_within + 1 } else { y_within };
+    (year, month as u32, day as u32)
+}
+
+/// Compose a tournament_id-scoped `NewAttempt` for a synthetic / test row.
+/// Not used in the live session path (which uses
+/// [`outcome_to_new_attempt`] / [`failure_to_new_attempt`]); useful inside
+/// tests that need to plant rows directly into the store.
+#[allow(clippy::too_many_arguments)]
+pub fn synthetic_attempt(
+    tournament_id: TournamentId,
+    game_config_id: &str,
+    player1_id: &str,
+    player2_id: &str,
+    seed: u64,
+    repetition_index: u32,
+    attempt_index: u32,
+    finished_at: &str,
+    outcome: NewAttemptOutcome,
+) -> NewAttempt {
+    NewAttempt {
+        key: AttemptKey {
+            tournament_id,
+            game_config_id: game_config_id.into(),
+            player1_id: player1_id.into(),
+            player2_id: player2_id.into(),
+            seed,
+            repetition_index,
+            attempt_index,
+        },
+        finished_at: finished_at.into(),
+        outcome,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use pyrat_host::match_host::MatchResult;
+    use pyrat_host::player::PlayerIdentity;
+    use pyrat_host::wire::{GameResult, Player};
+    use pyrat_orchestrator::MatchId;
+
+    use super::*;
+
+    fn descriptor() -> EvalMatchDescriptor {
+        EvalMatchDescriptor {
+            match_id: MatchId(1),
+            tournament_id: TournamentId(1),
+            game_config_id: "gc".into(),
+            player1_id: "a".into(),
+            player2_id: "b".into(),
+            seed: 7,
+            repetition_index: 0,
+            attempt_index: 0,
+            planned_at: SystemTime::UNIX_EPOCH,
+        }
+    }
+
+    fn identity(slot: Player) -> PlayerIdentity {
+        PlayerIdentity {
+            name: "x".into(),
+            author: "x".into(),
+            agent_id: "x".into(),
+            slot,
+        }
+    }
+
+    #[test]
+    fn classic_game_config_maps_to_record() {
+        let cfg = GameConfig::classic(7, 5, 3);
+        let rec = game_config_to_record(&cfg).unwrap();
+        assert_eq!(rec.width, 7);
+        assert_eq!(rec.height, 5);
+        assert_eq!(rec.cheese_count, 3);
+        assert!(rec.cheese_symmetric);
+        assert!(rec.connected);
+        assert!(rec.symmetric);
+    }
+
+    /// Pin the SQLite-format string for a few known instants. The values
+    /// here come from cross-checking with `python -c "import datetime;
+    /// print(datetime.datetime.utcfromtimestamp(N))"`.
+    #[test]
+    fn format_sqlite_datetime_matches_known_instants() {
+        // 2024-02-29 (leap day) 00:00:00 UTC
+        let t = UNIX_EPOCH + Duration::from_secs(1_709_164_800);
+        assert_eq!(format_sqlite_datetime(t), "2024-02-29 00:00:00");
+        // 2026-05-08 12:34:56 UTC
+        let t = UNIX_EPOCH + Duration::from_secs(1_778_243_696);
+        assert_eq!(format_sqlite_datetime(t), "2026-05-08 12:34:56");
+        // 2000-03-01 00:00:00 UTC (post leap day, exercises Hinnant's mp branch)
+        let t = UNIX_EPOCH + Duration::from_secs(951_868_800);
+        assert_eq!(format_sqlite_datetime(t), "2000-03-01 00:00:00");
+    }
+
+    /// Epoch boundary: 1970-01-01 00:00:00.
+    #[test]
+    fn format_sqlite_datetime_handles_epoch() {
+        assert_eq!(format_sqlite_datetime(UNIX_EPOCH), "1970-01-01 00:00:00");
+    }
+
+    #[test]
+    fn outcome_maps_to_new_attempt_success() {
+        let out = MatchOutcome {
+            descriptor: descriptor(),
+            started_at: UNIX_EPOCH + Duration::from_secs(100),
+            finished_at: UNIX_EPOCH + Duration::from_secs(200),
+            result: MatchResult {
+                result: GameResult::Player1,
+                player1_score: 5.0,
+                player2_score: 3.0,
+                turns_played: 50,
+            },
+            players: [identity(Player::Player1), identity(Player::Player2)],
+        };
+        let attempt = outcome_to_new_attempt(&out);
+        assert_eq!(attempt.key.tournament_id, TournamentId(1));
+        assert_eq!(attempt.key.attempt_index, 0);
+        assert_eq!(attempt.finished_at, "1970-01-01 00:03:20");
+        match attempt.outcome {
+            NewAttemptOutcome::Success {
+                player1_score,
+                player2_score,
+                turns,
+                started_at,
+            } => {
+                assert!((player1_score - 5.0).abs() < 1e-9);
+                assert!((player2_score - 3.0).abs() < 1e-9);
+                assert_eq!(turns, 50);
+                assert_eq!(started_at, "1970-01-01 00:01:40");
+            },
+            NewAttemptOutcome::Failure { .. } => panic!("expected Success outcome"),
+        }
+    }
+
+    #[test]
+    fn failure_maps_to_new_attempt_with_reason_string() {
+        let fail = MatchFailure {
+            descriptor: descriptor(),
+            started_at: None,
+            failed_at: UNIX_EPOCH + Duration::from_secs(50),
+            reason: FailureReason::SpawnFailed,
+            players: None,
+            durable_record: true,
+        };
+        let attempt = failure_to_new_attempt(&fail);
+        match attempt.outcome {
+            NewAttemptOutcome::Failure {
+                failure_reason,
+                started_at,
+            } => {
+                assert_eq!(failure_reason, "spawn_failed");
+                assert!(started_at.is_none());
+            },
+            NewAttemptOutcome::Success { .. } => panic!("expected Failure outcome"),
+        }
+    }
+
+    #[test]
+    fn failure_reason_string_includes_payload() {
+        let s = failure_reason_string(&FailureReason::ProtocolError("timeout: setup".into()));
+        assert_eq!(s, "protocol_error: timeout: setup");
+    }
+}

--- a/eval/session/src/observation.rs
+++ b/eval/session/src/observation.rs
@@ -1,0 +1,65 @@
+//! Lifecycle observation handed to the planner.
+//!
+//! `DriverEvent` carries orchestrator-shaped fields (`PlayerIdentity`, full
+//! `MatchOutcome` and `MatchFailure`). The planner only needs descriptor +
+//! durability, so we project to a slimmer type at the session boundary.
+
+use pyrat_orchestrator::{DriverEvent, FailureReason};
+
+use crate::descriptor::EvalMatchDescriptor;
+
+#[derive(Debug, Clone)]
+pub enum Observation {
+    Queued {
+        descriptor: EvalMatchDescriptor,
+    },
+    Started {
+        descriptor: EvalMatchDescriptor,
+    },
+    Finished {
+        descriptor: EvalMatchDescriptor,
+    },
+    Failed {
+        descriptor: EvalMatchDescriptor,
+        durable_record: bool,
+        reason: FailureReason,
+    },
+}
+
+impl Observation {
+    pub fn descriptor(&self) -> &EvalMatchDescriptor {
+        match self {
+            Self::Queued { descriptor }
+            | Self::Started { descriptor }
+            | Self::Finished { descriptor }
+            | Self::Failed { descriptor, .. } => descriptor,
+        }
+    }
+}
+
+impl Observation {
+    /// Project a `DriverEvent` to the planner-facing observation. Returns
+    /// `None` for variants this crate doesn't yet recognise (forward-compat
+    /// hatch — `DriverEvent` is `#[non_exhaustive]`). Callers should log and
+    /// skip; silently treating unknown variants as state-mutating events
+    /// would risk planner/state drift.
+    pub fn from_driver_event(event: &DriverEvent<EvalMatchDescriptor>) -> Option<Self> {
+        match event {
+            DriverEvent::MatchQueued { descriptor, .. } => Some(Observation::Queued {
+                descriptor: descriptor.clone(),
+            }),
+            DriverEvent::MatchStarted { descriptor, .. } => Some(Observation::Started {
+                descriptor: descriptor.clone(),
+            }),
+            DriverEvent::MatchFinished { outcome } => Some(Observation::Finished {
+                descriptor: outcome.descriptor.clone(),
+            }),
+            DriverEvent::MatchFailed { failure } => Some(Observation::Failed {
+                descriptor: failure.descriptor.clone(),
+                durable_record: failure.durable_record,
+                reason: failure.reason.clone(),
+            }),
+            _ => None,
+        }
+    }
+}

--- a/eval/session/src/plan.rs
+++ b/eval/session/src/plan.rs
@@ -112,8 +112,10 @@ pub trait Planner: Send {
     fn expected_tournament_seed(&self) -> u64;
 
     /// `target_games_per_matchup` if the planner has one, else `None`.
-    /// Round-robin returns `Some(target_per_pair)`; gauntlet doesn't have
-    /// a per-pair target so it returns `None`.
+    /// Round-robin returns `Some(target_per_pair)`; gauntlet surfaces
+    /// `Some(target_each)` (the per-opponent count has the same semantic
+    /// shape as round-robin's per-pair target, so resume's cross-check
+    /// can treat them uniformly).
     fn expected_target_per_pair(&self) -> Option<u32>;
 
     /// String tag identifying the planner format, compared against the

--- a/eval/session/src/plan.rs
+++ b/eval/session/src/plan.rs
@@ -115,6 +115,13 @@ pub trait Planner: Send {
     /// Round-robin returns `Some(target_per_pair)`; gauntlet doesn't have
     /// a per-pair target so it returns `None`.
     fn expected_target_per_pair(&self) -> Option<u32>;
+
+    /// String tag identifying the planner format, compared against the
+    /// stored `tournaments.format` on resume. Without this check, a
+    /// `GauntletPlanner` whose `expected_players()` happens to slot-match
+    /// a `round_robin` tournament's participants would pass validation
+    /// and silently skip the opponent-vs-opponent pairings.
+    fn expected_format(&self) -> &str;
 }
 
 // ---------------------------------------------------------------------------
@@ -232,6 +239,10 @@ impl Planner for RoundRobinPlanner {
     fn expected_target_per_pair(&self) -> Option<u32> {
         Some(self.config.target_per_pair)
     }
+
+    fn expected_format(&self) -> &str {
+        "round_robin"
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -348,6 +359,10 @@ impl Planner for GauntletPlanner {
         // consistency with the resume cross-check.
         Some(self.config.target_each)
     }
+
+    fn expected_format(&self) -> &str {
+        "gauntlet"
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -448,8 +463,8 @@ fn build_slot(
 
     let seed = matchup_seed(
         ctx.tournament_seed,
-        &key.player1_id,
-        &key.player2_id,
+        key.player1_id(),
+        key.player2_id(),
         ctx.game_config_id,
         repetition_index,
     );
@@ -457,8 +472,8 @@ fn build_slot(
         match_id: allocate_match_id(),
         tournament_id: ctx.tournament_id,
         game_config_id: ctx.game_config_id.to_owned(),
-        player1_id: key.player1_id.clone(),
-        player2_id: key.player2_id.clone(),
+        player1_id: key.player1_id().to_owned(),
+        player2_id: key.player2_id().to_owned(),
         seed,
         repetition_index,
         attempt_index,

--- a/eval/session/src/plan.rs
+++ b/eval/session/src/plan.rs
@@ -91,6 +91,30 @@ pub trait Planner: Send {
     /// capacity. Tournament terminates when this returns true and no
     /// matches are in flight.
     fn is_done(&self, state: &TournamentState) -> bool;
+
+    /// Tournament this planner is configured to drive. `EvalSession::start`
+    /// cross-checks this against the resumed `TournamentId` so a caller
+    /// can't accidentally point a planner at the wrong tournament.
+    fn tournament_id(&self) -> TournamentId;
+
+    /// Player ids in slot order. Compared against the stored
+    /// `tournament_players` rows on resume.
+    fn expected_players(&self) -> Vec<&str>;
+
+    /// Content-hash id of the game config this planner uses. Compared
+    /// against the stored `tournaments.game_config_id` on resume.
+    fn expected_game_config_id(&self) -> &str;
+
+    /// Tournament-level seed driving `matchup_seed`. Compared against the
+    /// stored `tournaments.tournament_seed` on resume. Two resumes with
+    /// different seeds would replay different games and silently fragment
+    /// the tournament.
+    fn expected_tournament_seed(&self) -> u64;
+
+    /// `target_games_per_matchup` if the planner has one, else `None`.
+    /// Round-robin returns `Some(target_per_pair)`; gauntlet doesn't have
+    /// a per-pair target so it returns `None`.
+    fn expected_target_per_pair(&self) -> Option<u32>;
 }
 
 // ---------------------------------------------------------------------------
@@ -188,6 +212,26 @@ impl Planner for RoundRobinPlanner {
             })
         })
     }
+
+    fn tournament_id(&self) -> TournamentId {
+        self.config.tournament_id
+    }
+
+    fn expected_players(&self) -> Vec<&str> {
+        self.config.players.iter().map(|p| p.id.as_str()).collect()
+    }
+
+    fn expected_game_config_id(&self) -> &str {
+        &self.config.game_config_id
+    }
+
+    fn expected_tournament_seed(&self) -> u64 {
+        self.config.tournament_seed
+    }
+
+    fn expected_target_per_pair(&self) -> Option<u32> {
+        Some(self.config.target_per_pair)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -277,6 +321,32 @@ impl Planner for GauntletPlanner {
                         .unwrap_or(false)
             })
         })
+    }
+
+    fn tournament_id(&self) -> TournamentId {
+        self.config.tournament_id
+    }
+
+    fn expected_players(&self) -> Vec<&str> {
+        // Slot 0 is the challenger; opponents follow in declaration order.
+        std::iter::once(self.config.challenger.id.as_str())
+            .chain(self.config.opponents.iter().map(|p| p.id.as_str()))
+            .collect()
+    }
+
+    fn expected_game_config_id(&self) -> &str {
+        &self.config.game_config_id
+    }
+
+    fn expected_tournament_seed(&self) -> u64 {
+        self.config.tournament_seed
+    }
+
+    fn expected_target_per_pair(&self) -> Option<u32> {
+        // Gauntlet's "target_each" is per opponent — same semantic shape
+        // as round-robin's target_per_pair, so we surface it here for
+        // consistency with the resume cross-check.
+        Some(self.config.target_each)
     }
 }
 

--- a/eval/session/src/plan.rs
+++ b/eval/session/src/plan.rs
@@ -202,7 +202,7 @@ impl Planner for RoundRobinPlanner {
             let a = &self.config.players[i];
             let b = &self.config.players[j];
             (0..self.config.target_per_pair).all(|rep| {
-                let key = canonical_key(&a.id, &b.id, &self.config.game_config_id, rep);
+                let key = MatchupKey::from_pair(&a.id, &b.id, &self.config.game_config_id, rep);
                 slot_done(&key, state, self.config.max_failures_per_pair)
                     && !self
                         .pending
@@ -307,7 +307,7 @@ impl Planner for GauntletPlanner {
     fn is_done(&self, state: &TournamentState) -> bool {
         self.config.opponents.iter().all(|opp| {
             (0..self.config.target_each).all(|rep| {
-                let key = canonical_key(
+                let key = MatchupKey::from_pair(
                     &self.config.challenger.id,
                     &opp.id,
                     &self.config.game_config_id,
@@ -354,16 +354,6 @@ impl Planner for GauntletPlanner {
 // Shared helpers
 // ---------------------------------------------------------------------------
 
-fn canonical_key(p_a: &str, p_b: &str, game_config_id: &str, repetition_index: u32) -> MatchupKey {
-    let (p1, p2) = if p_a <= p_b { (p_a, p_b) } else { (p_b, p_a) };
-    MatchupKey {
-        player1_id: p1.to_owned(),
-        player2_id: p2.to_owned(),
-        game_config_id: game_config_id.to_owned(),
-        repetition_index,
-    }
-}
-
 fn slot_done(key: &MatchupKey, state: &TournamentState, max_failures: u32) -> bool {
     let history = state.history.get(key).map(Vec::as_slice).unwrap_or(&[]);
     let success = history
@@ -384,12 +374,7 @@ fn clear_pending(pending: &mut HashMap<MatchupKey, HashSet<u32>>, observation: &
         Observation::Finished { descriptor } | Observation::Failed { descriptor, .. } => descriptor,
         Observation::Queued { .. } | Observation::Started { .. } => return,
     };
-    let key = canonical_key(
-        &desc.player1_id,
-        &desc.player2_id,
-        &desc.game_config_id,
-        desc.repetition_index,
-    );
+    let key = MatchupKey::from_descriptor(desc);
     if let Some(set) = pending.get_mut(&key) {
         set.remove(&desc.attempt_index);
     }
@@ -441,15 +426,12 @@ fn build_slot(
     pending: &mut HashMap<MatchupKey, HashSet<u32>>,
     allocate_match_id: &mut dyn FnMut() -> MatchId,
 ) -> Option<Matchup<EvalMatchDescriptor>> {
-    // Canonicalize player ids so repetition_index across orientations
-    // collapses onto a single MatchupKey.
+    // Lex-sort players for slot 0/1 so the planner submits descriptors in
+    // canonical orientation. `MatchupKey::from_pair` already canonicalizes
+    // its own player_ids, but the descriptor's slot order is what the
+    // engine sees.
     let (p1, p2) = if a.id <= b.id { (a, b) } else { (b, a) };
-    let key = MatchupKey {
-        player1_id: p1.id.clone(),
-        player2_id: p2.id.clone(),
-        game_config_id: ctx.game_config_id.to_owned(),
-        repetition_index,
-    };
+    let key = MatchupKey::from_pair(&p1.id, &p2.id, ctx.game_config_id, repetition_index);
 
     if slot_done(&key, state, ctx.max_failures) {
         return None;

--- a/eval/session/src/plan.rs
+++ b/eval/session/src/plan.rs
@@ -1,0 +1,695 @@
+//! Planner trait + concrete implementations.
+//!
+//! A planner reads `TournamentState` (durable) and tracks its own pending
+//! set (which `(matchup_key, attempt_index)` slots have been issued but not
+//! yet observed). On each `next_batch`, it picks unfinished slots up to
+//! `capacity` and emits ready-to-submit `Matchup<EvalMatchDescriptor>`s.
+//!
+//! Seeds are derived statelessly from the matchup key, so retries replay
+//! the exact same seeded match.
+
+use std::collections::{HashMap, HashSet};
+use std::time::SystemTime;
+
+use pyrat::game::builder::GameConfig;
+use pyrat_eval_store::TournamentId;
+use pyrat_orchestrator::{MatchId, Matchup, PlayerSpec, Timing};
+use sha2::{Digest, Sha256};
+
+use crate::descriptor::EvalMatchDescriptor;
+use crate::observation::Observation;
+use crate::state::{MatchupKey, MatchupOutcome, PlayerId, TournamentState};
+
+/// Stateless seed for one matchup slot.
+///
+/// Same `MatchupKey` always yields the same seed, regardless of scheduling
+/// order, parallelism, or resume. `attempt_index` is intentionally not in
+/// the derivation: retries replay the exact same seeded match (deterministic
+/// engine bugs surface every retry — that's correct, the planner gives up
+/// after `max_failures_per_pair`; flaky environmental failures are the use
+/// case where retries help).
+///
+/// The high bit is masked because SQLite `INTEGER` is signed `i64`; the
+/// store's `record_attempt` rejects values above `i64::MAX` as a defense in
+/// depth. 2^63 is still cosmically huge.
+pub fn matchup_seed(
+    tournament_seed: u64,
+    p1: &str,
+    p2: &str,
+    game_config_id: &str,
+    repetition_index: u32,
+) -> u64 {
+    let mut hasher = Sha256::new();
+    hasher.update(tournament_seed.to_le_bytes());
+    hasher.update(p1.as_bytes());
+    hasher.update(p2.as_bytes());
+    hasher.update(game_config_id.as_bytes());
+    hasher.update(repetition_index.to_le_bytes());
+    let bytes = hasher.finalize();
+    let raw = u64::from_le_bytes(bytes[..8].try_into().expect("sha256 yields 32 bytes"));
+    raw & (i64::MAX as u64)
+}
+
+/// One participant resolved from a `PlayerId` to a runnable `PlayerSpec`.
+/// The session resolves these from `tournament_players` rows + the user's
+/// `PlayerSpec` registry; planners never materialize new ones.
+#[derive(Clone)]
+pub struct ResolvedPlayer {
+    pub id: PlayerId,
+    pub spec: PlayerSpec,
+}
+
+impl std::fmt::Debug for ResolvedPlayer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResolvedPlayer")
+            .field("id", &self.id)
+            .finish_non_exhaustive()
+    }
+}
+
+pub trait Planner: Send {
+    /// Pick up to `capacity` new matchups from the current state. Returns
+    /// empty when there's nothing left to issue right now (either the
+    /// tournament is done or every unfinished slot already has a pending
+    /// attempt). Combine with [`Planner::is_done`] to distinguish.
+    ///
+    /// `allocate_match_id` is a callback into the caller's id allocator
+    /// (typically the orchestrator's). Keeping it as a closure means the
+    /// planner doesn't depend on `MatchIdAllocator` directly.
+    fn next_batch(
+        &mut self,
+        state: &TournamentState,
+        capacity: usize,
+        allocate_match_id: &mut dyn FnMut() -> MatchId,
+    ) -> Vec<Matchup<EvalMatchDescriptor>>;
+
+    /// Notification that one lifecycle event was observed. Used to clear
+    /// the planner's pending set.
+    fn on_observation(&mut self, observation: &Observation);
+
+    /// True when no further matchups will ever be issued, regardless of
+    /// capacity. Tournament terminates when this returns true and no
+    /// matches are in flight.
+    fn is_done(&self, state: &TournamentState) -> bool;
+}
+
+// ---------------------------------------------------------------------------
+// Round-robin
+// ---------------------------------------------------------------------------
+
+/// All-vs-all tournament. Each unordered pair `{p1, p2}` plays
+/// `target_per_pair` games. `repetition_index` distinguishes them; sides are
+/// fixed by lexicographic player id (player1 = lex_min, player2 = lex_max).
+/// Side alternation is a future enhancement (orthogonal to v1).
+#[derive(Clone)]
+pub struct RoundRobinPlannerConfig {
+    pub players: Vec<ResolvedPlayer>,
+    pub game_config: GameConfig,
+    pub game_config_id: String,
+    pub timing: Timing,
+    pub tournament_id: TournamentId,
+    pub target_per_pair: u32,
+    pub max_failures_per_pair: u32,
+    pub tournament_seed: u64,
+}
+
+pub struct RoundRobinPlanner {
+    config: RoundRobinPlannerConfig,
+    /// Computed once at construction. `n*(n-1)/2` entries, immutable for
+    /// the life of the planner — no reason to rebuild per `next_batch`.
+    pair_indices: Vec<(usize, usize)>,
+    /// `(matchup_key, attempt_index)` of every matchup we've submitted but
+    /// haven't seen a terminal observation for yet.
+    pending: HashMap<MatchupKey, HashSet<u32>>,
+}
+
+impl RoundRobinPlanner {
+    pub fn new(config: RoundRobinPlannerConfig) -> Self {
+        let n = config.players.len();
+        let mut pair_indices = Vec::with_capacity(n * (n.saturating_sub(1)) / 2);
+        for i in 0..n {
+            for j in (i + 1)..n {
+                pair_indices.push((i, j));
+            }
+        }
+        Self {
+            config,
+            pair_indices,
+            pending: HashMap::new(),
+        }
+    }
+}
+
+impl Planner for RoundRobinPlanner {
+    fn next_batch(
+        &mut self,
+        state: &TournamentState,
+        capacity: usize,
+        allocate_match_id: &mut dyn FnMut() -> MatchId,
+    ) -> Vec<Matchup<EvalMatchDescriptor>> {
+        if capacity == 0 {
+            return Vec::new();
+        }
+        let mut out = Vec::with_capacity(capacity);
+        let ctx = SlotContext::for_round_robin(&self.config);
+        for &(i, j) in &self.pair_indices {
+            for rep in 0..self.config.target_per_pair {
+                if out.len() == capacity {
+                    return out;
+                }
+                let a = &self.config.players[i];
+                let b = &self.config.players[j];
+                if let Some(matchup) =
+                    build_slot(a, b, rep, &ctx, state, &mut self.pending, allocate_match_id)
+                {
+                    out.push(matchup);
+                }
+            }
+        }
+        out
+    }
+
+    fn on_observation(&mut self, observation: &Observation) {
+        clear_pending(&mut self.pending, observation);
+    }
+
+    fn is_done(&self, state: &TournamentState) -> bool {
+        self.pair_indices.iter().all(|&(i, j)| {
+            let a = &self.config.players[i];
+            let b = &self.config.players[j];
+            (0..self.config.target_per_pair).all(|rep| {
+                let key = canonical_key(&a.id, &b.id, &self.config.game_config_id, rep);
+                slot_done(&key, state, self.config.max_failures_per_pair)
+                    && !self
+                        .pending
+                        .get(&key)
+                        .map(|s| !s.is_empty())
+                        .unwrap_or(false)
+            })
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Gauntlet (challenger vs many opponents)
+// ---------------------------------------------------------------------------
+
+/// One challenger plays each opponent `target_each` games. Use case: a new
+/// bot version vs the rest of the pool, when full round-robin is overkill.
+#[derive(Clone)]
+pub struct GauntletPlannerConfig {
+    pub challenger: ResolvedPlayer,
+    pub opponents: Vec<ResolvedPlayer>,
+    pub game_config: GameConfig,
+    pub game_config_id: String,
+    pub timing: Timing,
+    pub tournament_id: TournamentId,
+    pub target_each: u32,
+    pub max_failures_per_pair: u32,
+    pub tournament_seed: u64,
+}
+
+pub struct GauntletPlanner {
+    config: GauntletPlannerConfig,
+    pending: HashMap<MatchupKey, HashSet<u32>>,
+}
+
+impl GauntletPlanner {
+    pub fn new(config: GauntletPlannerConfig) -> Self {
+        Self {
+            config,
+            pending: HashMap::new(),
+        }
+    }
+}
+
+impl Planner for GauntletPlanner {
+    fn next_batch(
+        &mut self,
+        state: &TournamentState,
+        capacity: usize,
+        allocate_match_id: &mut dyn FnMut() -> MatchId,
+    ) -> Vec<Matchup<EvalMatchDescriptor>> {
+        if capacity == 0 {
+            return Vec::new();
+        }
+        let mut out = Vec::with_capacity(capacity);
+        let ctx = SlotContext::for_gauntlet(&self.config);
+        for opp in &self.config.opponents {
+            for rep in 0..self.config.target_each {
+                if out.len() == capacity {
+                    return out;
+                }
+                if let Some(matchup) = build_slot(
+                    &self.config.challenger,
+                    opp,
+                    rep,
+                    &ctx,
+                    state,
+                    &mut self.pending,
+                    allocate_match_id,
+                ) {
+                    out.push(matchup);
+                }
+            }
+        }
+        out
+    }
+
+    fn on_observation(&mut self, observation: &Observation) {
+        clear_pending(&mut self.pending, observation);
+    }
+
+    fn is_done(&self, state: &TournamentState) -> bool {
+        self.config.opponents.iter().all(|opp| {
+            (0..self.config.target_each).all(|rep| {
+                let key = canonical_key(
+                    &self.config.challenger.id,
+                    &opp.id,
+                    &self.config.game_config_id,
+                    rep,
+                );
+                slot_done(&key, state, self.config.max_failures_per_pair)
+                    && !self
+                        .pending
+                        .get(&key)
+                        .map(|s| !s.is_empty())
+                        .unwrap_or(false)
+            })
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+fn canonical_key(p_a: &str, p_b: &str, game_config_id: &str, repetition_index: u32) -> MatchupKey {
+    let (p1, p2) = if p_a <= p_b { (p_a, p_b) } else { (p_b, p_a) };
+    MatchupKey {
+        player1_id: p1.to_owned(),
+        player2_id: p2.to_owned(),
+        game_config_id: game_config_id.to_owned(),
+        repetition_index,
+    }
+}
+
+fn slot_done(key: &MatchupKey, state: &TournamentState, max_failures: u32) -> bool {
+    let history = state.history.get(key).map(Vec::as_slice).unwrap_or(&[]);
+    let success = history
+        .iter()
+        .any(|a| matches!(a.outcome, MatchupOutcome::Success { .. }));
+    if success {
+        return true;
+    }
+    let failures = history
+        .iter()
+        .filter(|a| matches!(a.outcome, MatchupOutcome::Failure))
+        .count();
+    failures as u32 >= max_failures
+}
+
+fn clear_pending(pending: &mut HashMap<MatchupKey, HashSet<u32>>, observation: &Observation) {
+    let desc = match observation {
+        Observation::Finished { descriptor } | Observation::Failed { descriptor, .. } => descriptor,
+        Observation::Queued { .. } | Observation::Started { .. } => return,
+    };
+    let key = canonical_key(
+        &desc.player1_id,
+        &desc.player2_id,
+        &desc.game_config_id,
+        desc.repetition_index,
+    );
+    if let Some(set) = pending.get_mut(&key) {
+        set.remove(&desc.attempt_index);
+    }
+}
+
+/// Tournament-level invariants `build_slot` reads. Bundling these into one
+/// struct keeps both planner impls calling `build_slot` with three clear
+/// arguments (the pair, this context, the live cursors) instead of twelve
+/// positional fields.
+struct SlotContext<'a> {
+    game_config: &'a GameConfig,
+    game_config_id: &'a str,
+    timing: Timing,
+    tournament_id: TournamentId,
+    tournament_seed: u64,
+    max_failures: u32,
+}
+
+impl<'a> SlotContext<'a> {
+    fn for_round_robin(config: &'a RoundRobinPlannerConfig) -> Self {
+        Self {
+            game_config: &config.game_config,
+            game_config_id: &config.game_config_id,
+            timing: config.timing,
+            tournament_id: config.tournament_id,
+            tournament_seed: config.tournament_seed,
+            max_failures: config.max_failures_per_pair,
+        }
+    }
+
+    fn for_gauntlet(config: &'a GauntletPlannerConfig) -> Self {
+        Self {
+            game_config: &config.game_config,
+            game_config_id: &config.game_config_id,
+            timing: config.timing,
+            tournament_id: config.tournament_id,
+            tournament_seed: config.tournament_seed,
+            max_failures: config.max_failures_per_pair,
+        }
+    }
+}
+
+fn build_slot(
+    a: &ResolvedPlayer,
+    b: &ResolvedPlayer,
+    repetition_index: u32,
+    ctx: &SlotContext<'_>,
+    state: &TournamentState,
+    pending: &mut HashMap<MatchupKey, HashSet<u32>>,
+    allocate_match_id: &mut dyn FnMut() -> MatchId,
+) -> Option<Matchup<EvalMatchDescriptor>> {
+    // Canonicalize player ids so repetition_index across orientations
+    // collapses onto a single MatchupKey.
+    let (p1, p2) = if a.id <= b.id { (a, b) } else { (b, a) };
+    let key = MatchupKey {
+        player1_id: p1.id.clone(),
+        player2_id: p2.id.clone(),
+        game_config_id: ctx.game_config_id.to_owned(),
+        repetition_index,
+    };
+
+    if slot_done(&key, state, ctx.max_failures) {
+        return None;
+    }
+    let pending_set = pending.entry(key.clone()).or_default();
+    if !pending_set.is_empty() {
+        // Already issued one for this slot; wait for terminal before retrying.
+        return None;
+    }
+
+    let history_len = state.history.get(&key).map(Vec::len).unwrap_or(0);
+    let attempt_index = history_len as u32;
+    pending_set.insert(attempt_index);
+
+    let seed = matchup_seed(
+        ctx.tournament_seed,
+        &key.player1_id,
+        &key.player2_id,
+        ctx.game_config_id,
+        repetition_index,
+    );
+    let descriptor = EvalMatchDescriptor {
+        match_id: allocate_match_id(),
+        tournament_id: ctx.tournament_id,
+        game_config_id: ctx.game_config_id.to_owned(),
+        player1_id: key.player1_id.clone(),
+        player2_id: key.player2_id.clone(),
+        seed,
+        repetition_index,
+        attempt_index,
+        planned_at: SystemTime::now(),
+    };
+
+    Some(Matchup {
+        descriptor,
+        game_config: ctx.game_config.clone(),
+        players: [p1.spec.clone(), p2.spec.clone()],
+        timing: ctx.timing,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::SystemTime;
+
+    use pyrat::Direction;
+    use pyrat_bot_api::Options;
+    use pyrat_host::player::{EmbeddedBot, EmbeddedCtx};
+    use pyrat_host::wire::TimingMode;
+    use pyrat_orchestrator::{
+        EmbeddedBotFactory, FailureReason, MatchFailure, MatchIdAllocator, MatchOutcome, PlayerSpec,
+    };
+    use pyrat_protocol::HashedTurnState;
+
+    use super::*;
+
+    struct StubBot;
+    impl Options for StubBot {}
+    impl EmbeddedBot for StubBot {
+        fn think(&mut self, _: &HashedTurnState, _: &EmbeddedCtx) -> Direction {
+            Direction::Stay
+        }
+    }
+
+    fn embedded(id: &str) -> ResolvedPlayer {
+        let factory: EmbeddedBotFactory = Arc::new(|| Box::new(StubBot));
+        ResolvedPlayer {
+            id: id.into(),
+            spec: PlayerSpec::Embedded {
+                agent_id: id.into(),
+                name: id.into(),
+                author: "x".into(),
+                factory,
+            },
+        }
+    }
+
+    fn timing() -> Timing {
+        Timing {
+            mode: TimingMode::Wait,
+            move_timeout_ms: 1000,
+            preprocessing_timeout_ms: 5000,
+        }
+    }
+
+    fn tiny_round_robin(target: u32, max_failures: u32) -> RoundRobinPlanner {
+        RoundRobinPlanner::new(RoundRobinPlannerConfig {
+            players: vec![embedded("a"), embedded("b"), embedded("c")],
+            game_config: GameConfig::classic(7, 5, 3),
+            game_config_id: "gc".into(),
+            timing: timing(),
+            tournament_id: TournamentId(1),
+            target_per_pair: target,
+            max_failures_per_pair: max_failures,
+            tournament_seed: 0xC0FFEE,
+        })
+    }
+
+    fn finished_obs(d: EvalMatchDescriptor) -> Observation {
+        Observation::Finished { descriptor: d }
+    }
+
+    fn failed_obs(d: EvalMatchDescriptor, durable: bool) -> Observation {
+        Observation::Failed {
+            descriptor: d,
+            durable_record: durable,
+            reason: FailureReason::SpawnFailed,
+        }
+    }
+
+    fn fold_outcome(
+        state: &mut TournamentState,
+        d: EvalMatchDescriptor,
+        p1_score: f64,
+        p2_score: f64,
+    ) {
+        use pyrat_host::match_host::MatchResult;
+        use pyrat_host::player::PlayerIdentity;
+        use pyrat_host::wire::{GameResult, Player};
+        let identity = |slot| PlayerIdentity {
+            name: "x".into(),
+            author: "x".into(),
+            agent_id: "x".into(),
+            slot,
+        };
+        state.apply(&pyrat_orchestrator::DriverEvent::MatchFinished {
+            outcome: MatchOutcome {
+                descriptor: d,
+                started_at: SystemTime::UNIX_EPOCH,
+                finished_at: SystemTime::UNIX_EPOCH,
+                result: MatchResult {
+                    result: GameResult::Draw,
+                    player1_score: p1_score as f32,
+                    player2_score: p2_score as f32,
+                    turns_played: 50,
+                },
+                players: [identity(Player::Player1), identity(Player::Player2)],
+            },
+        });
+    }
+
+    fn fold_failure(state: &mut TournamentState, d: EvalMatchDescriptor, durable: bool) {
+        state.apply(&pyrat_orchestrator::DriverEvent::MatchFailed {
+            failure: MatchFailure {
+                descriptor: d,
+                started_at: None,
+                failed_at: SystemTime::UNIX_EPOCH,
+                reason: FailureReason::SpawnFailed,
+                players: None,
+                durable_record: durable,
+            },
+        });
+    }
+
+    /// 3 players × 1 game per pair = 3 unique matchups.
+    /// All MatchupKeys are distinct: planner issues every slot exactly once.
+    #[test]
+    fn round_robin_target_one_yields_three_pair_matchups() {
+        let mut p = tiny_round_robin(1, 3);
+        let alloc = MatchIdAllocator::new();
+        let state = TournamentState::empty(TournamentId(1));
+        let batch = p.next_batch(&state, 100, &mut || alloc.allocate());
+        assert_eq!(batch.len(), 3);
+        // Distinct (player1, player2) lex-canonical pairs.
+        let mut pairs: Vec<_> = batch
+            .iter()
+            .map(|m| {
+                (
+                    m.descriptor.player1_id.clone(),
+                    m.descriptor.player2_id.clone(),
+                )
+            })
+            .collect();
+        pairs.sort();
+        assert_eq!(
+            pairs,
+            vec![
+                ("a".into(), "b".into()),
+                ("a".into(), "c".into()),
+                ("b".into(), "c".into()),
+            ]
+        );
+    }
+
+    /// Capacity caps the batch: 3 pairs × 2 games = 6 slots, capacity=2.
+    /// Only 2 matchups returned; remaining slots issued on later calls.
+    #[test]
+    fn next_batch_respects_capacity() {
+        let mut p = tiny_round_robin(2, 3);
+        let alloc = MatchIdAllocator::new();
+        let state = TournamentState::empty(TournamentId(1));
+        let batch = p.next_batch(&state, 2, &mut || alloc.allocate());
+        assert_eq!(batch.len(), 2);
+    }
+
+    /// Pending set prevents double-issuing: after issuing slot (a,b,rep=0),
+    /// the next call (with state still showing zero history for that slot)
+    /// must skip it until on_observation clears the pending entry.
+    #[test]
+    fn pending_set_prevents_double_issue() {
+        let mut p = tiny_round_robin(1, 3);
+        let alloc = MatchIdAllocator::new();
+        let mut state = TournamentState::empty(TournamentId(1));
+        let batch1 = p.next_batch(&state, 100, &mut || alloc.allocate());
+        assert_eq!(batch1.len(), 3);
+        // Without observation, planner sees nothing it can issue.
+        let batch2 = p.next_batch(&state, 100, &mut || alloc.allocate());
+        assert!(batch2.is_empty());
+        // After we observe a finished + state.apply, that slot is done; the
+        // other two are still pending.
+        let m = batch1[0].clone();
+        fold_outcome(&mut state, m.descriptor.clone(), 5.0, 3.0);
+        p.on_observation(&finished_obs(m.descriptor));
+        let batch3 = p.next_batch(&state, 100, &mut || alloc.allocate());
+        assert_eq!(batch3.len(), 0); // others still in flight
+    }
+
+    /// Failure observation lets the planner re-issue at attempt_index+1
+    /// (until max_failures_per_pair is hit).
+    #[test]
+    fn failure_triggers_retry_at_next_attempt_index() {
+        let mut p = tiny_round_robin(1, 3);
+        let alloc = MatchIdAllocator::new();
+        let mut state = TournamentState::empty(TournamentId(1));
+        let batch1 = p.next_batch(&state, 100, &mut || alloc.allocate());
+        let first = batch1[0].clone();
+        assert_eq!(first.descriptor.attempt_index, 0);
+        // Durable failure: history gets a Failure entry.
+        fold_failure(&mut state, first.descriptor.clone(), true);
+        p.on_observation(&failed_obs(first.descriptor.clone(), true));
+        let batch2 = p.next_batch(&state, 100, &mut || alloc.allocate());
+        // The retried slot should appear with attempt_index=1.
+        let retry = batch2
+            .iter()
+            .find(|m| {
+                m.descriptor.player1_id == first.descriptor.player1_id
+                    && m.descriptor.player2_id == first.descriptor.player2_id
+            })
+            .expect("retry of the failed pair");
+        assert_eq!(retry.descriptor.attempt_index, 1);
+    }
+
+    /// `durable_record == false` means no durable row exists; the planner
+    /// must re-issue at the *same* attempt_index (silent retry).
+    #[test]
+    fn non_durable_failure_retries_at_same_attempt_index() {
+        let mut p = tiny_round_robin(1, 3);
+        let alloc = MatchIdAllocator::new();
+        let mut state = TournamentState::empty(TournamentId(1));
+        let batch1 = p.next_batch(&state, 100, &mut || alloc.allocate());
+        let first = batch1[0].clone();
+        assert_eq!(first.descriptor.attempt_index, 0);
+        // Non-durable failure: history is NOT touched (state.apply enforces
+        // this).
+        fold_failure(&mut state, first.descriptor.clone(), false);
+        p.on_observation(&failed_obs(first.descriptor.clone(), false));
+        let batch2 = p.next_batch(&state, 100, &mut || alloc.allocate());
+        let retry = batch2
+            .iter()
+            .find(|m| {
+                m.descriptor.player1_id == first.descriptor.player1_id
+                    && m.descriptor.player2_id == first.descriptor.player2_id
+            })
+            .expect("silent retry of the lost pair");
+        assert_eq!(retry.descriptor.attempt_index, 0);
+        // And the seed is identical: same matchup key → same seed.
+        assert_eq!(retry.descriptor.seed, first.descriptor.seed);
+    }
+
+    /// After max_failures_per_pair durable failures, the planner gives up
+    /// on that slot and is_done returns true (assuming all other slots also
+    /// resolved).
+    #[test]
+    fn max_failures_per_pair_terminates_slot() {
+        // Single pair to keep the assertion clean.
+        let mut p = RoundRobinPlanner::new(RoundRobinPlannerConfig {
+            players: vec![embedded("a"), embedded("b")],
+            game_config: GameConfig::classic(7, 5, 3),
+            game_config_id: "gc".into(),
+            timing: timing(),
+            tournament_id: TournamentId(1),
+            target_per_pair: 1,
+            max_failures_per_pair: 2,
+            tournament_seed: 1,
+        });
+        let alloc = MatchIdAllocator::new();
+        let mut state = TournamentState::empty(TournamentId(1));
+        for _ in 0..2 {
+            let batch = p.next_batch(&state, 100, &mut || alloc.allocate());
+            assert_eq!(batch.len(), 1);
+            let m = batch[0].clone();
+            fold_failure(&mut state, m.descriptor.clone(), true);
+            p.on_observation(&failed_obs(m.descriptor, true));
+        }
+        let batch3 = p.next_batch(&state, 100, &mut || alloc.allocate());
+        assert!(batch3.is_empty());
+        assert!(p.is_done(&state));
+    }
+
+    /// Same matchup key always yields the same seed, regardless of caller
+    /// order. Pins the stateless-derivation contract.
+    #[test]
+    fn matchup_seed_is_pure() {
+        let s1 = matchup_seed(0xDEAD, "a", "b", "gc", 0);
+        let s2 = matchup_seed(0xDEAD, "a", "b", "gc", 0);
+        assert_eq!(s1, s2);
+        let s3 = matchup_seed(0xDEAD, "a", "b", "gc", 1);
+        assert_ne!(s1, s3);
+        // High bit always masked.
+        assert!(s1 <= i64::MAX as u64);
+    }
+}

--- a/eval/session/src/session.rs
+++ b/eval/session/src/session.rs
@@ -28,6 +28,7 @@ use pyrat_orchestrator::{
 };
 use tokio::sync::{broadcast, mpsc, watch};
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 use crate::descriptor::EvalMatchDescriptor;
 use crate::mapping::MappingError;
@@ -150,6 +151,12 @@ pub enum SessionError {
 
     #[error("orchestrator error: {0}")]
     Orchestrator(#[from] OrchestratorError),
+
+    /// The session run loop panicked. The string is the panic message
+    /// stringified — `tokio::task::JoinError` itself is not part of the
+    /// public API so we don't carry it through.
+    #[error("run loop panicked: {0}")]
+    RunLoopPanicked(String),
 }
 
 // ---------------------------------------------------------------------------
@@ -167,10 +174,12 @@ pub struct EvalSession {
     session_events: broadcast::Sender<SessionEvent>,
     publish_mutex: Arc<Mutex<()>>,
     orch: Arc<Orchestrator<EvalMatchDescriptor>>,
-    /// Held so `live_events()` can hand out new receivers via `orch.events()`.
-    /// (Field exists implicitly through `orch` — no extra storage.)
-    /// Run-loop join handle. `None` after `shutdown` consumes the session.
-    run_loop_handle: Option<JoinHandle<()>>,
+    /// Cancellation seam for `shutdown`. The run-loop selects on this
+    /// alongside `driver_rx.recv()` so cancellation always wins even if no
+    /// further lifecycle events arrive.
+    cancel: CancellationToken,
+    /// Run-loop join handle. `None` after `shutdown`/`join` consume it.
+    run_loop_handle: Option<JoinHandle<Result<(), SessionError>>>,
 }
 
 impl EvalSession {
@@ -241,34 +250,59 @@ impl EvalSession {
     }
 
     /// Wait for the tournament to finish (planner.is_done && orch.idle).
-    /// Returns when the run-loop emits `TournamentFinished`.
-    pub async fn join(mut self) {
+    /// Returns when the run-loop emits `TournamentFinished`. Surfaces
+    /// `SessionError::RunLoopPanicked` if the run-loop task panicked.
+    pub async fn join(mut self) -> Result<(), SessionError> {
         if let Some(h) = self.run_loop_handle.take() {
-            let _ = h.await;
+            await_run_loop(h).await?;
         }
+        Ok(())
     }
 
-    /// Cancel the run loop and shut down the orchestrator. Blocks until
-    /// every match has terminated (with `MatchFailed { Cancelled }` for
-    /// in-flight ones).
+    /// Cancel the run loop and drain the orchestrator.
     ///
-    /// The orchestrator's `Drop` impl handles its own task abort once the
-    /// last `Arc` ref drops; we don't `try_unwrap` to call its consuming
-    /// `shutdown(self)` because the run-loop holds an `Arc` clone that
-    /// only drops after `h.await` returns — at that point `self` is also
-    /// going out of scope, so the `Drop` path runs naturally.
-    pub async fn shutdown(mut self) {
-        self.orch.abort();
+    /// Sequence:
+    /// 1. Cancel the session token — the run-loop's `select!` picks this up
+    ///    and exits on the next iteration, dropping its `Arc<Orchestrator>`
+    ///    clone.
+    /// 2. Await the run-loop handle.
+    /// 3. Reclaim the orchestrator via `Arc::try_unwrap` and call its
+    ///    consuming `shutdown().await` for graceful drain. Falls back to
+    ///    `abort()` if any other `Arc` clone exists.
+    ///
+    /// **Drain guarantee.** Graceful drain runs only when `EvalSession`
+    /// owns the last `Arc<Orchestrator>` at shutdown time. Today only the
+    /// session struct and the run-loop task clone the Arc; the loop drops
+    /// its clone when it exits, so `try_unwrap` succeeds and drain runs.
+    /// If a future caller retains a clone (for cross-session inspection,
+    /// say), `shutdown` falls back to `abort` and drain becomes best-effort.
+    pub async fn shutdown(mut self) -> Result<(), SessionError> {
+        self.cancel.cancel();
         if let Some(h) = self.run_loop_handle.take() {
-            let _ = h.await;
+            await_run_loop(h).await?;
         }
+        match Arc::try_unwrap(self.orch) {
+            Ok(orch) => orch.shutdown().await,
+            Err(arc) => arc.abort(),
+        }
+        Ok(())
+    }
+}
+
+/// Map a finished run-loop `JoinHandle` to a `SessionError`-shaped result.
+/// Panics flow through as `RunLoopPanicked`; the inner `Result` carries any
+/// `SessionError` the run-loop returned.
+async fn await_run_loop(h: JoinHandle<Result<(), SessionError>>) -> Result<(), SessionError> {
+    match h.await {
+        Ok(inner) => inner,
+        Err(join_err) => Err(SessionError::RunLoopPanicked(join_err.to_string())),
     }
 }
 
 impl EvalSession {
     fn launch<P: Planner + 'static>(
         store: Arc<Mutex<EvalStore>>,
-        tournament_id: TournamentId,
+        _tournament_id: TournamentId,
         initial_state: TournamentState,
         planner: P,
         orch_config: OrchestratorConfig,
@@ -283,17 +317,18 @@ impl EvalSession {
         let (state_watch, _state_rx) = watch::channel(initial_state.clone());
         let (session_events, _events_rx) = broadcast::channel(256);
         let publish_mutex = Arc::new(Mutex::new(()));
+        let cancel = CancellationToken::new();
 
         let run_loop_handle = tokio::spawn(run_loop(
             planner,
             initial_state,
-            tournament_id,
             state_watch.clone(),
             session_events.clone(),
             publish_mutex.clone(),
             orch.clone(),
             driver_rx,
             elo_options,
+            cancel.clone(),
         ));
 
         Ok(Self {
@@ -301,6 +336,7 @@ impl EvalSession {
             session_events,
             publish_mutex,
             orch,
+            cancel,
             run_loop_handle: Some(run_loop_handle),
         })
     }
@@ -412,14 +448,14 @@ fn player_agent_id(spec: &pyrat_orchestrator::PlayerSpec) -> &str {
 async fn run_loop<P: Planner>(
     mut planner: P,
     mut state: TournamentState,
-    _tournament_id: TournamentId,
     state_watch: watch::Sender<TournamentState>,
     session_events: broadcast::Sender<SessionEvent>,
     publish_mutex: Arc<Mutex<()>>,
     orch: Arc<Orchestrator<EvalMatchDescriptor>>,
     mut driver_rx: mpsc::Receiver<DriverEvent<EvalMatchDescriptor>>,
     elo_options: EloOptions,
-) {
+    cancel: CancellationToken,
+) -> Result<(), SessionError> {
     // Initial Elo on resume (so subscribers see standings before the first
     // MatchFinished arrives).
     state.recompute_elo(&elo_options);
@@ -437,40 +473,47 @@ async fn run_loop<P: Planner>(
                 planner.next_batch(&state, cap, &mut allocate)
             };
             for matchup in batch {
-                if orch.submit(matchup).await.is_err() {
-                    // Orchestrator shut down underneath us.
-                    return;
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => return Ok(()),
+                    res = orch.submit(matchup) => {
+                        if res.is_err() {
+                            // Orchestrator shut down underneath us.
+                            return Ok(());
+                        }
+                    }
                 }
             }
         }
 
         if planner.is_done(&state) && orch.idle() {
             let _ = session_events.send(SessionEvent::TournamentFinished);
-            return;
+            return Ok(());
         }
 
-        match driver_rx.recv().await {
-            Some(event) => {
-                state.apply(&event);
-                if matches!(event, DriverEvent::MatchFinished { .. }) {
-                    state.recompute_elo(&elo_options);
-                }
-                {
-                    let _g = publish_mutex.lock();
-                    state_watch.send_replace(state.clone());
-                    if let Some(se) = SessionEvent::from_driver(&event) {
-                        let _ = session_events.send(se);
-                    }
-                }
-                if let Some(obs) = Observation::from_driver_event(&event) {
-                    planner.on_observation(&obs);
-                }
-            },
-            None => {
+        let event = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return Ok(()),
+            maybe = driver_rx.recv() => match maybe {
+                Some(e) => e,
                 // Driver channel closed (orchestrator dropped). Tournament
                 // can't progress further.
-                return;
-            },
+                None => return Ok(()),
+            }
+        };
+        state.apply(&event);
+        if matches!(event, DriverEvent::MatchFinished { .. }) {
+            state.recompute_elo(&elo_options);
+        }
+        {
+            let _g = publish_mutex.lock();
+            state_watch.send_replace(state.clone());
+            if let Some(se) = SessionEvent::from_driver(&event) {
+                let _ = session_events.send(se);
+            }
+        }
+        if let Some(obs) = Observation::from_driver_event(&event) {
+            planner.on_observation(&obs);
         }
     }
 }

--- a/eval/session/src/session.rs
+++ b/eval/session/src/session.rs
@@ -383,7 +383,8 @@ impl Drop for EvalSession {
     /// or `join`. The loop's `select!` picks up the cancellation on its
     /// next iteration and exits, dropping its `Arc<Orchestrator>` clone;
     /// the session's own clone goes away with `self`. The orchestrator's
-    /// tasks then drain through its own `Drop`.
+    /// in-flight tasks are then cancelled and aborted by
+    /// `Orchestrator::Drop` (no graceful drain on this path).
     ///
     /// Fire-and-forget: we can't `await` here, so this is best-effort.
     /// Callers who need a guaranteed graceful drain should call

--- a/eval/session/src/session.rs
+++ b/eval/session/src/session.rs
@@ -21,7 +21,7 @@ use parking_lot::Mutex;
 use pyrat::game::builder::GameConfig;
 use pyrat_eval_store::{
     AddTournamentPlayerError, CreateTournamentError, EloOptions, EvalError, EvalStore,
-    NewTournament, RegisterPlayerError, TournamentId,
+    NewTournament, RegisterPlayerError, TournamentId, TournamentParticipant, TournamentRecord,
 };
 use pyrat_orchestrator::{
     CompositeSink, DriverEvent, FailureReason, MatchSink, Orchestrator, OrchestratorConfig,
@@ -201,6 +201,13 @@ pub enum SessionError {
     #[error("background task `{what}` panicked: {message}")]
     TaskPanicked { what: &'static str, message: String },
 
+    /// The planner handed to `EvalSession::start` doesn't match the stored
+    /// tournament's spec (players, game config, seed, or per-pair target).
+    /// Reconstructing state from someone else's tournament would silently
+    /// fragment standings.
+    #[error("planner does not match stored tournament: {0}")]
+    TournamentMismatch(String),
+
     /// A single matchup has hit the configured ceiling of consecutive
     /// `SinkFlushError` terminals (see
     /// [`SessionConfig::max_consecutive_sink_flush_failures`]). The store
@@ -258,6 +265,12 @@ impl EvalSession {
     /// anchor player must be one of the resolved player ids.
     /// `session_config` carries session-level tunables (defaults are fine
     /// for most callers).
+    ///
+    /// Validates the planner against the stored tournament's spec
+    /// (tournament_id, players, game_config_id, tournament_seed,
+    /// target_games_per_matchup). Returns `SessionError::TournamentMismatch`
+    /// on any divergence so a drifted planner can't silently fragment the
+    /// tournament's history.
     pub async fn start<P: Planner + 'static>(
         store: Arc<Mutex<EvalStore>>,
         mode: SessionMode,
@@ -266,12 +279,14 @@ impl EvalSession {
         elo_options: EloOptions,
         session_config: SessionConfig,
     ) -> Result<Self, SessionError> {
-        let (tournament_id, initial_state) =
+        let (tournament_record, tournament_players, initial_state) =
             reconstruct_tournament_state(store.clone(), mode.tournament_id).await?;
+
+        validate_planner_against_stored_spec(&planner, &tournament_record, &tournament_players)?;
 
         Self::launch(
             store,
-            tournament_id,
+            tournament_record.id,
             initial_state,
             planner,
             orch_config,
@@ -494,31 +509,93 @@ async fn bootstrap_new_tournament(
 
 /// Reconstruct state from store rows for a resume.
 ///
-/// Loads attempts once (no per-loop queries). Folds successes into Elo
-/// and into per-MatchupKey history. The planner picks up from there: it
-/// re-issues missing slots (no row yet) and retries failed slots up to
-/// `max_failures_per_pair` (its own config).
+/// Loads the tournament record, its participants, and all attempts in one
+/// blocking call. The caller cross-checks the planner against the
+/// returned record before launching.
 async fn reconstruct_tournament_state(
     store: Arc<Mutex<EvalStore>>,
     tournament_id: TournamentId,
-) -> Result<(TournamentId, TournamentState), SessionError> {
-    let (tournament_id, state) = tokio::task::spawn_blocking(move || {
+) -> Result<
+    (
+        TournamentRecord,
+        Vec<TournamentParticipant>,
+        TournamentState,
+    ),
+    SessionError,
+> {
+    tokio::task::spawn_blocking(move || {
         let store = store.lock();
         let tournament = store
             .get_tournament(tournament_id)?
             .ok_or(SessionError::TournamentNotFound(tournament_id))?;
+        let tournament_players = store.get_tournament_players(tournament.id)?;
         let mut state = TournamentState::empty(tournament.id);
         for attempt in store.get_attempts(tournament.id, None)? {
             state.fold_attempt(&attempt);
         }
-        Ok::<(TournamentId, TournamentState), SessionError>((tournament.id, state))
+        Ok::<_, SessionError>((tournament, tournament_players, state))
     })
     .await
     .map_err(|e| SessionError::TaskPanicked {
         what: "reconstruct_tournament_state",
         message: e.to_string(),
-    })??;
-    Ok((tournament_id, state))
+    })?
+}
+
+/// Cross-check the planner's expected spec against what the store has on
+/// the tournament. Anything that diverges returns
+/// `SessionError::TournamentMismatch` with a precise reason.
+fn validate_planner_against_stored_spec(
+    planner: &impl Planner,
+    tournament: &TournamentRecord,
+    tournament_players: &[TournamentParticipant],
+) -> Result<(), SessionError> {
+    if planner.tournament_id() != tournament.id {
+        return Err(SessionError::TournamentMismatch(format!(
+            "tournament_id: planner expected {:?}, stored is {:?}",
+            planner.tournament_id(),
+            tournament.id
+        )));
+    }
+    if planner.expected_game_config_id() != tournament.game_config_id {
+        return Err(SessionError::TournamentMismatch(format!(
+            "game_config_id: planner expected {:?}, stored is {:?}",
+            planner.expected_game_config_id(),
+            tournament.game_config_id
+        )));
+    }
+    if planner.expected_tournament_seed() != tournament.tournament_seed {
+        return Err(SessionError::TournamentMismatch(format!(
+            "tournament_seed: planner expected {}, stored is {}",
+            planner.expected_tournament_seed(),
+            tournament.tournament_seed
+        )));
+    }
+    // target_games_per_matchup: both sides know it only when both surface
+    // a value. Don't enforce when either side is None.
+    if let (Some(planner_target), Some(stored_target)) = (
+        planner.expected_target_per_pair(),
+        tournament.target_games_per_matchup,
+    ) {
+        if planner_target != stored_target {
+            return Err(SessionError::TournamentMismatch(format!(
+                "target_games_per_matchup: planner expected {planner_target}, stored is {stored_target}",
+            )));
+        }
+    }
+    // Players: stored rows are sorted by slot (`get_tournament_players`'s
+    // ORDER BY). Compare by id+slot in that order.
+    let stored_ids: Vec<&str> = tournament_players
+        .iter()
+        .map(|p| p.player_id.as_str())
+        .collect();
+    let expected_ids = planner.expected_players();
+    if expected_ids != stored_ids {
+        return Err(SessionError::TournamentMismatch(format!(
+            "players: planner expected {expected_ids:?}, stored is {stored_ids:?}",
+        )));
+    }
+    Ok(())
 }
 
 fn player_agent_id(spec: &pyrat_orchestrator::PlayerSpec) -> &str {

--- a/eval/session/src/session.rs
+++ b/eval/session/src/session.rs
@@ -1,0 +1,432 @@
+//! `EvalSession` — drives the planner-orchestrator-store loop.
+//!
+//! Responsibilities:
+//! - Own the lossless `DriverEvent` mpsc from the orchestrator. Lifecycle
+//!   events are the canonical mutator of `TournamentState`.
+//! - Re-publish lifecycle to its own broadcast (`SessionEvent`) so consumers
+//!   subscribing to the session see exactly the events that changed state.
+//! - Pass through the orchestrator's broadcast (`OrchestratorEvent`) for
+//!   live per-turn UIs.
+//! - Atomic `subscribe()`: state-then-tail consistency under a publish
+//!   mutex (sync only, no awaits inside).
+//!
+//! Two construction modes: `New` (create a tournament) and `Resume`
+//! (reconstruct from store rows). Both produce a session that runs to
+//! completion (planner.is_done && orchestrator.idle).
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use pyrat_eval_store::{
+    AddTournamentPlayerError, EloOptions, EvalError, EvalStore, NewTournament, RegisterPlayerError,
+    TournamentId,
+};
+use pyrat_orchestrator::{
+    CompositeSink, DriverEvent, MatchSink, Orchestrator, OrchestratorConfig, OrchestratorError,
+    OrchestratorEvent, SinkRole,
+};
+use tokio::sync::{broadcast, mpsc, watch};
+use tokio::task::JoinHandle;
+
+use crate::descriptor::EvalMatchDescriptor;
+use crate::mapping::MappingError;
+use crate::observation::Observation;
+use crate::plan::{Planner, ResolvedPlayer};
+use crate::state::TournamentState;
+use crate::store_sink::StoreSink;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// Specification for a brand-new tournament. Stored opaquely as
+/// `tournaments.params_json`; planners deserialize whatever they need.
+#[derive(Debug, Clone)]
+pub struct TournamentSpec {
+    pub format: String,
+    pub target_games_per_matchup: Option<u32>,
+    pub params_json: String,
+}
+
+/// Reconstruct mode handed to `EvalSession::start`.
+///
+/// The session always runs against an *existing* tournament id. To create
+/// one, call [`EvalSession::create_tournament`] first — it returns a
+/// `TournamentId` you then plug into the planner config and pass here.
+/// Two-phase split sidesteps the chicken-and-egg between "session creates
+/// the tid" and "planner needs the tid before construction".
+pub struct SessionMode {
+    pub tournament_id: TournamentId,
+}
+
+/// Lifecycle events surfaced by the session. Translated from the
+/// orchestrator's `DriverEvent` plus an extra `TournamentFinished` terminal
+/// after the run-loop exits.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum SessionEvent {
+    MatchSubmitted {
+        descriptor: EvalMatchDescriptor,
+    },
+    MatchStarted {
+        descriptor: EvalMatchDescriptor,
+    },
+    MatchFinished {
+        descriptor: EvalMatchDescriptor,
+    },
+    MatchFailed {
+        descriptor: EvalMatchDescriptor,
+        durable_record: bool,
+    },
+    TournamentFinished,
+}
+
+impl SessionEvent {
+    fn from_driver(event: &DriverEvent<EvalMatchDescriptor>) -> Option<Self> {
+        match event {
+            DriverEvent::MatchQueued { descriptor, .. } => Some(SessionEvent::MatchSubmitted {
+                descriptor: descriptor.clone(),
+            }),
+            DriverEvent::MatchStarted { descriptor, .. } => Some(SessionEvent::MatchStarted {
+                descriptor: descriptor.clone(),
+            }),
+            DriverEvent::MatchFinished { outcome } => Some(SessionEvent::MatchFinished {
+                descriptor: outcome.descriptor.clone(),
+            }),
+            DriverEvent::MatchFailed { failure } => Some(SessionEvent::MatchFailed {
+                descriptor: failure.descriptor.clone(),
+                durable_record: failure.durable_record,
+            }),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SessionError {
+    #[error("store error: {0}")]
+    Store(#[from] EvalError),
+
+    #[error("register player failed: {0}")]
+    RegisterPlayer(#[from] RegisterPlayerError),
+
+    #[error("attach tournament player failed: {0}")]
+    AddTournamentPlayer(#[from] AddTournamentPlayerError),
+
+    #[error("game-config mapping failed: {0}")]
+    Mapping(#[from] MappingError),
+
+    #[error("tournament {0:?} not found in store")]
+    TournamentNotFound(TournamentId),
+
+    #[error("orchestrator error: {0}")]
+    Orchestrator(#[from] OrchestratorError),
+}
+
+// ---------------------------------------------------------------------------
+// EvalSession
+// ---------------------------------------------------------------------------
+
+/// Session ties orchestrator + planner + store together for one tournament.
+///
+/// The session owns the driver mpsc, applies lifecycle events to its
+/// `TournamentState`, and re-publishes them to its own broadcast for
+/// consumers. Live per-turn events flow through `live_events()`
+/// (pass-through to the orchestrator's broadcast).
+pub struct EvalSession {
+    state_watch: watch::Sender<TournamentState>,
+    session_events: broadcast::Sender<SessionEvent>,
+    publish_mutex: Arc<Mutex<()>>,
+    orch: Arc<Orchestrator<EvalMatchDescriptor>>,
+    /// Held so `live_events()` can hand out new receivers via `orch.events()`.
+    /// (Field exists implicitly through `orch` — no extra storage.)
+    /// Run-loop join handle. `None` after `shutdown` consumes the session.
+    run_loop_handle: Option<JoinHandle<()>>,
+}
+
+impl EvalSession {
+    /// Create a fresh tournament: register players, insert the tournament
+    /// row, attach participants. Returns the freshly allocated id, which
+    /// the caller plugs into their planner config before [`Self::start`].
+    pub async fn create_tournament(
+        store: Arc<Mutex<EvalStore>>,
+        spec: TournamentSpec,
+        players: Vec<ResolvedPlayer>,
+    ) -> Result<TournamentId, SessionError> {
+        bootstrap_new_tournament(store, &spec, &players)
+            .await
+            .map(|(tid, _)| tid)
+    }
+
+    /// Construct + start the session against an existing tournament id.
+    /// Spawns the run-loop task; `shutdown` awaits it cleanly.
+    ///
+    /// `elo_options` controls Elo recompute on each `MatchFinished`. The
+    /// anchor player must be one of the resolved player ids.
+    pub async fn start<P: Planner + 'static>(
+        store: Arc<Mutex<EvalStore>>,
+        mode: SessionMode,
+        planner: P,
+        orch_config: OrchestratorConfig,
+        elo_options: EloOptions,
+    ) -> Result<Self, SessionError> {
+        let (tournament_id, initial_state) =
+            reconstruct_tournament_state(store.clone(), mode.tournament_id).await?;
+
+        Self::launch(
+            store,
+            tournament_id,
+            initial_state,
+            planner,
+            orch_config,
+            elo_options,
+        )
+    }
+
+    /// Atomic `(state, events)` snapshot+tail. Lifecycle effects reflected
+    /// in the snapshot precede any subsequent broadcast item the receiver
+    /// observes — same contract as the orchestrator's `subscribe`.
+    pub fn subscribe(&self) -> (TournamentState, broadcast::Receiver<SessionEvent>) {
+        let _g = self.publish_mutex.lock();
+        let state = self.state_watch.borrow().clone();
+        let rx = self.session_events.subscribe();
+        (state, rx)
+    }
+
+    /// Watch over `TournamentState`. Useful for one-shot snapshots.
+    pub fn state(&self) -> watch::Receiver<TournamentState> {
+        self.state_watch.subscribe()
+    }
+
+    /// Lossy session-lifecycle event stream. Use [`Self::subscribe`] for
+    /// snapshot+tail consistency.
+    pub fn events(&self) -> broadcast::Receiver<SessionEvent> {
+        self.session_events.subscribe()
+    }
+
+    /// Pass-through to the orchestrator's broadcast: every event including
+    /// per-turn `MatchEvent`s. Lossy. Used by GUIs that want live per-turn
+    /// detail.
+    pub fn live_events(&self) -> broadcast::Receiver<OrchestratorEvent<EvalMatchDescriptor>> {
+        self.orch.events()
+    }
+
+    /// Wait for the tournament to finish (planner.is_done && orch.idle).
+    /// Returns when the run-loop emits `TournamentFinished`.
+    pub async fn join(mut self) {
+        if let Some(h) = self.run_loop_handle.take() {
+            let _ = h.await;
+        }
+    }
+
+    /// Cancel the run loop and shut down the orchestrator. Blocks until
+    /// every match has terminated (with `MatchFailed { Cancelled }` for
+    /// in-flight ones).
+    ///
+    /// The orchestrator's `Drop` impl handles its own task abort once the
+    /// last `Arc` ref drops; we don't `try_unwrap` to call its consuming
+    /// `shutdown(self)` because the run-loop holds an `Arc` clone that
+    /// only drops after `h.await` returns — at that point `self` is also
+    /// going out of scope, so the `Drop` path runs naturally.
+    pub async fn shutdown(mut self) {
+        self.orch.abort();
+        if let Some(h) = self.run_loop_handle.take() {
+            let _ = h.await;
+        }
+    }
+}
+
+impl EvalSession {
+    fn launch<P: Planner + 'static>(
+        store: Arc<Mutex<EvalStore>>,
+        tournament_id: TournamentId,
+        initial_state: TournamentState,
+        planner: P,
+        orch_config: OrchestratorConfig,
+        elo_options: EloOptions,
+    ) -> Result<Self, SessionError> {
+        let store_sink: Arc<dyn MatchSink<EvalMatchDescriptor>> =
+            Arc::new(StoreSink::new(store.clone()));
+        let composite = Arc::new(CompositeSink::new(vec![(SinkRole::Required, store_sink)]));
+        let (orch, driver_rx) = Orchestrator::<EvalMatchDescriptor>::new(orch_config, composite);
+        let orch = Arc::new(orch);
+
+        let (state_watch, _state_rx) = watch::channel(initial_state.clone());
+        let (session_events, _events_rx) = broadcast::channel(256);
+        let publish_mutex = Arc::new(Mutex::new(()));
+
+        let run_loop_handle = tokio::spawn(run_loop(
+            planner,
+            initial_state,
+            tournament_id,
+            state_watch.clone(),
+            session_events.clone(),
+            publish_mutex.clone(),
+            orch.clone(),
+            driver_rx,
+            elo_options,
+        ));
+
+        Ok(Self {
+            state_watch,
+            session_events,
+            publish_mutex,
+            orch,
+            run_loop_handle: Some(run_loop_handle),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Construction modes
+// ---------------------------------------------------------------------------
+
+/// Bootstrap a new tournament: register identity-bearing rows for each
+/// player, create the tournament, attach participants. Returns a fresh
+/// (empty) `TournamentState`.
+async fn bootstrap_new_tournament(
+    store: Arc<Mutex<EvalStore>>,
+    spec: &TournamentSpec,
+    players: &[ResolvedPlayer],
+) -> Result<(TournamentId, TournamentState), SessionError> {
+    let new_tournament = NewTournament {
+        format: spec.format.clone(),
+        target_games_per_matchup: spec.target_games_per_matchup,
+        params_json: spec.params_json.clone(),
+    };
+    let players_to_register: Vec<_> = players
+        .iter()
+        .map(|p| pyrat_eval_store::NewPlayer {
+            id: p.id.clone(),
+            display_name: p.id.clone(),
+            agent_id: Some(player_agent_id(&p.spec).into()),
+            version: None,
+            command: None,
+            metadata_json: None,
+        })
+        .collect();
+
+    let tournament_id = tokio::task::spawn_blocking(move || {
+        let store = store.lock();
+        for p in &players_to_register {
+            store.register_player(p)?;
+        }
+        let tid = store.create_tournament(&new_tournament)?;
+        for (slot, p) in players_to_register.iter().enumerate() {
+            store.add_tournament_player(tid, &p.id, slot as i64)?;
+        }
+        Ok::<TournamentId, SessionError>(tid)
+    })
+    .await
+    .expect("bootstrap blocking task panicked")?;
+
+    Ok((tournament_id, TournamentState::empty(tournament_id)))
+}
+
+/// Reconstruct state from store rows for a resume.
+///
+/// Loads attempts once (no per-loop queries). Folds successes into Elo
+/// and into per-MatchupKey history. The planner picks up from there: it
+/// re-issues missing slots (no row yet) and retries failed slots up to
+/// `max_failures_per_pair` (its own config).
+async fn reconstruct_tournament_state(
+    store: Arc<Mutex<EvalStore>>,
+    tournament_id: TournamentId,
+) -> Result<(TournamentId, TournamentState), SessionError> {
+    let (tournament_id, state) = tokio::task::spawn_blocking(move || {
+        let store = store.lock();
+        let tournament = store
+            .get_tournament(tournament_id)?
+            .ok_or(SessionError::TournamentNotFound(tournament_id))?;
+        let mut state = TournamentState::empty(tournament.id);
+        for attempt in store.get_attempts(tournament.id, None)? {
+            state.fold_attempt(&attempt);
+        }
+        Ok::<(TournamentId, TournamentState), SessionError>((tournament.id, state))
+    })
+    .await
+    .expect("reconstruct blocking task panicked")?;
+    Ok((tournament_id, state))
+}
+
+fn player_agent_id(spec: &pyrat_orchestrator::PlayerSpec) -> &str {
+    match spec {
+        pyrat_orchestrator::PlayerSpec::Subprocess { agent_id, .. } => agent_id,
+        pyrat_orchestrator::PlayerSpec::Embedded { agent_id, .. } => agent_id,
+        // PlayerSpec is `#[non_exhaustive]`. Falls back to "" for unknown
+        // variants — the row gets registered without an agent_id, and the
+        // ensure_player NULL-fill path applies on later updates.
+        _ => "",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Run loop
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::too_many_arguments)]
+async fn run_loop<P: Planner>(
+    mut planner: P,
+    mut state: TournamentState,
+    _tournament_id: TournamentId,
+    state_watch: watch::Sender<TournamentState>,
+    session_events: broadcast::Sender<SessionEvent>,
+    publish_mutex: Arc<Mutex<()>>,
+    orch: Arc<Orchestrator<EvalMatchDescriptor>>,
+    mut driver_rx: mpsc::Receiver<DriverEvent<EvalMatchDescriptor>>,
+    elo_options: EloOptions,
+) {
+    // Initial Elo on resume (so subscribers see standings before the first
+    // MatchFinished arrives).
+    state.recompute_elo(&elo_options);
+    {
+        let _g = publish_mutex.lock();
+        state_watch.send_replace(state.clone());
+    }
+
+    loop {
+        let cap = orch.available_capacity();
+        if cap > 0 {
+            let batch = {
+                let orch_for_alloc = orch.clone();
+                let mut allocate = move || orch_for_alloc.allocate_id();
+                planner.next_batch(&state, cap, &mut allocate)
+            };
+            for matchup in batch {
+                if orch.submit(matchup).await.is_err() {
+                    // Orchestrator shut down underneath us.
+                    return;
+                }
+            }
+        }
+
+        if planner.is_done(&state) && orch.idle() {
+            let _ = session_events.send(SessionEvent::TournamentFinished);
+            return;
+        }
+
+        match driver_rx.recv().await {
+            Some(event) => {
+                state.apply(&event);
+                if matches!(event, DriverEvent::MatchFinished { .. }) {
+                    state.recompute_elo(&elo_options);
+                }
+                {
+                    let _g = publish_mutex.lock();
+                    state_watch.send_replace(state.clone());
+                    if let Some(se) = SessionEvent::from_driver(&event) {
+                        let _ = session_events.send(se);
+                    }
+                }
+                if let Some(obs) = Observation::from_driver_event(&event) {
+                    planner.on_observation(&obs);
+                }
+            },
+            None => {
+                // Driver channel closed (orchestrator dropped). Tournament
+                // can't progress further.
+                return;
+            },
+        }
+    }
+}

--- a/eval/session/src/session.rs
+++ b/eval/session/src/session.rs
@@ -194,6 +194,13 @@ pub enum SessionError {
     #[error("run loop panicked: {0}")]
     RunLoopPanicked(String),
 
+    /// A `spawn_blocking` task panicked during setup (bootstrap or resume
+    /// reconstruction). `what` identifies the task; `message` is the
+    /// stringified panic. Distinct from `RunLoopPanicked` because the
+    /// failure happens before the run loop is even spawned.
+    #[error("background task `{what}` panicked: {message}")]
+    TaskPanicked { what: &'static str, message: String },
+
     /// A single matchup has hit the configured ceiling of consecutive
     /// `SinkFlushError` terminals (see
     /// [`SessionConfig::max_consecutive_sink_flush_failures`]). The store
@@ -479,7 +486,10 @@ async fn bootstrap_new_tournament(
         })
     })
     .await
-    .expect("bootstrap blocking task panicked")
+    .map_err(|e| SessionError::TaskPanicked {
+        what: "bootstrap_new_tournament",
+        message: e.to_string(),
+    })?
 }
 
 /// Reconstruct state from store rows for a resume.
@@ -504,7 +514,10 @@ async fn reconstruct_tournament_state(
         Ok::<(TournamentId, TournamentState), SessionError>((tournament.id, state))
     })
     .await
-    .expect("reconstruct blocking task panicked")?;
+    .map_err(|e| SessionError::TaskPanicked {
+        what: "reconstruct_tournament_state",
+        message: e.to_string(),
+    })??;
     Ok((tournament_id, state))
 }
 

--- a/eval/session/src/session.rs
+++ b/eval/session/src/session.rs
@@ -730,11 +730,11 @@ fn persistent_failure_check(
         // MatchFinished terminals reset it (handled below via the
         // explicit MatchFinished arm).
         if let DriverEvent::MatchFinished { outcome } = event {
-            counts.remove(&matchup_key_from_descriptor(&outcome.descriptor));
+            counts.remove(&MatchupKey::from_descriptor(&outcome.descriptor));
         }
         return None;
     };
-    let key = matchup_key_from_descriptor(&failure.descriptor);
+    let key = MatchupKey::from_descriptor(&failure.descriptor);
     let is_sink_flush = matches!(failure.reason, FailureReason::SinkFlushError(_));
     if !is_sink_flush {
         // Any other terminal — durable failure, cancellation, internal —
@@ -763,25 +763,6 @@ struct PersistentFailureBreach {
     matchup_key: MatchupKey,
     attempt_index: u32,
     last_message: String,
-}
-
-/// Canonical `MatchupKey` for a descriptor (lex-sorted players). The session
-/// indexes by canonical key so two orientations of the same pair share a
-/// counter regardless of which planner submitted them. Commit 7 will fold
-/// this into `MatchupKey::from_descriptor`; until then this stays a local
-/// helper.
-fn matchup_key_from_descriptor(desc: &EvalMatchDescriptor) -> MatchupKey {
-    let (p1, p2) = if desc.player1_id <= desc.player2_id {
-        (desc.player1_id.clone(), desc.player2_id.clone())
-    } else {
-        (desc.player2_id.clone(), desc.player1_id.clone())
-    };
-    MatchupKey {
-        player1_id: p1,
-        player2_id: p2,
-        game_config_id: desc.game_config_id.clone(),
-        repetition_index: desc.repetition_index,
-    }
 }
 
 #[cfg(test)]

--- a/eval/session/src/session.rs
+++ b/eval/session/src/session.rs
@@ -17,9 +17,10 @@
 use std::sync::Arc;
 
 use parking_lot::Mutex;
+use pyrat::game::builder::GameConfig;
 use pyrat_eval_store::{
-    AddTournamentPlayerError, EloOptions, EvalError, EvalStore, NewTournament, RegisterPlayerError,
-    TournamentId,
+    AddTournamentPlayerError, CreateTournamentError, EloOptions, EvalError, EvalStore,
+    NewTournament, RegisterPlayerError, TournamentId,
 };
 use pyrat_orchestrator::{
     CompositeSink, DriverEvent, MatchSink, Orchestrator, OrchestratorConfig, OrchestratorError,
@@ -39,13 +40,38 @@ use crate::store_sink::StoreSink;
 // Public types
 // ---------------------------------------------------------------------------
 
-/// Specification for a brand-new tournament. Stored opaquely as
-/// `tournaments.params_json`; planners deserialize whatever they need.
-#[derive(Debug, Clone)]
+/// Specification for a brand-new tournament. `format`, `target_games_per_matchup`,
+/// and `params_json` are stored opaquely; planners deserialize whatever they
+/// need from `params_json`. `game_config` and `tournament_seed` are the
+/// tournament's runtime identity. Bootstrap derives the durable record from
+/// the config (via `mapping::game_config_to_record`) and stores both on the
+/// tournament row so resume can validate the planner.
+///
+/// `Debug` and `Clone` are not derived: `GameConfig` itself is `Clone` but
+/// not `Debug` — callers that need to log a spec should format the relevant
+/// fields explicitly.
+#[derive(Clone)]
 pub struct TournamentSpec {
     pub format: String,
     pub target_games_per_matchup: Option<u32>,
     pub params_json: String,
+    /// Runtime config — caller hands one source of truth. The bootstrap
+    /// derives the `GameConfigRecord`, ensures the row, and returns the id.
+    pub game_config: GameConfig,
+    /// Tournament-level seed for `matchup_seed` derivation. The high bit is
+    /// dropped at the store boundary; callers can pass any `u64`.
+    pub tournament_seed: u64,
+}
+
+/// Result of [`EvalSession::create_tournament`]. Carries both the freshly
+/// allocated `TournamentId` and the content-hashed `game_config_id` resolved
+/// from `TournamentSpec.game_config`. Callers plug the id into their planner
+/// config; the `game_config_id` saves them a second `ensure_game_config`
+/// round-trip.
+#[derive(Debug, Clone)]
+pub struct CreatedTournament {
+    pub tournament_id: TournamentId,
+    pub game_config_id: String,
 }
 
 /// Reconstruct mode handed to `EvalSession::start`.
@@ -113,6 +139,9 @@ pub enum SessionError {
     #[error("attach tournament player failed: {0}")]
     AddTournamentPlayer(#[from] AddTournamentPlayerError),
 
+    #[error("create tournament failed: {0}")]
+    CreateTournament(#[from] CreateTournamentError),
+
     #[error("game-config mapping failed: {0}")]
     Mapping(#[from] MappingError),
 
@@ -145,17 +174,17 @@ pub struct EvalSession {
 }
 
 impl EvalSession {
-    /// Create a fresh tournament: register players, insert the tournament
-    /// row, attach participants. Returns the freshly allocated id, which
-    /// the caller plugs into their planner config before [`Self::start`].
+    /// Create a fresh tournament: ensure the game config row, register
+    /// players, insert the tournament, attach participants. Returns both
+    /// the freshly allocated `TournamentId` and the resolved
+    /// `game_config_id` (caller plugs both into their planner config
+    /// before [`Self::start`]).
     pub async fn create_tournament(
         store: Arc<Mutex<EvalStore>>,
         spec: TournamentSpec,
         players: Vec<ResolvedPlayer>,
-    ) -> Result<TournamentId, SessionError> {
-        bootstrap_new_tournament(store, &spec, &players)
-            .await
-            .map(|(tid, _)| tid)
+    ) -> Result<CreatedTournament, SessionError> {
+        bootstrap_new_tournament(store, &spec, &players).await
     }
 
     /// Construct + start the session against an existing tournament id.
@@ -281,19 +310,25 @@ impl EvalSession {
 // Construction modes
 // ---------------------------------------------------------------------------
 
-/// Bootstrap a new tournament: register identity-bearing rows for each
-/// player, create the tournament, attach participants. Returns a fresh
-/// (empty) `TournamentState`.
+/// Bootstrap a new tournament: derive the durable `GameConfigRecord` from
+/// the runtime `GameConfig`, ensure the row, register identity-bearing
+/// player rows, insert the tournament with `game_config_id` +
+/// `tournament_seed`, attach participants. Returns the resolved id pair.
+///
+/// `ensure_game_config` is the single source of truth for `game_config_id`:
+/// content-hashed, idempotent. The caller never passes the id directly,
+/// which removes any chance of disagreement between the durable form and
+/// the runtime form.
 async fn bootstrap_new_tournament(
     store: Arc<Mutex<EvalStore>>,
     spec: &TournamentSpec,
     players: &[ResolvedPlayer],
-) -> Result<(TournamentId, TournamentState), SessionError> {
-    let new_tournament = NewTournament {
-        format: spec.format.clone(),
-        target_games_per_matchup: spec.target_games_per_matchup,
-        params_json: spec.params_json.clone(),
-    };
+) -> Result<CreatedTournament, SessionError> {
+    let game_config_record = crate::mapping::game_config_to_record(&spec.game_config)?;
+    let format = spec.format.clone();
+    let target_games_per_matchup = spec.target_games_per_matchup;
+    let params_json = spec.params_json.clone();
+    let tournament_seed = spec.tournament_seed;
     let players_to_register: Vec<_> = players
         .iter()
         .map(|p| pyrat_eval_store::NewPlayer {
@@ -306,21 +341,30 @@ async fn bootstrap_new_tournament(
         })
         .collect();
 
-    let tournament_id = tokio::task::spawn_blocking(move || {
+    tokio::task::spawn_blocking(move || {
         let store = store.lock();
+        let game_config_id = store.ensure_game_config(&game_config_record)?;
         for p in &players_to_register {
             store.register_player(p)?;
         }
+        let new_tournament = NewTournament {
+            format,
+            target_games_per_matchup,
+            params_json,
+            game_config_id: game_config_id.clone(),
+            tournament_seed,
+        };
         let tid = store.create_tournament(&new_tournament)?;
         for (slot, p) in players_to_register.iter().enumerate() {
             store.add_tournament_player(tid, &p.id, slot as i64)?;
         }
-        Ok::<TournamentId, SessionError>(tid)
+        Ok::<CreatedTournament, SessionError>(CreatedTournament {
+            tournament_id: tid,
+            game_config_id,
+        })
     })
     .await
-    .expect("bootstrap blocking task panicked")?;
-
-    Ok((tournament_id, TournamentState::empty(tournament_id)))
+    .expect("bootstrap blocking task panicked")
 }
 
 /// Reconstruct state from store rows for a resume.

--- a/eval/session/src/session.rs
+++ b/eval/session/src/session.rs
@@ -14,6 +14,7 @@
 //! (reconstruct from store rows). Both produce a session that runs to
 //! completion (planner.is_done && orchestrator.idle).
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
@@ -23,8 +24,8 @@ use pyrat_eval_store::{
     NewTournament, RegisterPlayerError, TournamentId,
 };
 use pyrat_orchestrator::{
-    CompositeSink, DriverEvent, MatchSink, Orchestrator, OrchestratorConfig, OrchestratorError,
-    OrchestratorEvent, SinkRole,
+    CompositeSink, DriverEvent, FailureReason, MatchSink, Orchestrator, OrchestratorConfig,
+    OrchestratorError, OrchestratorEvent, SinkRole,
 };
 use tokio::sync::{broadcast, mpsc, watch};
 use tokio::task::JoinHandle;
@@ -34,7 +35,7 @@ use crate::descriptor::EvalMatchDescriptor;
 use crate::mapping::MappingError;
 use crate::observation::Observation;
 use crate::plan::{Planner, ResolvedPlayer};
-use crate::state::TournamentState;
+use crate::state::{MatchupKey, TournamentState};
 use crate::store_sink::StoreSink;
 
 // ---------------------------------------------------------------------------
@@ -75,6 +76,33 @@ pub struct CreatedTournament {
     pub game_config_id: String,
 }
 
+/// Session-level tunables. Defaults are sensible for most callers.
+#[derive(Debug, Clone)]
+pub struct SessionConfig {
+    /// Per-matchup ceiling on consecutive `FailureReason::SinkFlushError`
+    /// terminals. When hit, the run loop aborts with
+    /// [`SessionError::PersistentSinkFlushError`].
+    ///
+    /// Why only `SinkFlushError`: `durable_record=false` also covers
+    /// `Cancelled` (intentional shutdown) and `Internal(_)` (ambiguous);
+    /// neither belongs in an infinite-loop guard. `SinkFlushError` is the
+    /// "infrastructure broken" signal — read-only DB, disk full, FK
+    /// violation, etc. The counter resets on any other terminal for the
+    /// same key (a successful match, durable failure, or cancellation).
+    ///
+    /// The counter is transient (in-memory, not persisted), so a fresh
+    /// process retries from zero. Default: 5.
+    pub max_consecutive_sink_flush_failures: u32,
+}
+
+impl Default for SessionConfig {
+    fn default() -> Self {
+        Self {
+            max_consecutive_sink_flush_failures: 5,
+        }
+    }
+}
+
 /// Reconstruct mode handed to `EvalSession::start`.
 ///
 /// The session always runs against an *existing* tournament id. To create
@@ -106,6 +134,14 @@ pub enum SessionEvent {
         durable_record: bool,
     },
     TournamentFinished,
+    /// Tournament terminated abnormally. Emitted in addition to the
+    /// `SessionError` that `join`/`shutdown` return — consumers that only
+    /// watch the broadcast (e.g. GUIs) get a signal that the tournament
+    /// won't progress further. Currently the only producer is the
+    /// persistent-sink-flush guard.
+    TournamentAborted {
+        reason: String,
+    },
 }
 
 impl SessionEvent {
@@ -157,6 +193,18 @@ pub enum SessionError {
     /// public API so we don't carry it through.
     #[error("run loop panicked: {0}")]
     RunLoopPanicked(String),
+
+    /// A single matchup has hit the configured ceiling of consecutive
+    /// `SinkFlushError` terminals (see
+    /// [`SessionConfig::max_consecutive_sink_flush_failures`]). The store
+    /// is likely broken in a non-transient way (read-only DB, disk full,
+    /// schema mismatch, ...); operator intervention is needed.
+    #[error("persistent sink-flush failure for matchup {matchup_key:?} at attempt {attempt_index}: {last_message}")]
+    PersistentSinkFlushError {
+        matchup_key: MatchupKey,
+        attempt_index: u32,
+        last_message: String,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -201,12 +249,15 @@ impl EvalSession {
     ///
     /// `elo_options` controls Elo recompute on each `MatchFinished`. The
     /// anchor player must be one of the resolved player ids.
+    /// `session_config` carries session-level tunables (defaults are fine
+    /// for most callers).
     pub async fn start<P: Planner + 'static>(
         store: Arc<Mutex<EvalStore>>,
         mode: SessionMode,
         planner: P,
         orch_config: OrchestratorConfig,
         elo_options: EloOptions,
+        session_config: SessionConfig,
     ) -> Result<Self, SessionError> {
         let (tournament_id, initial_state) =
             reconstruct_tournament_state(store.clone(), mode.tournament_id).await?;
@@ -218,6 +269,7 @@ impl EvalSession {
             planner,
             orch_config,
             elo_options,
+            session_config,
         )
     }
 
@@ -302,15 +354,41 @@ async fn await_run_loop(h: JoinHandle<Result<(), SessionError>>) -> Result<(), S
 impl EvalSession {
     fn launch<P: Planner + 'static>(
         store: Arc<Mutex<EvalStore>>,
+        tournament_id: TournamentId,
+        initial_state: TournamentState,
+        planner: P,
+        orch_config: OrchestratorConfig,
+        elo_options: EloOptions,
+        session_config: SessionConfig,
+    ) -> Result<Self, SessionError> {
+        let store_sink: Arc<dyn MatchSink<EvalMatchDescriptor>> =
+            Arc::new(StoreSink::new(store.clone()));
+        let sinks = vec![(SinkRole::Required, store_sink)];
+        Self::launch_with_sinks(
+            tournament_id,
+            initial_state,
+            planner,
+            orch_config,
+            elo_options,
+            session_config,
+            sinks,
+        )
+    }
+
+    /// Test seam: build the orchestrator from caller-supplied sinks instead
+    /// of the default `StoreSink`. Lets unit tests plant a deliberately
+    /// failing sink to exercise [`SessionConfig::max_consecutive_sink_flush_failures`].
+    /// Not part of the public API.
+    pub(crate) fn launch_with_sinks<P: Planner + 'static>(
         _tournament_id: TournamentId,
         initial_state: TournamentState,
         planner: P,
         orch_config: OrchestratorConfig,
         elo_options: EloOptions,
+        session_config: SessionConfig,
+        sinks: Vec<(SinkRole, Arc<dyn MatchSink<EvalMatchDescriptor>>)>,
     ) -> Result<Self, SessionError> {
-        let store_sink: Arc<dyn MatchSink<EvalMatchDescriptor>> =
-            Arc::new(StoreSink::new(store.clone()));
-        let composite = Arc::new(CompositeSink::new(vec![(SinkRole::Required, store_sink)]));
+        let composite = Arc::new(CompositeSink::new(sinks));
         let (orch, driver_rx) = Orchestrator::<EvalMatchDescriptor>::new(orch_config, composite);
         let orch = Arc::new(orch);
 
@@ -328,6 +406,7 @@ impl EvalSession {
             orch.clone(),
             driver_rx,
             elo_options,
+            session_config,
             cancel.clone(),
         ));
 
@@ -454,6 +533,7 @@ async fn run_loop<P: Planner>(
     orch: Arc<Orchestrator<EvalMatchDescriptor>>,
     mut driver_rx: mpsc::Receiver<DriverEvent<EvalMatchDescriptor>>,
     elo_options: EloOptions,
+    session_config: SessionConfig,
     cancel: CancellationToken,
 ) -> Result<(), SessionError> {
     // Initial Elo on resume (so subscribers see standings before the first
@@ -463,6 +543,10 @@ async fn run_loop<P: Planner>(
         let _g = publish_mutex.lock();
         state_watch.send_replace(state.clone());
     }
+
+    // Transient (in-memory) counter of consecutive `SinkFlushError` terminals
+    // per matchup key. See `SessionConfig::max_consecutive_sink_flush_failures`.
+    let mut sink_flush_counts: HashMap<MatchupKey, u32> = HashMap::new();
 
     loop {
         let cap = orch.available_capacity();
@@ -514,6 +598,417 @@ async fn run_loop<P: Planner>(
         }
         if let Some(obs) = Observation::from_driver_event(&event) {
             planner.on_observation(&obs);
+        }
+
+        // Persistent-sink-flush guard. Counts only `SinkFlushError` so
+        // benign non-durable terminals (`Cancelled`, `Internal`) don't
+        // burn the counter. Any other terminal for the same key resets it.
+        if let Some(check) = persistent_failure_check(
+            &event,
+            &mut sink_flush_counts,
+            session_config.max_consecutive_sink_flush_failures,
+        ) {
+            let _ = session_events.send(SessionEvent::TournamentAborted {
+                reason: format!(
+                    "persistent sink-flush failure: {} consecutive `SinkFlushError`s for matchup {:?} (last: {})",
+                    session_config.max_consecutive_sink_flush_failures,
+                    check.matchup_key,
+                    check.last_message
+                ),
+            });
+            return Err(SessionError::PersistentSinkFlushError {
+                matchup_key: check.matchup_key,
+                attempt_index: check.attempt_index,
+                last_message: check.last_message,
+            });
+        }
+    }
+}
+
+/// Per-event update of the per-matchup sink-flush counter. Returns the
+/// breach details when a matchup hits `threshold` consecutive
+/// `SinkFlushError`s, otherwise `None`.
+fn persistent_failure_check(
+    event: &DriverEvent<EvalMatchDescriptor>,
+    counts: &mut HashMap<MatchupKey, u32>,
+    threshold: u32,
+) -> Option<PersistentFailureBreach> {
+    let DriverEvent::MatchFailed { failure } = event else {
+        // Non-terminal events don't update the counter.
+        // MatchFinished terminals reset it (handled below via the
+        // explicit MatchFinished arm).
+        if let DriverEvent::MatchFinished { outcome } = event {
+            counts.remove(&matchup_key_from_descriptor(&outcome.descriptor));
+        }
+        return None;
+    };
+    let key = matchup_key_from_descriptor(&failure.descriptor);
+    let is_sink_flush = matches!(failure.reason, FailureReason::SinkFlushError(_));
+    if !is_sink_flush {
+        // Any other terminal — durable failure, cancellation, internal —
+        // resets the counter for this matchup.
+        counts.remove(&key);
+        return None;
+    }
+    let count = counts.entry(key.clone()).or_insert(0);
+    *count += 1;
+    if *count >= threshold {
+        let last_message = match &failure.reason {
+            FailureReason::SinkFlushError(s) => s.clone(),
+            _ => unreachable!("guard above guarantees SinkFlushError"),
+        };
+        Some(PersistentFailureBreach {
+            matchup_key: key,
+            attempt_index: failure.descriptor.attempt_index,
+            last_message,
+        })
+    } else {
+        None
+    }
+}
+
+struct PersistentFailureBreach {
+    matchup_key: MatchupKey,
+    attempt_index: u32,
+    last_message: String,
+}
+
+/// Canonical `MatchupKey` for a descriptor (lex-sorted players). The session
+/// indexes by canonical key so two orientations of the same pair share a
+/// counter regardless of which planner submitted them. Commit 7 will fold
+/// this into `MatchupKey::from_descriptor`; until then this stays a local
+/// helper.
+fn matchup_key_from_descriptor(desc: &EvalMatchDescriptor) -> MatchupKey {
+    let (p1, p2) = if desc.player1_id <= desc.player2_id {
+        (desc.player1_id.clone(), desc.player2_id.clone())
+    } else {
+        (desc.player2_id.clone(), desc.player1_id.clone())
+    };
+    MatchupKey {
+        player1_id: p1,
+        player2_id: p2,
+        game_config_id: desc.game_config_id.clone(),
+        repetition_index: desc.repetition_index,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests that exercise the `pub(crate)` test seam `launch_with_sinks`
+    //! and the persistent-sink-flush guard. Lives in `src/` (not `tests/`)
+    //! because integration tests compile as external crates and can't see
+    //! `pub(crate)` items.
+
+    use std::time::{Duration, SystemTime};
+
+    use async_trait::async_trait;
+    use pyrat_host::match_host::MatchEvent;
+    use pyrat_host::player::PlayerIdentity;
+    use pyrat_orchestrator::{MatchFailure, MatchId, MatchOutcome, OrchestratorConfig, SinkError};
+
+    use super::*;
+
+    /// Synthetic `MatchFailure` shaped for the persistent-failure tests.
+    fn synthetic_failure(
+        match_id: u64,
+        attempt_index: u32,
+        player1: &str,
+        player2: &str,
+        reason: FailureReason,
+    ) -> MatchFailure<EvalMatchDescriptor> {
+        MatchFailure {
+            descriptor: EvalMatchDescriptor {
+                match_id: MatchId(match_id),
+                tournament_id: TournamentId(1),
+                game_config_id: "gc".into(),
+                player1_id: player1.into(),
+                player2_id: player2.into(),
+                seed: 7,
+                repetition_index: 0,
+                attempt_index,
+                planned_at: SystemTime::UNIX_EPOCH,
+            },
+            started_at: None,
+            failed_at: SystemTime::UNIX_EPOCH,
+            reason,
+            players: None,
+            // `durable_record=false` is the value the run-loop sees from
+            // the orchestrator after a sink flush failure.
+            durable_record: false,
+        }
+    }
+
+    fn driver_failed(
+        failure: MatchFailure<EvalMatchDescriptor>,
+    ) -> DriverEvent<EvalMatchDescriptor> {
+        DriverEvent::MatchFailed { failure }
+    }
+
+    #[test]
+    fn persistent_failure_check_increments_on_sink_flush() {
+        let mut counts = HashMap::new();
+        // 4 of 5 — not yet a breach.
+        for i in 0..4 {
+            let ev = driver_failed(synthetic_failure(
+                i,
+                i as u32,
+                "a",
+                "b",
+                FailureReason::SinkFlushError(format!("planted #{i}")),
+            ));
+            assert!(persistent_failure_check(&ev, &mut counts, 5).is_none());
+        }
+        // 5th SinkFlushError trips the threshold.
+        let ev = driver_failed(synthetic_failure(
+            4,
+            4,
+            "a",
+            "b",
+            FailureReason::SinkFlushError("planted #4".into()),
+        ));
+        let breach = persistent_failure_check(&ev, &mut counts, 5).expect("threshold should fire");
+        assert_eq!(breach.attempt_index, 4);
+        assert_eq!(breach.last_message, "planted #4");
+        assert_eq!(breach.matchup_key.player1_id, "a");
+        assert_eq!(breach.matchup_key.player2_id, "b");
+    }
+
+    #[test]
+    fn persistent_failure_check_resets_on_non_sink_flush_terminal() {
+        let mut counts = HashMap::new();
+        // Two SinkFlush failures.
+        for i in 0..2 {
+            persistent_failure_check(
+                &driver_failed(synthetic_failure(
+                    i,
+                    i as u32,
+                    "a",
+                    "b",
+                    FailureReason::SinkFlushError("planted".into()),
+                )),
+                &mut counts,
+                5,
+            );
+        }
+        assert_eq!(*counts.iter().next().unwrap().1, 2);
+
+        // A `Cancelled` failure on the same matchup resets the counter.
+        let cancel = driver_failed(synthetic_failure(2, 2, "a", "b", FailureReason::Cancelled));
+        persistent_failure_check(&cancel, &mut counts, 5);
+        assert!(counts.is_empty(), "Cancelled resets the counter");
+    }
+
+    #[test]
+    fn persistent_failure_check_resets_on_match_finished() {
+        let mut counts = HashMap::new();
+        persistent_failure_check(
+            &driver_failed(synthetic_failure(
+                0,
+                0,
+                "a",
+                "b",
+                FailureReason::SinkFlushError("planted".into()),
+            )),
+            &mut counts,
+            5,
+        );
+        assert_eq!(counts.len(), 1);
+
+        // Synthesize a successful terminal for the same matchup.
+        let success = DriverEvent::MatchFinished {
+            outcome: MatchOutcome {
+                descriptor: EvalMatchDescriptor {
+                    match_id: MatchId(99),
+                    tournament_id: TournamentId(1),
+                    game_config_id: "gc".into(),
+                    player1_id: "a".into(),
+                    player2_id: "b".into(),
+                    seed: 7,
+                    repetition_index: 0,
+                    attempt_index: 1,
+                    planned_at: SystemTime::UNIX_EPOCH,
+                },
+                started_at: SystemTime::UNIX_EPOCH,
+                finished_at: SystemTime::UNIX_EPOCH,
+                result: pyrat_host::match_host::MatchResult {
+                    result: pyrat_host::wire::GameResult::Draw,
+                    player1_score: 0.0,
+                    player2_score: 0.0,
+                    turns_played: 5,
+                },
+                players: [
+                    PlayerIdentity {
+                        name: "a".into(),
+                        author: "x".into(),
+                        agent_id: "a".into(),
+                        slot: pyrat_host::wire::Player::Player1,
+                    },
+                    PlayerIdentity {
+                        name: "b".into(),
+                        author: "x".into(),
+                        agent_id: "b".into(),
+                        slot: pyrat_host::wire::Player::Player2,
+                    },
+                ],
+            },
+        };
+        persistent_failure_check(&success, &mut counts, 5);
+        assert!(counts.is_empty(), "MatchFinished resets the counter");
+    }
+
+    /// A `MatchSink` that returns `Err` on every terminal callback,
+    /// producing the `SinkFlushError` chain the guard is designed to catch.
+    struct AlwaysFailingSink;
+
+    #[async_trait]
+    impl MatchSink<EvalMatchDescriptor> for AlwaysFailingSink {
+        async fn on_match_started(
+            &self,
+            _descriptor: &EvalMatchDescriptor,
+            _players: &[PlayerIdentity; 2],
+        ) -> Result<(), SinkError> {
+            Ok(())
+        }
+        async fn on_match_event(&self, _id: MatchId, _event: &MatchEvent) -> Result<(), SinkError> {
+            Ok(())
+        }
+        async fn on_match_finished(
+            &self,
+            _outcome: &MatchOutcome<EvalMatchDescriptor>,
+        ) -> Result<(), SinkError> {
+            Err(SinkError {
+                source: anyhow::anyhow!("planted sink failure"),
+            })
+        }
+        async fn on_match_failed(
+            &self,
+            _failure: &MatchFailure<EvalMatchDescriptor>,
+        ) -> Result<(), SinkError> {
+            Ok(())
+        }
+    }
+
+    /// End-to-end via `launch_with_sinks`: plant an always-failing sink and
+    /// confirm the session aborts with `PersistentSinkFlushError` instead of
+    /// looping forever.
+    #[tokio::test]
+    async fn launch_with_sinks_persists_sink_flush_failure_triggers_abort() {
+        use crate::plan::{RoundRobinPlanner, RoundRobinPlannerConfig};
+        use pyrat::game::builder::GameBuilder;
+        use pyrat::{Coordinates, Direction};
+        use pyrat_bot_api::Options;
+        use pyrat_host::player::{EmbeddedBot, EmbeddedCtx};
+        use pyrat_host::wire::TimingMode;
+        use pyrat_orchestrator::{EmbeddedBotFactory, PlayerSpec, Timing};
+        use pyrat_protocol::HashedTurnState;
+
+        struct StayBot;
+        impl Options for StayBot {}
+        impl EmbeddedBot for StayBot {
+            fn think(&mut self, _: &HashedTurnState, _: &EmbeddedCtx) -> Direction {
+                Direction::Stay
+            }
+        }
+
+        let store = Arc::new(Mutex::new(EvalStore::open_in_memory().unwrap()));
+
+        let game_config = GameBuilder::new(3, 3)
+            .with_max_turns(5)
+            .with_open_maze()
+            .with_custom_positions(Coordinates::new(0, 0), Coordinates::new(2, 2))
+            .with_random_cheese(1, false)
+            .build();
+
+        let factory: EmbeddedBotFactory = Arc::new(|| Box::new(StayBot));
+        let players = vec![
+            ResolvedPlayer {
+                id: "a".into(),
+                spec: PlayerSpec::Embedded {
+                    agent_id: "a".into(),
+                    name: "a".into(),
+                    author: "tests".into(),
+                    factory: factory.clone(),
+                },
+            },
+            ResolvedPlayer {
+                id: "b".into(),
+                spec: PlayerSpec::Embedded {
+                    agent_id: "b".into(),
+                    name: "b".into(),
+                    author: "tests".into(),
+                    factory,
+                },
+            },
+        ];
+
+        let spec = TournamentSpec {
+            format: "round_robin".into(),
+            target_games_per_matchup: Some(10),
+            params_json: "{}".into(),
+            game_config: game_config.clone(),
+            tournament_seed: 0xC0FFEE,
+        };
+        let created = EvalSession::create_tournament(store.clone(), spec, players.clone())
+            .await
+            .expect("create_tournament");
+
+        let planner = RoundRobinPlanner::new(RoundRobinPlannerConfig {
+            players,
+            game_config,
+            game_config_id: created.game_config_id,
+            timing: Timing {
+                mode: TimingMode::Wait,
+                move_timeout_ms: 1000,
+                preprocessing_timeout_ms: 5000,
+            },
+            tournament_id: created.tournament_id,
+            target_per_pair: 10,
+            // High enough that the counter trips first, not max_failures.
+            max_failures_per_pair: 999,
+            tournament_seed: 0xC0FFEE,
+        });
+
+        let initial_state = TournamentState::empty(created.tournament_id);
+        let failing_sink: Arc<dyn MatchSink<EvalMatchDescriptor>> = Arc::new(AlwaysFailingSink);
+        let sinks = vec![(SinkRole::Required, failing_sink)];
+
+        let session = EvalSession::launch_with_sinks(
+            created.tournament_id,
+            initial_state,
+            planner,
+            OrchestratorConfig {
+                max_parallel: 1,
+                ..OrchestratorConfig::default()
+            },
+            EloOptions::new("a"),
+            SessionConfig {
+                max_consecutive_sink_flush_failures: 3,
+            },
+            sinks,
+        )
+        .expect("launch");
+
+        let result = tokio::time::timeout(Duration::from_secs(5), session.join())
+            .await
+            .expect("session should not hang");
+        match result {
+            Err(SessionError::PersistentSinkFlushError {
+                attempt_index,
+                last_message,
+                ..
+            }) => {
+                // 3 consecutive failures → counter hits threshold on the 3rd,
+                // so attempt_index in [0, 2].
+                assert!(
+                    attempt_index < 3,
+                    "unexpected attempt_index {attempt_index}"
+                );
+                assert!(
+                    last_message.contains("planted sink failure"),
+                    "unexpected message: {last_message}"
+                );
+            },
+            other => panic!("expected PersistentSinkFlushError, got {other:?}"),
         }
     }
 }

--- a/eval/session/src/session.rs
+++ b/eval/session/src/session.rs
@@ -403,7 +403,7 @@ impl EvalSession {
     /// Not part of the public API.
     pub(crate) fn launch_with_sinks<P: Planner + 'static>(
         _tournament_id: TournamentId,
-        initial_state: TournamentState,
+        mut initial_state: TournamentState,
         planner: P,
         orch_config: OrchestratorConfig,
         elo_options: EloOptions,
@@ -413,6 +413,12 @@ impl EvalSession {
         let composite = Arc::new(CompositeSink::new(sinks));
         let (orch, driver_rx) = Orchestrator::<EvalMatchDescriptor>::new(orch_config, composite);
         let orch = Arc::new(orch);
+
+        // Recompute Elo on the initial state *before* publishing to the
+        // watch. Otherwise a subscriber hitting `subscribe()` between
+        // `start()` returning and the run-loop's first iteration sees a
+        // resumed-tournament snapshot with empty standings.
+        initial_state.recompute_elo(&elo_options);
 
         let (state_watch, _state_rx) = watch::channel(initial_state.clone());
         let (session_events, _events_rx) = broadcast::channel(256);
@@ -626,13 +632,9 @@ async fn run_loop<P: Planner>(
     session_config: SessionConfig,
     cancel: CancellationToken,
 ) -> Result<(), SessionError> {
-    // Initial Elo on resume (so subscribers see standings before the first
-    // MatchFinished arrives).
-    state.recompute_elo(&elo_options);
-    {
-        let _g = publish_mutex.lock();
-        state_watch.send_replace(state.clone());
-    }
+    // Initial Elo was recomputed in `launch_with_sinks` before this task
+    // was spawned, so a subscriber that lands during start sees standings
+    // immediately. The watch was already populated with that state.
 
     // Transient (in-memory) counter of consecutive `SinkFlushError` terminals
     // per matchup key. See `SessionConfig::max_consecutive_sink_flush_failures`.

--- a/eval/session/src/session.rs
+++ b/eval/session/src/session.rs
@@ -60,8 +60,11 @@ pub struct TournamentSpec {
     /// Runtime config — caller hands one source of truth. The bootstrap
     /// derives the `GameConfigRecord`, ensures the row, and returns the id.
     pub game_config: GameConfig,
-    /// Tournament-level seed for `matchup_seed` derivation. The high bit is
-    /// dropped at the store boundary; callers can pass any `u64`.
+    /// Tournament-level seed for `matchup_seed` derivation. Must be
+    /// `<= i64::MAX` — SQLite's INTEGER column is signed, and the store
+    /// rejects out-of-range values with
+    /// `CreateTournamentError::SeedOutOfRange` so the caller's seed and
+    /// the stored seed always agree.
     pub tournament_seed: u64,
 }
 
@@ -235,10 +238,14 @@ pub struct EvalSession {
     state_watch: watch::Sender<TournamentState>,
     session_events: broadcast::Sender<SessionEvent>,
     publish_mutex: Arc<Mutex<()>>,
-    orch: Arc<Orchestrator<EvalMatchDescriptor>>,
-    /// Cancellation seam for `shutdown`. The run-loop selects on this
-    /// alongside `driver_rx.recv()` so cancellation always wins even if no
-    /// further lifecycle events arrive.
+    /// `Option` so `shutdown` can `.take()` the Arc and `Arc::try_unwrap`
+    /// it. Rust forbids partial moves out of types with a `Drop` impl,
+    /// so the only way to keep `Drop for EvalSession` *and* hand `orch`
+    /// to `try_unwrap` is to gate it behind `Option`.
+    orch: Option<Arc<Orchestrator<EvalMatchDescriptor>>>,
+    /// Cancellation seam for `shutdown` and `Drop`. The run-loop selects
+    /// on this alongside `driver_rx.recv()` so cancellation always wins
+    /// even if no further lifecycle events arrive.
     cancel: CancellationToken,
     /// Run-loop join handle. `None` after `shutdown`/`join` consume it.
     run_loop_handle: Option<JoinHandle<Result<(), SessionError>>>,
@@ -286,7 +293,6 @@ impl EvalSession {
 
         Self::launch(
             store,
-            tournament_record.id,
             initial_state,
             planner,
             orch_config,
@@ -319,8 +325,15 @@ impl EvalSession {
     /// Pass-through to the orchestrator's broadcast: every event including
     /// per-turn `MatchEvent`s. Lossy. Used by GUIs that want live per-turn
     /// detail.
+    ///
+    /// # Panics
+    /// Panics if called after [`Self::shutdown`] (the orchestrator handle
+    /// is consumed there). A live session always has it.
     pub fn live_events(&self) -> broadcast::Receiver<OrchestratorEvent<EvalMatchDescriptor>> {
-        self.orch.events()
+        self.orch
+            .as_ref()
+            .expect("live_events called after shutdown")
+            .events()
     }
 
     /// Wait for the tournament to finish (planner.is_done && orch.idle).
@@ -355,11 +368,28 @@ impl EvalSession {
         if let Some(h) = self.run_loop_handle.take() {
             await_run_loop(h).await?;
         }
-        match Arc::try_unwrap(self.orch) {
-            Ok(orch) => orch.shutdown().await,
-            Err(arc) => arc.abort(),
+        if let Some(orch) = self.orch.take() {
+            match Arc::try_unwrap(orch) {
+                Ok(o) => o.shutdown().await,
+                Err(a) => a.abort(),
+            }
         }
         Ok(())
+    }
+}
+
+impl Drop for EvalSession {
+    /// Cancel the run loop if the session is dropped without `shutdown`
+    /// or `join`. The loop's `select!` picks up the cancellation on its
+    /// next iteration and exits, dropping its `Arc<Orchestrator>` clone;
+    /// the session's own clone goes away with `self`. The orchestrator's
+    /// tasks then drain through its own `Drop`.
+    ///
+    /// Fire-and-forget: we can't `await` here, so this is best-effort.
+    /// Callers who need a guaranteed graceful drain should call
+    /// [`Self::shutdown`].
+    fn drop(&mut self) {
+        self.cancel.cancel();
     }
 }
 
@@ -376,7 +406,6 @@ async fn await_run_loop(h: JoinHandle<Result<(), SessionError>>) -> Result<(), S
 impl EvalSession {
     fn launch<P: Planner + 'static>(
         store: Arc<Mutex<EvalStore>>,
-        tournament_id: TournamentId,
         initial_state: TournamentState,
         planner: P,
         orch_config: OrchestratorConfig,
@@ -387,7 +416,6 @@ impl EvalSession {
             Arc::new(StoreSink::new(store.clone()));
         let sinks = vec![(SinkRole::Required, store_sink)];
         Self::launch_with_sinks(
-            tournament_id,
             initial_state,
             planner,
             orch_config,
@@ -400,9 +428,10 @@ impl EvalSession {
     /// Test seam: build the orchestrator from caller-supplied sinks instead
     /// of the default `StoreSink`. Lets unit tests plant a deliberately
     /// failing sink to exercise [`SessionConfig::max_consecutive_sink_flush_failures`].
-    /// Not part of the public API.
+    /// Not part of the public API. The tournament id lives on
+    /// `initial_state.tournament_id`, so the explicit parameter that
+    /// earlier versions carried was redundant.
     pub(crate) fn launch_with_sinks<P: Planner + 'static>(
-        _tournament_id: TournamentId,
         mut initial_state: TournamentState,
         planner: P,
         orch_config: OrchestratorConfig,
@@ -442,10 +471,29 @@ impl EvalSession {
             state_watch,
             session_events,
             publish_mutex,
-            orch,
+            orch: Some(orch),
             cancel,
             run_loop_handle: Some(run_loop_handle),
         })
+    }
+
+    /// Test seam: clone of the session's cancellation token. Used by the
+    /// Drop test to verify that dropping the session fires cancellation.
+    #[cfg(test)]
+    pub(crate) fn cancel_token_for_test(&self) -> CancellationToken {
+        self.cancel.clone()
+    }
+
+    /// Test seam: weak reference to the orchestrator. Used by the Drop
+    /// test to verify the run loop actually drops its `Arc` clone after
+    /// cancellation, proving the leak is closed.
+    #[cfg(test)]
+    pub(crate) fn orch_weak_for_test(&self) -> std::sync::Weak<Orchestrator<EvalMatchDescriptor>> {
+        Arc::downgrade(
+            self.orch
+                .as_ref()
+                .expect("orch_weak_for_test called after shutdown"),
+        )
     }
 }
 
@@ -477,7 +525,7 @@ async fn bootstrap_new_tournament(
         .map(|p| pyrat_eval_store::NewPlayer {
             id: p.id.clone(),
             display_name: p.id.clone(),
-            agent_id: Some(player_agent_id(&p.spec).into()),
+            agent_id: player_agent_id(&p.spec).map(String::from),
             version: None,
             command: None,
             metadata_json: None,
@@ -485,25 +533,31 @@ async fn bootstrap_new_tournament(
         .collect();
 
     tokio::task::spawn_blocking(move || {
-        let store = store.lock();
-        let game_config_id = store.ensure_game_config(&game_config_record)?;
-        for p in &players_to_register {
-            store.register_player(p)?;
-        }
-        let new_tournament = NewTournament {
-            format,
-            target_games_per_matchup,
-            params_json,
-            game_config_id: game_config_id.clone(),
-            tournament_seed,
-        };
-        let tid = store.create_tournament(&new_tournament)?;
-        for (slot, p) in players_to_register.iter().enumerate() {
-            store.add_tournament_player(tid, &p.id, slot as i64)?;
-        }
-        Ok::<CreatedTournament, SessionError>(CreatedTournament {
-            tournament_id: tid,
-            game_config_id,
+        let mut store = store.lock();
+        // Wrap the four bootstrap operations in one transaction so a
+        // mid-sequence failure (e.g. a slot-taken or duplicate-player
+        // error in `add_tournament_player`) doesn't leave a tournament
+        // row + partial participants behind.
+        store.transaction(move |tx| -> Result<CreatedTournament, SessionError> {
+            let game_config_id = tx.ensure_game_config(&game_config_record)?;
+            for p in &players_to_register {
+                tx.register_player(p)?;
+            }
+            let new_tournament = NewTournament {
+                format,
+                target_games_per_matchup,
+                params_json,
+                game_config_id: game_config_id.clone(),
+                tournament_seed,
+            };
+            let tid = tx.create_tournament(&new_tournament)?;
+            for (slot, p) in players_to_register.iter().enumerate() {
+                tx.add_tournament_player(tid, &p.id, slot as i64)?;
+            }
+            Ok(CreatedTournament {
+                tournament_id: tid,
+                game_config_id,
+            })
         })
     })
     .await
@@ -556,6 +610,13 @@ fn validate_planner_against_stored_spec(
     tournament: &TournamentRecord,
     tournament_players: &[TournamentParticipant],
 ) -> Result<(), SessionError> {
+    if planner.expected_format() != tournament.format {
+        return Err(SessionError::TournamentMismatch(format!(
+            "format: planner expected {:?}, stored is {:?}",
+            planner.expected_format(),
+            tournament.format
+        )));
+    }
     if planner.tournament_id() != tournament.id {
         return Err(SessionError::TournamentMismatch(format!(
             "tournament_id: planner expected {:?}, stored is {:?}",
@@ -604,14 +665,14 @@ fn validate_planner_against_stored_spec(
     Ok(())
 }
 
-fn player_agent_id(spec: &pyrat_orchestrator::PlayerSpec) -> &str {
+fn player_agent_id(spec: &pyrat_orchestrator::PlayerSpec) -> Option<&str> {
     match spec {
-        pyrat_orchestrator::PlayerSpec::Subprocess { agent_id, .. } => agent_id,
-        pyrat_orchestrator::PlayerSpec::Embedded { agent_id, .. } => agent_id,
-        // PlayerSpec is `#[non_exhaustive]`. Falls back to "" for unknown
-        // variants — the row gets registered without an agent_id, and the
-        // ensure_player NULL-fill path applies on later updates.
-        _ => "",
+        pyrat_orchestrator::PlayerSpec::Subprocess { agent_id, .. }
+        | pyrat_orchestrator::PlayerSpec::Embedded { agent_id, .. } => Some(agent_id),
+        // PlayerSpec is `#[non_exhaustive]`. Return None for unknown
+        // variants so the row registers with `agent_id = NULL`; the
+        // `register_player` NULL-fill path then applies on later updates.
+        _ => None,
     }
 }
 
@@ -842,8 +903,8 @@ mod tests {
         let breach = persistent_failure_check(&ev, &mut counts, 5).expect("threshold should fire");
         assert_eq!(breach.attempt_index, 4);
         assert_eq!(breach.last_message, "planted #4");
-        assert_eq!(breach.matchup_key.player1_id, "a");
-        assert_eq!(breach.matchup_key.player2_id, "b");
+        assert_eq!(breach.matchup_key.player1_id(), "a");
+        assert_eq!(breach.matchup_key.player2_id(), "b");
     }
 
     #[test]
@@ -1046,7 +1107,6 @@ mod tests {
         let sinks = vec![(SinkRole::Required, failing_sink)];
 
         let session = EvalSession::launch_with_sinks(
-            created.tournament_id,
             initial_state,
             planner,
             OrchestratorConfig {
@@ -1083,5 +1143,126 @@ mod tests {
             },
             other => panic!("expected PersistentSinkFlushError, got {other:?}"),
         }
+    }
+
+    /// Drop without `join`/`shutdown` must cancel the run loop and let
+    /// the orchestrator be released. Two assertions:
+    ///   1. The cancel token transitions to cancelled — proves Drop fired.
+    ///   2. The `Weak<Orchestrator>` fails to upgrade within a bounded
+    ///      window — proves the run loop's `Arc` clone was actually
+    ///      dropped (the leak is closed). Cancellation alone proves the
+    ///      signal; the weak-release check proves the consequence.
+    #[tokio::test]
+    async fn dropping_session_cancels_run_loop_and_releases_orchestrator() {
+        use crate::plan::{RoundRobinPlanner, RoundRobinPlannerConfig};
+        use pyrat::game::builder::GameBuilder;
+        use pyrat::{Coordinates, Direction};
+        use pyrat_bot_api::Options;
+        use pyrat_host::player::{EmbeddedBot, EmbeddedCtx};
+        use pyrat_host::wire::TimingMode;
+        use pyrat_orchestrator::{EmbeddedBotFactory, PlayerSpec, Timing};
+        use pyrat_protocol::HashedTurnState;
+
+        struct StayBot;
+        impl Options for StayBot {}
+        impl EmbeddedBot for StayBot {
+            fn think(&mut self, _: &HashedTurnState, _: &EmbeddedCtx) -> Direction {
+                Direction::Stay
+            }
+        }
+
+        let game_config = GameBuilder::new(3, 3)
+            .with_max_turns(5)
+            .with_open_maze()
+            .with_custom_positions(Coordinates::new(0, 0), Coordinates::new(2, 2))
+            .with_random_cheese(1, false)
+            .build();
+
+        let factory: EmbeddedBotFactory = Arc::new(|| Box::new(StayBot));
+        let players = vec![
+            ResolvedPlayer {
+                id: "a".into(),
+                spec: PlayerSpec::Embedded {
+                    agent_id: "a".into(),
+                    name: "a".into(),
+                    author: "tests".into(),
+                    factory: factory.clone(),
+                },
+            },
+            ResolvedPlayer {
+                id: "b".into(),
+                spec: PlayerSpec::Embedded {
+                    agent_id: "b".into(),
+                    name: "b".into(),
+                    author: "tests".into(),
+                    factory,
+                },
+            },
+        ];
+
+        // 100 games-per-pair: more than enough pending work so the loop
+        // is busy when we drop. We never observe a terminal — Drop fires
+        // mid-run.
+        let planner = RoundRobinPlanner::new(RoundRobinPlannerConfig {
+            players,
+            game_config,
+            game_config_id: "test-config".into(),
+            timing: Timing {
+                mode: TimingMode::Wait,
+                move_timeout_ms: 1000,
+                preprocessing_timeout_ms: 5000,
+            },
+            tournament_id: TournamentId(1),
+            target_per_pair: 100,
+            max_failures_per_pair: 999,
+            tournament_seed: 0xC0FFEE,
+        });
+
+        let initial_state = TournamentState::empty(TournamentId(1));
+        let noop_sink: Arc<dyn MatchSink<EvalMatchDescriptor>> =
+            Arc::new(pyrat_orchestrator::NoOpSink::<EvalMatchDescriptor>::new());
+        let sinks = vec![(SinkRole::Required, noop_sink)];
+
+        let session = EvalSession::launch_with_sinks(
+            initial_state,
+            planner,
+            OrchestratorConfig {
+                max_parallel: 1,
+                ..OrchestratorConfig::default()
+            },
+            EloOptions::new("a"),
+            SessionConfig::default(),
+            sinks,
+        )
+        .expect("launch");
+
+        let token = session.cancel_token_for_test();
+        let weak = session.orch_weak_for_test();
+        assert!(
+            weak.upgrade().is_some(),
+            "orchestrator should be live before drop"
+        );
+
+        drop(session);
+
+        // 1. Cancellation fired — proves Drop ran.
+        tokio::time::timeout(Duration::from_secs(1), token.cancelled())
+            .await
+            .expect("cancel token should fire within 1s of drop");
+
+        // 2. The Arc was actually released — proves the leak is closed.
+        let start = std::time::Instant::now();
+        let mut released = false;
+        while start.elapsed() < Duration::from_secs(1) {
+            if weak.upgrade().is_none() {
+                released = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            released,
+            "orchestrator Arc was not released within 1s of drop"
+        );
     }
 }

--- a/eval/session/src/state.rs
+++ b/eval/session/src/state.rs
@@ -351,6 +351,40 @@ mod tests {
         assert!(s.in_flight.contains(&MatchId(7)));
     }
 
+    /// `MatchStarted` is information-only; `apply` must not touch
+    /// `history` or remove from `in_flight`. Pins the no-op so a future
+    /// edit that (say) starts indexing by start time can't silently
+    /// regress the contract.
+    #[test]
+    fn match_started_is_a_no_op_for_state() {
+        use pyrat_host::player::PlayerIdentity;
+        use pyrat_host::wire::Player;
+
+        let mut s = TournamentState::empty(TournamentId(1));
+        let d = desc(0, "a", "b");
+        s.apply(&DriverEvent::MatchQueued {
+            id: d.match_id,
+            descriptor: d.clone(),
+        });
+        let key = MatchupKey::from_descriptor(&d);
+        let identity = |slot, name: &str| PlayerIdentity {
+            name: name.into(),
+            author: "x".into(),
+            agent_id: name.into(),
+            slot,
+        };
+        s.apply(&DriverEvent::MatchStarted {
+            id: d.match_id,
+            descriptor: d.clone(),
+            players: [
+                identity(Player::Player1, "a"),
+                identity(Player::Player2, "b"),
+            ],
+        });
+        assert!(s.in_flight.contains(&d.match_id), "in_flight unchanged");
+        assert!(!s.history.contains_key(&key), "history unchanged");
+    }
+
     #[test]
     fn match_finished_removes_in_flight_and_appends_success() {
         let mut s = TournamentState::empty(TournamentId(1));

--- a/eval/session/src/state.rs
+++ b/eval/session/src/state.rs
@@ -28,6 +28,12 @@ pub type GameConfigId = String;
 
 /// Identity of one matchup-pair-with-config-and-repetition.
 ///
+/// Always canonical: the constructors lex-sort the player ids, so two
+/// orientations of the same pair `(a, b)` and `(b, a)` collapse onto one
+/// key. Direct struct literal construction is discouraged but not forbidden;
+/// callers should prefer [`MatchupKey::from_descriptor`] or
+/// [`MatchupKey::from_pair`] for the canonicalization guarantee.
+///
 /// Seed is intentionally NOT in the key: it is functionally derived from
 /// the other fields via the planner's stateless seed function. Including
 /// seed here would make every retry a distinct matchup, breaking the
@@ -38,6 +44,32 @@ pub struct MatchupKey {
     pub player2_id: PlayerId,
     pub game_config_id: GameConfigId,
     pub repetition_index: u32,
+}
+
+impl MatchupKey {
+    /// Canonical key for a descriptor — lex-sorts the players so the key
+    /// is invariant under the descriptor's slot orientation.
+    pub fn from_descriptor(desc: &EvalMatchDescriptor) -> Self {
+        Self::from_pair(
+            &desc.player1_id,
+            &desc.player2_id,
+            &desc.game_config_id,
+            desc.repetition_index,
+        )
+    }
+
+    /// Canonical key for a pair — lex-sorts the players. Use this when
+    /// the caller has loose pair fields (e.g. building a key inside a
+    /// planner's `is_done` check).
+    pub fn from_pair(p_a: &str, p_b: &str, game_config_id: &str, repetition_index: u32) -> Self {
+        let (lo, hi) = if p_a <= p_b { (p_a, p_b) } else { (p_b, p_a) };
+        Self {
+            player1_id: lo.to_owned(),
+            player2_id: hi.to_owned(),
+            game_config_id: game_config_id.to_owned(),
+            repetition_index,
+        }
+    }
 }
 
 /// One attempt for a matchup. Carries enough to recompute Elo without
@@ -93,20 +125,29 @@ impl TournamentState {
 
     /// Fold one durable row into history. Used by resume.
     pub fn fold_attempt(&mut self, a: &AttemptRecord) {
-        let key = MatchupKey {
-            player1_id: a.key.player1_id.clone(),
-            player2_id: a.key.player2_id.clone(),
-            game_config_id: a.key.game_config_id.clone(),
-            repetition_index: a.key.repetition_index,
-        };
+        let key = MatchupKey::from_pair(
+            &a.key.player1_id,
+            &a.key.player2_id,
+            &a.key.game_config_id,
+            a.key.repetition_index,
+        );
         let outcome = match &a.outcome {
             AttemptOutcome::Success {
                 player1_score,
                 player2_score,
                 ..
-            } => MatchupOutcome::Success {
-                player1_score: *player1_score,
-                player2_score: *player2_score,
+            } => {
+                // Canonicalize scores to match the canonical key orientation.
+                let (p1_score, p2_score) = canonicalize_scores(
+                    &a.key.player1_id,
+                    &a.key.player2_id,
+                    *player1_score,
+                    *player2_score,
+                );
+                MatchupOutcome::Success {
+                    player1_score: p1_score,
+                    player2_score: p2_score,
+                }
             },
             AttemptOutcome::Failure { .. } => MatchupOutcome::Failure,
         };
@@ -129,14 +170,20 @@ impl TournamentState {
             DriverEvent::MatchFinished { outcome } => {
                 self.in_flight.remove(&outcome.descriptor.match_id);
                 let desc = &outcome.descriptor;
+                let (p1_score, p2_score) = canonicalize_scores(
+                    &desc.player1_id,
+                    &desc.player2_id,
+                    f64::from(outcome.result.player1_score),
+                    f64::from(outcome.result.player2_score),
+                );
                 self.history
-                    .entry(matchup_key(desc))
+                    .entry(MatchupKey::from_descriptor(desc))
                     .or_default()
                     .push(MatchupAttempt {
                         attempt_index: desc.attempt_index,
                         outcome: MatchupOutcome::Success {
-                            player1_score: f64::from(outcome.result.player1_score),
-                            player2_score: f64::from(outcome.result.player2_score),
+                            player1_score: p1_score,
+                            player2_score: p2_score,
                         },
                     });
             },
@@ -145,7 +192,7 @@ impl TournamentState {
                 if failure.durable_record {
                     let desc = &failure.descriptor;
                     self.history
-                        .entry(matchup_key(desc))
+                        .entry(MatchupKey::from_descriptor(desc))
                         .or_default()
                         .push(MatchupAttempt {
                             attempt_index: desc.attempt_index,
@@ -208,12 +255,14 @@ impl TournamentState {
     }
 }
 
-fn matchup_key(desc: &EvalMatchDescriptor) -> MatchupKey {
-    MatchupKey {
-        player1_id: desc.player1_id.clone(),
-        player2_id: desc.player2_id.clone(),
-        game_config_id: desc.game_config_id.clone(),
-        repetition_index: desc.repetition_index,
+/// Swap `(s1, s2)` if `(p1, p2)` would be sorted by `MatchupKey::from_pair`.
+/// Stored history scores must align with the canonical key's player order
+/// so `head_to_head` reads scores in the right slot.
+fn canonicalize_scores(p1: &str, p2: &str, s1: f64, s2: f64) -> (f64, f64) {
+    if p1 <= p2 {
+        (s1, s2)
+    } else {
+        (s2, s1)
     }
 }
 
@@ -312,7 +361,7 @@ mod tests {
         });
         s.apply(&finished(d.clone(), 5.0, 3.0));
         assert!(!s.in_flight.contains(&d.match_id));
-        let key = matchup_key(&d);
+        let key = MatchupKey::from_descriptor(&d);
         let entries = s.history.get(&key).unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].attempt_index, 0);
@@ -335,7 +384,7 @@ mod tests {
         });
         s.apply(&failed(d.clone(), true));
         assert!(!s.in_flight.contains(&d.match_id));
-        let entries = s.history.get(&matchup_key(&d)).unwrap();
+        let entries = s.history.get(&MatchupKey::from_descriptor(&d)).unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].attempt_index, 2);
         assert_eq!(entries[0].outcome.status(), AttemptStatus::Failure);
@@ -355,7 +404,7 @@ mod tests {
         });
         s.apply(&failed(d.clone(), false));
         assert!(!s.in_flight.contains(&d.match_id));
-        assert!(!s.history.contains_key(&matchup_key(&d)));
+        assert!(!s.history.contains_key(&MatchupKey::from_descriptor(&d)));
     }
 
     #[test]

--- a/eval/session/src/state.rs
+++ b/eval/session/src/state.rs
@@ -1,0 +1,428 @@
+//! Tournament-level state: what the planner reads, what resume reconstructs.
+//!
+//! Two views into the same data:
+//! - `history: HashMap<MatchupKey, MatchupHistory>` — per-matchup attempts
+//!   (success rows carry scores so Elo can be recomputed without re-querying
+//!   the store).
+//! - `in_flight: HashSet<MatchId>` — runtime-only set of submitted matches
+//!   whose terminal has not yet been observed.
+//!
+//! `apply(&DriverEvent)` is the canonical state mutator. The four-rule
+//! contract pinned at `plan.md:468` keeps runtime state byte-equivalent to
+//! the durable record: anything not in `match_attempts` is not in `history`
+//! either (kill-9 mid-match leaves no row and no entry; the planner re-issues
+//! at the same `attempt_index` on the next tick).
+
+use std::collections::{HashMap, HashSet};
+
+use pyrat_eval_store::{
+    aggregate_pairs, compute_elo, AttemptOutcome, AttemptRecord, AttemptStatus, EloOptions,
+    EloRating, EloResult, HeadToHead, TournamentId,
+};
+use pyrat_orchestrator::{DriverEvent, MatchId};
+
+use crate::descriptor::EvalMatchDescriptor;
+
+pub type PlayerId = String;
+pub type GameConfigId = String;
+
+/// Identity of one matchup-pair-with-config-and-repetition.
+///
+/// Seed is intentionally NOT in the key: it is functionally derived from
+/// the other fields via the planner's stateless seed function. Including
+/// seed here would make every retry a distinct matchup, breaking the
+/// "retry plays the same seeded game" semantics.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MatchupKey {
+    pub player1_id: PlayerId,
+    pub player2_id: PlayerId,
+    pub game_config_id: GameConfigId,
+    pub repetition_index: u32,
+}
+
+/// One attempt for a matchup. Carries enough to recompute Elo without
+/// re-querying the store.
+///
+/// The plan originally specified `(u32, AttemptStatus)` here. Extended to
+/// carry success scores so `head_to_head` can aggregate without fabricating
+/// `AttemptRecord`s (the in-memory shape stays a faithful projection of the
+/// durable row).
+#[derive(Debug, Clone, PartialEq)]
+pub struct MatchupAttempt {
+    pub attempt_index: u32,
+    pub outcome: MatchupOutcome,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MatchupOutcome {
+    Success {
+        player1_score: f64,
+        player2_score: f64,
+    },
+    Failure,
+}
+
+impl MatchupOutcome {
+    pub fn status(&self) -> AttemptStatus {
+        match self {
+            Self::Success { .. } => AttemptStatus::Success,
+            Self::Failure => AttemptStatus::Failure,
+        }
+    }
+}
+
+pub type MatchupHistory = Vec<MatchupAttempt>;
+
+#[derive(Debug, Clone)]
+pub struct TournamentState {
+    pub tournament_id: TournamentId,
+    pub history: HashMap<MatchupKey, MatchupHistory>,
+    pub in_flight: HashSet<MatchId>,
+    pub standings: Vec<EloRating>,
+}
+
+impl TournamentState {
+    pub fn empty(tournament_id: TournamentId) -> Self {
+        Self {
+            tournament_id,
+            history: HashMap::new(),
+            in_flight: HashSet::new(),
+            standings: Vec::new(),
+        }
+    }
+
+    /// Fold one durable row into history. Used by resume.
+    pub fn fold_attempt(&mut self, a: &AttemptRecord) {
+        let key = MatchupKey {
+            player1_id: a.key.player1_id.clone(),
+            player2_id: a.key.player2_id.clone(),
+            game_config_id: a.key.game_config_id.clone(),
+            repetition_index: a.key.repetition_index,
+        };
+        let outcome = match &a.outcome {
+            AttemptOutcome::Success {
+                player1_score,
+                player2_score,
+                ..
+            } => MatchupOutcome::Success {
+                player1_score: *player1_score,
+                player2_score: *player2_score,
+            },
+            AttemptOutcome::Failure { .. } => MatchupOutcome::Failure,
+        };
+        self.history.entry(key).or_default().push(MatchupAttempt {
+            attempt_index: a.key.attempt_index,
+            outcome,
+        });
+    }
+
+    /// Apply one lifecycle event from the orchestrator. See `plan.md:468`
+    /// for the four-rule contract this implements.
+    pub fn apply(&mut self, event: &DriverEvent<EvalMatchDescriptor>) {
+        // DriverEvent is `#[non_exhaustive]`. The wildcard absorbs future
+        // lifecycle variants; current ones are exhaustive.
+        match event {
+            DriverEvent::MatchQueued { id, .. } => {
+                self.in_flight.insert(*id);
+            },
+            DriverEvent::MatchStarted { .. } => {},
+            DriverEvent::MatchFinished { outcome } => {
+                self.in_flight.remove(&outcome.descriptor.match_id);
+                let desc = &outcome.descriptor;
+                self.history
+                    .entry(matchup_key(desc))
+                    .or_default()
+                    .push(MatchupAttempt {
+                        attempt_index: desc.attempt_index,
+                        outcome: MatchupOutcome::Success {
+                            player1_score: f64::from(outcome.result.player1_score),
+                            player2_score: f64::from(outcome.result.player2_score),
+                        },
+                    });
+            },
+            DriverEvent::MatchFailed { failure } => {
+                self.in_flight.remove(&failure.descriptor.match_id);
+                if failure.durable_record {
+                    let desc = &failure.descriptor;
+                    self.history
+                        .entry(matchup_key(desc))
+                        .or_default()
+                        .push(MatchupAttempt {
+                            attempt_index: desc.attempt_index,
+                            outcome: MatchupOutcome::Failure,
+                        });
+                } else {
+                    tracing::error!(
+                        match_id = ?failure.descriptor.match_id,
+                        attempt_index = failure.descriptor.attempt_index,
+                        reason = ?failure.reason,
+                        "lost match without durable row; planner will silently retry at same attempt_index",
+                    );
+                }
+            },
+            _ => {},
+        }
+    }
+
+    /// Aggregate the success rows in history into head-to-head records
+    /// (Elo input). Failure rows are skipped — Elo is computed from
+    /// successful matches only, mirroring `head_to_head_from_attempt_records`.
+    pub fn head_to_head(&self) -> Vec<HeadToHead> {
+        let pairs = self.history.iter().flat_map(|(key, attempts)| {
+            attempts.iter().filter_map(move |a| match &a.outcome {
+                MatchupOutcome::Success {
+                    player1_score,
+                    player2_score,
+                } => Some((
+                    &key.player1_id,
+                    &key.player2_id,
+                    *player1_score,
+                    *player2_score,
+                )),
+                MatchupOutcome::Failure => None,
+            })
+        });
+        aggregate_pairs(pairs)
+    }
+
+    /// Recompute Elo from current history. On error (no records, disconnected
+    /// graph) standings are cleared. The session calls this after each
+    /// `MatchFinished` apply.
+    pub fn recompute_elo(&mut self, options: &EloOptions) -> Option<EloResult> {
+        let h2h = self.head_to_head();
+        match compute_elo(&h2h, options) {
+            Ok(result) => {
+                self.standings = result.ratings.clone();
+                Some(result)
+            },
+            Err(err) => {
+                tracing::debug!(
+                    tournament_id = ?self.tournament_id,
+                    error = %err,
+                    "elo recompute skipped",
+                );
+                self.standings.clear();
+                None
+            },
+        }
+    }
+}
+
+fn matchup_key(desc: &EvalMatchDescriptor) -> MatchupKey {
+    MatchupKey {
+        player1_id: desc.player1_id.clone(),
+        player2_id: desc.player2_id.clone(),
+        game_config_id: desc.game_config_id.clone(),
+        repetition_index: desc.repetition_index,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::SystemTime;
+
+    use pyrat_eval_store::{AttemptKey, AttemptOutcome};
+    use pyrat_host::match_host::MatchResult;
+    use pyrat_host::player::PlayerIdentity;
+    use pyrat_host::wire::{GameResult, Player};
+    use pyrat_orchestrator::{FailureReason, MatchFailure, MatchOutcome};
+
+    use super::*;
+
+    fn desc(attempt_index: u32, p1: &str, p2: &str) -> EvalMatchDescriptor {
+        EvalMatchDescriptor {
+            match_id: MatchId(u64::from(attempt_index)),
+            tournament_id: TournamentId(1),
+            game_config_id: "gc".into(),
+            player1_id: p1.into(),
+            player2_id: p2.into(),
+            seed: 0,
+            repetition_index: 0,
+            attempt_index,
+            planned_at: SystemTime::UNIX_EPOCH,
+        }
+    }
+
+    fn identity(slot: Player) -> PlayerIdentity {
+        PlayerIdentity {
+            name: "x".into(),
+            author: "x".into(),
+            agent_id: "x".into(),
+            slot,
+        }
+    }
+
+    fn finished(
+        d: EvalMatchDescriptor,
+        p1_score: f32,
+        p2_score: f32,
+    ) -> DriverEvent<EvalMatchDescriptor> {
+        DriverEvent::MatchFinished {
+            outcome: MatchOutcome {
+                descriptor: d,
+                started_at: SystemTime::UNIX_EPOCH,
+                finished_at: SystemTime::UNIX_EPOCH,
+                result: MatchResult {
+                    result: if p1_score > p2_score {
+                        GameResult::Player1
+                    } else if p2_score > p1_score {
+                        GameResult::Player2
+                    } else {
+                        GameResult::Draw
+                    },
+                    player1_score: p1_score,
+                    player2_score: p2_score,
+                    turns_played: 50,
+                },
+                players: [identity(Player::Player1), identity(Player::Player2)],
+            },
+        }
+    }
+
+    fn failed(d: EvalMatchDescriptor, durable: bool) -> DriverEvent<EvalMatchDescriptor> {
+        DriverEvent::MatchFailed {
+            failure: MatchFailure {
+                descriptor: d,
+                started_at: None,
+                failed_at: SystemTime::UNIX_EPOCH,
+                reason: FailureReason::SpawnFailed,
+                players: None,
+                durable_record: durable,
+            },
+        }
+    }
+
+    #[test]
+    fn match_queued_inserts_in_flight() {
+        let mut s = TournamentState::empty(TournamentId(1));
+        s.apply(&DriverEvent::MatchQueued {
+            id: MatchId(7),
+            descriptor: desc(0, "a", "b"),
+        });
+        assert!(s.in_flight.contains(&MatchId(7)));
+    }
+
+    #[test]
+    fn match_finished_removes_in_flight_and_appends_success() {
+        let mut s = TournamentState::empty(TournamentId(1));
+        let d = desc(0, "a", "b");
+        s.apply(&DriverEvent::MatchQueued {
+            id: d.match_id,
+            descriptor: d.clone(),
+        });
+        s.apply(&finished(d.clone(), 5.0, 3.0));
+        assert!(!s.in_flight.contains(&d.match_id));
+        let key = matchup_key(&d);
+        let entries = s.history.get(&key).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].attempt_index, 0);
+        assert!(matches!(
+            entries[0].outcome,
+            MatchupOutcome::Success {
+                player1_score: 5.0,
+                player2_score: 3.0
+            }
+        ));
+    }
+
+    #[test]
+    fn match_failed_durable_appends_failure_entry() {
+        let mut s = TournamentState::empty(TournamentId(1));
+        let d = desc(2, "a", "b");
+        s.apply(&DriverEvent::MatchQueued {
+            id: d.match_id,
+            descriptor: d.clone(),
+        });
+        s.apply(&failed(d.clone(), true));
+        assert!(!s.in_flight.contains(&d.match_id));
+        let entries = s.history.get(&matchup_key(&d)).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].attempt_index, 2);
+        assert_eq!(entries[0].outcome.status(), AttemptStatus::Failure);
+    }
+
+    /// `durable_record == false` is the kill-9 / sink-flush-error case.
+    /// State must remove from `in_flight` but leave `history` untouched —
+    /// otherwise resume diverges from the durable record (no row exists in
+    /// the store; an entry here would make the planner skip the slot).
+    #[test]
+    fn match_failed_non_durable_does_not_touch_history() {
+        let mut s = TournamentState::empty(TournamentId(1));
+        let d = desc(2, "a", "b");
+        s.apply(&DriverEvent::MatchQueued {
+            id: d.match_id,
+            descriptor: d.clone(),
+        });
+        s.apply(&failed(d.clone(), false));
+        assert!(!s.in_flight.contains(&d.match_id));
+        assert!(!s.history.contains_key(&matchup_key(&d)));
+    }
+
+    #[test]
+    fn fold_attempt_reconstructs_history_from_records() {
+        let mut s = TournamentState::empty(TournamentId(1));
+        let key = AttemptKey {
+            tournament_id: TournamentId(1),
+            game_config_id: "gc".into(),
+            player1_id: "a".into(),
+            player2_id: "b".into(),
+            seed: 0,
+            repetition_index: 0,
+            attempt_index: 0,
+        };
+        let rec = AttemptRecord {
+            id: 1,
+            key: key.clone(),
+            finished_at: "2026-05-07 00:00:00".into(),
+            outcome: AttemptOutcome::Success {
+                player1_score: 4.0,
+                player2_score: 2.0,
+                turns: 50,
+                started_at: "2026-05-07 00:00:00".into(),
+            },
+        };
+        s.fold_attempt(&rec);
+        let entries = s
+            .history
+            .get(&MatchupKey {
+                player1_id: "a".into(),
+                player2_id: "b".into(),
+                game_config_id: "gc".into(),
+                repetition_index: 0,
+            })
+            .unwrap();
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn head_to_head_skips_failures() {
+        let mut s = TournamentState::empty(TournamentId(1));
+        s.apply(&finished(desc(0, "a", "b"), 5.0, 3.0));
+        s.apply(&finished(desc(1, "a", "b"), 1.0, 4.0));
+        s.apply(&failed(desc(2, "a", "b"), true));
+        let h = s.head_to_head();
+        assert_eq!(h.len(), 1);
+        assert_eq!(h[0].player_a, "a");
+        assert_eq!(h[0].player_b, "b");
+        assert_eq!(h[0].wins_a, 1);
+        assert_eq!(h[0].wins_b, 1);
+        assert_eq!(h[0].draws, 0);
+    }
+
+    #[test]
+    fn head_to_head_normalizes_pair_order() {
+        // Storing under (b, a) should still aggregate into the canonical
+        // (a, b) pair (sorted) so the same pair from different MatchupKey
+        // orientations doesn't fragment.
+        let mut s = TournamentState::empty(TournamentId(1));
+        s.apply(&finished(desc(0, "a", "b"), 5.0, 3.0));
+        s.apply(&finished(desc(1, "b", "a"), 5.0, 3.0));
+        let h = s.head_to_head();
+        assert_eq!(h.len(), 1);
+        // Both games go to the canonical (a, b) pair.
+        // (a, b, 5, 3) → wins_a += 1.
+        // (b, a, 5, 3) → swapped to (a, b, 3, 5) → wins_b += 1.
+        assert_eq!(h[0].wins_a, 1);
+        assert_eq!(h[0].wins_b, 1);
+    }
+}

--- a/eval/session/src/state.rs
+++ b/eval/session/src/state.rs
@@ -30,9 +30,9 @@ pub type GameConfigId = String;
 ///
 /// Always canonical: the constructors lex-sort the player ids, so two
 /// orientations of the same pair `(a, b)` and `(b, a)` collapse onto one
-/// key. Direct struct literal construction is discouraged but not forbidden;
-/// callers should prefer [`MatchupKey::from_descriptor`] or
-/// [`MatchupKey::from_pair`] for the canonicalization guarantee.
+/// key. Fields are private so direct struct-literal construction can't
+/// break the invariant; use [`MatchupKey::from_descriptor`] or
+/// [`MatchupKey::from_pair`], read with the accessor methods below.
 ///
 /// Seed is intentionally NOT in the key: it is functionally derived from
 /// the other fields via the planner's stateless seed function. Including
@@ -40,10 +40,10 @@ pub type GameConfigId = String;
 /// "retry plays the same seeded game" semantics.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MatchupKey {
-    pub player1_id: PlayerId,
-    pub player2_id: PlayerId,
-    pub game_config_id: GameConfigId,
-    pub repetition_index: u32,
+    player1_id: PlayerId,
+    player2_id: PlayerId,
+    game_config_id: GameConfigId,
+    repetition_index: u32,
 }
 
 impl MatchupKey {
@@ -69,6 +69,27 @@ impl MatchupKey {
             game_config_id: game_config_id.to_owned(),
             repetition_index,
         }
+    }
+
+    /// Canonical player id at slot 0 (lex-min).
+    pub fn player1_id(&self) -> &str {
+        &self.player1_id
+    }
+
+    /// Canonical player id at slot 1 (lex-max).
+    pub fn player2_id(&self) -> &str {
+        &self.player2_id
+    }
+
+    /// Content-hashed id of the game config this matchup uses.
+    pub fn game_config_id(&self) -> &str {
+        &self.game_config_id
+    }
+
+    /// 0-based index distinguishing the Nth game of this pair-and-config
+    /// matchup (target > 1 schedules multiple games per pair).
+    pub fn repetition_index(&self) -> u32 {
+        self.repetition_index
     }
 }
 
@@ -467,12 +488,7 @@ mod tests {
         s.fold_attempt(&rec);
         let entries = s
             .history
-            .get(&MatchupKey {
-                player1_id: "a".into(),
-                player2_id: "b".into(),
-                game_config_id: "gc".into(),
-                repetition_index: 0,
-            })
+            .get(&MatchupKey::from_pair("a", "b", "gc", 0))
             .unwrap();
         assert_eq!(entries.len(), 1);
     }

--- a/eval/session/src/store_sink.rs
+++ b/eval/session/src/store_sink.rs
@@ -1,0 +1,345 @@
+//! `MatchSink` that writes `match_attempts` rows to `pyrat-eval-store`.
+//!
+//! Always classified `Required` by callers — a flush failure here means the
+//! tournament's durable record is incomplete.
+//!
+//! `durable_record == false` failures are skipped: they signal "the row
+//! couldn't be written" (sink flush failure) or "the match was lost without
+//! a record" (kill-9). Either way, no row exists, so the planner re-issues
+//! at the same `attempt_index` on resume. This is what keeps runtime state
+//! and durable state byte-equivalent.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use parking_lot::Mutex;
+use pyrat_eval_store::{EvalStore, RecordAttemptError};
+use pyrat_host::match_host::MatchEvent;
+use pyrat_host::player::PlayerIdentity;
+use pyrat_orchestrator::{MatchFailure, MatchId, MatchOutcome, MatchSink, SinkError};
+
+use crate::descriptor::EvalMatchDescriptor;
+use crate::mapping::{failure_to_new_attempt, outcome_to_new_attempt};
+
+/// Required sink that persists match terminals as `match_attempts` rows.
+///
+/// SQLite ownership: a single `Arc<Mutex<EvalStore>>` is acquired inside
+/// `tokio::task::spawn_blocking`, never held across an `.await` (rusqlite
+/// is sync, so the mutex covers the inline blocking call). For a future
+/// hot path, the alternative is a per-call connection pool — documented
+/// here, not implemented in v1.
+pub struct StoreSink {
+    store: Arc<Mutex<EvalStore>>,
+}
+
+impl StoreSink {
+    pub fn new(store: Arc<Mutex<EvalStore>>) -> Self {
+        Self { store }
+    }
+}
+
+#[async_trait]
+impl MatchSink<EvalMatchDescriptor> for StoreSink {
+    async fn on_match_started(
+        &self,
+        _descriptor: &EvalMatchDescriptor,
+        _players: &[PlayerIdentity; 2],
+    ) -> Result<(), SinkError> {
+        // No row at start. v1 punt: an `attempts.status='in_flight'` row
+        // would give forensics on lost matches, but it complicates resume
+        // (must reconcile). The plan documents this as a follow-up.
+        Ok(())
+    }
+
+    async fn on_match_event(&self, _id: MatchId, _event: &MatchEvent) -> Result<(), SinkError> {
+        // Per-event accept is cheap. The store is terminal-only; replay
+        // sinks (a separate Optional sink) handle per-event capture.
+        Ok(())
+    }
+
+    async fn on_match_finished(
+        &self,
+        outcome: &MatchOutcome<EvalMatchDescriptor>,
+    ) -> Result<(), SinkError> {
+        let attempt = outcome_to_new_attempt(outcome);
+        let store = self.store.clone();
+        tokio::task::spawn_blocking(move || {
+            store
+                .lock()
+                .record_attempt(&attempt)
+                .map(|_id| ())
+                .map_err(StoreSinkError::Record)
+        })
+        .await
+        .map_err(StoreSinkError::Join)
+        .and_then(|r| r)
+        .map_err(|e| SinkError {
+            source: anyhow::Error::new(e),
+        })
+    }
+
+    async fn on_match_failed(
+        &self,
+        failure: &MatchFailure<EvalMatchDescriptor>,
+    ) -> Result<(), SinkError> {
+        // The orchestrator emits durable_record=false in two cases:
+        //   1. The match was lost without a row (kill-9).
+        //   2. A Required sink errored on terminal flush — the executor uses
+        //      this to signal "the broken sink isn't called again".
+        // In both, no row should exist, otherwise the planner would think
+        // the slot is done and skip retry.
+        if !failure.durable_record {
+            tracing::error!(
+                match_id = ?failure.descriptor.match_id,
+                attempt_index = failure.descriptor.attempt_index,
+                reason = ?failure.reason,
+                "skipping store write for non-durable failure (planner will silently retry)",
+            );
+            return Ok(());
+        }
+        let attempt = failure_to_new_attempt(failure);
+        let store = self.store.clone();
+        tokio::task::spawn_blocking(move || {
+            store
+                .lock()
+                .record_attempt(&attempt)
+                .map(|_id| ())
+                .map_err(StoreSinkError::Record)
+        })
+        .await
+        .map_err(StoreSinkError::Join)
+        .and_then(|r| r)
+        .map_err(|e| SinkError {
+            source: anyhow::Error::new(e),
+        })
+    }
+}
+
+/// Internal store-sink error. Wrapped in `SinkError` at the sink boundary so
+/// the orchestrator's contract sees `anyhow::Error`.
+#[derive(Debug, thiserror::Error)]
+pub enum StoreSinkError {
+    #[error("blocking task panicked: {0}")]
+    Join(tokio::task::JoinError),
+
+    #[error("record_attempt failed: {0}")]
+    Record(#[from] RecordAttemptError),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    use pyrat_eval_store::{
+        AttemptOutcome, EvalStore, GameConfigRecord, NewPlayer, NewTournament, TournamentId,
+    };
+    use pyrat_host::match_host::MatchResult;
+    use pyrat_host::player::PlayerIdentity;
+    use pyrat_host::wire::{GameResult, Player};
+    use pyrat_orchestrator::{FailureReason, MatchId};
+
+    use super::*;
+
+    fn identity(slot: Player) -> PlayerIdentity {
+        PlayerIdentity {
+            name: "x".into(),
+            author: "x".into(),
+            agent_id: "x".into(),
+            slot,
+        }
+    }
+
+    /// Bootstrap an in-memory store with one tournament, two players, one
+    /// game-config row. Returns the seeded ids.
+    fn seeded_store() -> (Arc<Mutex<EvalStore>>, TournamentId, String) {
+        let store = EvalStore::open_in_memory().unwrap();
+        let game_config_id = store
+            .ensure_game_config(&GameConfigRecord {
+                width: 7,
+                height: 5,
+                max_turns: 300,
+                wall_density: 0.7,
+                mud_density: 0.1,
+                mud_range: 3,
+                connected: true,
+                symmetric: true,
+                cheese_count: 3,
+                cheese_symmetric: true,
+            })
+            .unwrap();
+        store
+            .register_player(&NewPlayer {
+                id: "a".into(),
+                display_name: "A".into(),
+                agent_id: Some("a".into()),
+                version: None,
+                command: None,
+                metadata_json: None,
+            })
+            .unwrap();
+        store
+            .register_player(&NewPlayer {
+                id: "b".into(),
+                display_name: "B".into(),
+                agent_id: Some("b".into()),
+                version: None,
+                command: None,
+                metadata_json: None,
+            })
+            .unwrap();
+        let tid = store
+            .create_tournament(&NewTournament {
+                format: "round_robin".into(),
+                target_games_per_matchup: Some(1),
+                params_json: "{}".into(),
+            })
+            .unwrap();
+        store.add_tournament_player(tid, "a", 0).unwrap();
+        store.add_tournament_player(tid, "b", 1).unwrap();
+        (Arc::new(Mutex::new(store)), tid, game_config_id)
+    }
+
+    fn descriptor(
+        tid: TournamentId,
+        game_config_id: &str,
+        match_id: u64,
+        attempt_index: u32,
+    ) -> EvalMatchDescriptor {
+        EvalMatchDescriptor {
+            match_id: MatchId(match_id),
+            tournament_id: tid,
+            game_config_id: game_config_id.into(),
+            player1_id: "a".into(),
+            player2_id: "b".into(),
+            seed: 42,
+            repetition_index: 0,
+            attempt_index,
+            planned_at: SystemTime::UNIX_EPOCH,
+        }
+    }
+
+    #[tokio::test]
+    async fn on_match_finished_writes_success_row() {
+        let (store, tid, gc) = seeded_store();
+        let sink = StoreSink::new(store.clone());
+        let outcome = MatchOutcome {
+            descriptor: descriptor(tid, &gc, 1, 0),
+            started_at: UNIX_EPOCH + Duration::from_secs(100),
+            finished_at: UNIX_EPOCH + Duration::from_secs(200),
+            result: MatchResult {
+                result: GameResult::Player1,
+                player1_score: 5.0,
+                player2_score: 3.0,
+                turns_played: 50,
+            },
+            players: [identity(Player::Player1), identity(Player::Player2)],
+        };
+        sink.on_match_finished(&outcome).await.unwrap();
+        // Row visible via the same store handle (sufficient because we
+        // hold the only writer; PR 5's plan refers to "via a separate
+        // SQLite connection" but the in-memory store is single-connection
+        // by design — re-opening creates a new empty DB).
+        let attempts = store.lock().get_attempts(tid, None).unwrap();
+        assert_eq!(attempts.len(), 1);
+        match &attempts[0].outcome {
+            AttemptOutcome::Success {
+                player1_score,
+                player2_score,
+                turns,
+                ..
+            } => {
+                assert!((player1_score - 5.0).abs() < 1e-9);
+                assert!((player2_score - 3.0).abs() < 1e-9);
+                assert_eq!(*turns, 50);
+            },
+            AttemptOutcome::Failure { .. } => panic!("expected success"),
+        }
+    }
+
+    #[tokio::test]
+    async fn on_match_failed_durable_writes_failure_row() {
+        let (store, tid, gc) = seeded_store();
+        let sink = StoreSink::new(store.clone());
+        let failure = MatchFailure {
+            descriptor: descriptor(tid, &gc, 1, 0),
+            started_at: None,
+            failed_at: UNIX_EPOCH + Duration::from_secs(50),
+            reason: FailureReason::SpawnFailed,
+            players: None,
+            durable_record: true,
+        };
+        sink.on_match_failed(&failure).await.unwrap();
+        let attempts = store.lock().get_attempts(tid, None).unwrap();
+        assert_eq!(attempts.len(), 1);
+        match &attempts[0].outcome {
+            AttemptOutcome::Failure {
+                failure_reason,
+                started_at,
+            } => {
+                assert_eq!(failure_reason, "spawn_failed");
+                assert!(started_at.is_none());
+            },
+            AttemptOutcome::Success { .. } => panic!("expected failure"),
+        }
+    }
+
+    /// `durable_record == false` is the load-bearing rule: skip the write
+    /// entirely so resume / runtime state stays equivalent.
+    #[tokio::test]
+    async fn on_match_failed_non_durable_skips_write() {
+        let (store, tid, gc) = seeded_store();
+        let sink = StoreSink::new(store.clone());
+        let failure = MatchFailure {
+            descriptor: descriptor(tid, &gc, 1, 0),
+            started_at: None,
+            failed_at: UNIX_EPOCH + Duration::from_secs(50),
+            reason: FailureReason::Cancelled,
+            players: None,
+            durable_record: false,
+        };
+        sink.on_match_failed(&failure).await.unwrap();
+        let attempts = store.lock().get_attempts(tid, None).unwrap();
+        assert!(attempts.is_empty(), "no row should be written");
+    }
+
+    /// Descriptor fields end up in the right `match_attempts` columns.
+    /// Pins the projection contract.
+    #[tokio::test]
+    async fn descriptor_fields_round_trip_to_attempt_record() {
+        let (store, tid, gc) = seeded_store();
+        let sink = StoreSink::new(store.clone());
+        let outcome = MatchOutcome {
+            descriptor: EvalMatchDescriptor {
+                match_id: MatchId(7),
+                tournament_id: tid,
+                game_config_id: gc.clone(),
+                player1_id: "a".into(),
+                player2_id: "b".into(),
+                seed: 0x1234,
+                repetition_index: 2,
+                attempt_index: 3,
+                planned_at: SystemTime::UNIX_EPOCH,
+            },
+            started_at: UNIX_EPOCH + Duration::from_secs(100),
+            finished_at: UNIX_EPOCH + Duration::from_secs(200),
+            result: MatchResult {
+                result: GameResult::Draw,
+                player1_score: 1.0,
+                player2_score: 1.0,
+                turns_played: 25,
+            },
+            players: [identity(Player::Player1), identity(Player::Player2)],
+        };
+        sink.on_match_finished(&outcome).await.unwrap();
+        let attempts = store.lock().get_attempts(tid, None).unwrap();
+        assert_eq!(attempts.len(), 1);
+        let key = &attempts[0].key;
+        assert_eq!(key.tournament_id, tid);
+        assert_eq!(key.game_config_id, gc);
+        assert_eq!(key.player1_id, "a");
+        assert_eq!(key.player2_id, "b");
+        assert_eq!(key.seed, 0x1234);
+        assert_eq!(key.repetition_index, 2);
+        assert_eq!(key.attempt_index, 3);
+    }
+}

--- a/eval/session/src/store_sink.rs
+++ b/eval/session/src/store_sink.rs
@@ -192,6 +192,8 @@ mod tests {
                 format: "round_robin".into(),
                 target_games_per_matchup: Some(1),
                 params_json: "{}".into(),
+                game_config_id: game_config_id.clone(),
+                tournament_seed: 0,
             })
             .unwrap();
         store.add_tournament_player(tid, "a", 0).unwrap();

--- a/eval/session/tests/bootstrap_atomic.rs
+++ b/eval/session/tests/bootstrap_atomic.rs
@@ -1,0 +1,77 @@
+//! `EvalSession::create_tournament` runs its four bootstrap steps inside a
+//! single SQLite transaction. A mid-sequence failure must roll the
+//! tournament row + any participants back so the store doesn't end up in a
+//! partial state that would confuse resume.
+
+mod common;
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use pyrat_eval::{EvalSession, ResolvedPlayer, SessionError, TournamentSpec};
+use pyrat_eval_store::{AddTournamentPlayerError, EvalStore, TournamentId};
+use pyrat_orchestrator::PlayerSpec;
+
+use crate::common::{mock_factory, small_game_config};
+
+/// Two `ResolvedPlayer`s with the same id and identical identity fields.
+/// `register_player` is idempotent for matching identities, so both
+/// register cleanly. The tournament row inserts. The first
+/// `add_tournament_player` succeeds at slot 0. The second collides on
+/// `PRIMARY KEY (tournament_id, player_id)` and the store's typed
+/// pre-check returns `PlayerAlreadyInTournament` — failure lands *after*
+/// the tournament row is inserted, which is what makes rollback meaningful.
+#[tokio::test]
+async fn tournament_row_not_orphaned_on_mid_bootstrap_failure() {
+    let store = Arc::new(Mutex::new(EvalStore::open_in_memory().unwrap()));
+    let duplicate = ResolvedPlayer {
+        id: "a".into(),
+        spec: PlayerSpec::Embedded {
+            agent_id: "a".into(),
+            name: "a".into(),
+            author: "tests".into(),
+            factory: mock_factory(),
+        },
+    };
+    // Same id, same identity — both register as no-op-success.
+    let players = vec![duplicate.clone(), duplicate];
+
+    let spec = TournamentSpec {
+        format: "round_robin".into(),
+        target_games_per_matchup: Some(1),
+        params_json: "{}".into(),
+        game_config: small_game_config(),
+        tournament_seed: 0xC0FFEE,
+    };
+
+    let err = EvalSession::create_tournament(store.clone(), spec, players)
+        .await
+        .expect_err("duplicate player id should fail bootstrap");
+
+    // The typed error must bubble through.
+    match err {
+        SessionError::AddTournamentPlayer(
+            AddTournamentPlayerError::PlayerAlreadyInTournament { .. },
+        ) => {},
+        other => panic!("expected PlayerAlreadyInTournament, got {other:?}"),
+    }
+
+    // Post-state assertions — the call errored so there is no `tid` to
+    // query directly. Use the list to prove no row survived.
+    let s = store.lock();
+    let tournaments = s.list_tournaments().expect("list_tournaments");
+    assert!(
+        tournaments.is_empty(),
+        "tournament row leaked after rollback: {tournaments:?}"
+    );
+    // Defense-in-depth: a fresh DB would have allocated id 1. If the
+    // rollback failed to remove the slot-0 participant, the row would
+    // still be visible by that id.
+    let participants = s
+        .get_tournament_players(TournamentId(1))
+        .expect("get_tournament_players");
+    assert!(
+        participants.is_empty(),
+        "participant row leaked after rollback: {participants:?}"
+    );
+}

--- a/eval/session/tests/common/mod.rs
+++ b/eval/session/tests/common/mod.rs
@@ -1,0 +1,116 @@
+//! Shared fixtures for session integration tests.
+//!
+//! Mirrors `eval/orchestrator/tests/common/mod.rs` but specialised to the
+//! eval-session types (`EvalMatchDescriptor`, `ResolvedPlayer`).
+
+#![allow(dead_code)]
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use pyrat::game::builder::GameConfig;
+use pyrat::{Coordinates, Direction, GameBuilder};
+use pyrat_bot_api::Options;
+use pyrat_eval::{
+    GameConfigId, ResolvedPlayer, RoundRobinPlanner, RoundRobinPlannerConfig, TournamentSpec,
+};
+use pyrat_eval_store::{EvalStore, GameConfigRecord};
+use pyrat_host::player::{EmbeddedBot, EmbeddedCtx};
+use pyrat_host::wire::TimingMode;
+use pyrat_orchestrator::{EmbeddedBotFactory, OrchestratorConfig, PlayerSpec, Timing};
+use pyrat_protocol::HashedTurnState;
+
+pub struct MockBot;
+impl Options for MockBot {}
+impl EmbeddedBot for MockBot {
+    fn think(&mut self, _: &HashedTurnState, _: &EmbeddedCtx) -> Direction {
+        Direction::Stay
+    }
+}
+
+pub fn mock_factory() -> EmbeddedBotFactory {
+    Arc::new(|| Box::new(MockBot))
+}
+
+/// Tiny deterministic config: 3x3 open maze, corner starts, single cheese,
+/// 5-turn cap. Two MockBots draw with player1/player2 score = 0.5 / 0.5.
+pub fn small_game_config() -> GameConfig {
+    GameBuilder::new(3, 3)
+        .with_max_turns(5)
+        .with_open_maze()
+        .with_custom_positions(Coordinates::new(0, 0), Coordinates::new(2, 2))
+        .with_custom_cheese(vec![Coordinates::new(1, 1)])
+        .build()
+}
+
+pub fn embedded_player(id: &str) -> ResolvedPlayer {
+    ResolvedPlayer {
+        id: id.into(),
+        spec: PlayerSpec::Embedded {
+            agent_id: id.into(),
+            name: id.into(),
+            author: "tests".into(),
+            factory: mock_factory(),
+        },
+    }
+}
+
+pub fn fast_orch_config() -> OrchestratorConfig {
+    OrchestratorConfig {
+        max_parallel: 2,
+        ..OrchestratorConfig::default()
+    }
+}
+
+pub fn fast_timing() -> Timing {
+    Timing {
+        mode: TimingMode::Wait,
+        move_timeout_ms: 1000,
+        preprocessing_timeout_ms: 5000,
+    }
+}
+
+pub fn open_store_with_config(store: &Arc<Mutex<EvalStore>>) -> GameConfigId {
+    store
+        .lock()
+        .ensure_game_config(&GameConfigRecord {
+            width: 3,
+            height: 3,
+            max_turns: 5,
+            wall_density: 0.0,
+            mud_density: 0.0,
+            mud_range: 2,
+            connected: true,
+            symmetric: false,
+            cheese_count: 1,
+            cheese_symmetric: false,
+        })
+        .expect("ensure_game_config")
+}
+
+pub fn round_robin(
+    players: Vec<ResolvedPlayer>,
+    game_config: GameConfig,
+    game_config_id: String,
+    tournament_id: pyrat_eval_store::TournamentId,
+    target_per_pair: u32,
+) -> RoundRobinPlanner {
+    RoundRobinPlanner::new(RoundRobinPlannerConfig {
+        players,
+        game_config,
+        game_config_id,
+        timing: fast_timing(),
+        tournament_id,
+        target_per_pair,
+        max_failures_per_pair: 3,
+        tournament_seed: 0xC0FFEE,
+    })
+}
+
+pub fn round_robin_spec() -> TournamentSpec {
+    TournamentSpec {
+        format: "round_robin".into(),
+        target_games_per_matchup: Some(1),
+        params_json: "{}".into(),
+    }
+}

--- a/eval/session/tests/common/mod.rs
+++ b/eval/session/tests/common/mod.rs
@@ -32,14 +32,19 @@ pub fn mock_factory() -> EmbeddedBotFactory {
     Arc::new(|| Box::new(MockBot))
 }
 
-/// Tiny deterministic config: 3x3 open maze, corner starts, single cheese,
-/// 5-turn cap. Two MockBots draw with player1/player2 score = 0.5 / 0.5.
+/// Tiny config: 3x3 open maze, corner starts, single random cheese,
+/// 5-turn cap. Random cheese (instead of custom) so the config maps
+/// cleanly through `game_config_to_record` (the durable record schema
+/// only represents random cheese). MockBots always Stay, so neither
+/// reaches any cheese regardless of where it spawns and the game runs
+/// to max_turns with score 0/0 — the test outcome is `AttemptOutcome::Success`
+/// regardless of cheese placement.
 pub fn small_game_config() -> GameConfig {
     GameBuilder::new(3, 3)
         .with_max_turns(5)
         .with_open_maze()
         .with_custom_positions(Coordinates::new(0, 0), Coordinates::new(2, 2))
-        .with_custom_cheese(vec![Coordinates::new(1, 1)])
+        .with_random_cheese(1, false)
         .build()
 }
 
@@ -70,6 +75,9 @@ pub fn fast_timing() -> Timing {
     }
 }
 
+/// Insert the game config row that matches [`small_game_config`] and return
+/// its content-hash id. For tests that bypass [`EvalSession::create_tournament`]
+/// and plant rows into the store directly (the session does this itself).
 pub fn open_store_with_config(store: &Arc<Mutex<EvalStore>>) -> GameConfigId {
     store
         .lock()
@@ -112,5 +120,7 @@ pub fn round_robin_spec() -> TournamentSpec {
         format: "round_robin".into(),
         target_games_per_matchup: Some(1),
         params_json: "{}".into(),
+        game_config: small_game_config(),
+        tournament_seed: 0xC0FFEE,
     }
 }

--- a/eval/session/tests/e2e_session.rs
+++ b/eval/session/tests/e2e_session.rs
@@ -44,7 +44,7 @@ async fn round_robin_two_mockbots_finishes_with_durable_rows() {
     .await
     .expect("session start");
 
-    session.join().await;
+    session.join().await.expect("session join");
 
     let attempts = store
         .lock()
@@ -94,7 +94,7 @@ async fn three_player_round_robin_records_three_attempts() {
     )
     .await
     .unwrap();
-    session.join().await;
+    session.join().await.expect("session join");
 
     let attempts = store
         .lock()

--- a/eval/session/tests/e2e_session.rs
+++ b/eval/session/tests/e2e_session.rs
@@ -1,0 +1,90 @@
+//! End-to-end: real `EvalSession` with embedded MockBots, real
+//! `pyrat-orchestrator`, real `pyrat-eval-store`. Two MockBots play a
+//! round-robin to completion. Verifies durable rows match the planned set.
+
+mod common;
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use pyrat_eval::{EvalSession, SessionMode};
+use pyrat_eval_store::{AttemptOutcome, EloOptions, EvalStore};
+
+use crate::common::{
+    embedded_player, fast_orch_config, open_store_with_config, round_robin, round_robin_spec,
+    small_game_config,
+};
+
+#[tokio::test]
+async fn round_robin_two_mockbots_finishes_with_durable_rows() {
+    let store = Arc::new(Mutex::new(EvalStore::open_in_memory().unwrap()));
+    let game_config_id = open_store_with_config(&store);
+
+    let players = vec![embedded_player("a"), embedded_player("b")];
+
+    let tid = EvalSession::create_tournament(store.clone(), round_robin_spec(), players.clone())
+        .await
+        .expect("create_tournament");
+
+    let planner = round_robin(players, small_game_config(), game_config_id, tid, 1);
+    let session = EvalSession::start(
+        store.clone(),
+        SessionMode { tournament_id: tid },
+        planner,
+        fast_orch_config(),
+        EloOptions::new("a"),
+    )
+    .await
+    .expect("session start");
+
+    session.join().await;
+
+    let attempts = store.lock().get_attempts(tid, None).unwrap();
+    // 2 players × 1 game per pair = 1 matchup.
+    assert_eq!(
+        attempts.len(),
+        1,
+        "expected 1 attempt row, got {attempts:?}"
+    );
+    assert!(matches!(
+        attempts[0].outcome,
+        AttemptOutcome::Success { .. }
+    ));
+}
+
+#[tokio::test]
+async fn three_player_round_robin_records_three_attempts() {
+    let store = Arc::new(Mutex::new(EvalStore::open_in_memory().unwrap()));
+    let game_config_id = open_store_with_config(&store);
+    let players = vec![
+        embedded_player("a"),
+        embedded_player("b"),
+        embedded_player("c"),
+    ];
+
+    let tid = EvalSession::create_tournament(store.clone(), round_robin_spec(), players.clone())
+        .await
+        .unwrap();
+
+    let planner = round_robin(players, small_game_config(), game_config_id, tid, 1);
+    let session = EvalSession::start(
+        store.clone(),
+        SessionMode { tournament_id: tid },
+        planner,
+        fast_orch_config(),
+        EloOptions::new("a"),
+    )
+    .await
+    .unwrap();
+    session.join().await;
+
+    let attempts = store.lock().get_attempts(tid, None).unwrap();
+    assert_eq!(
+        attempts.len(),
+        3,
+        "expected 3 attempts (3 unordered pairs × 1 game)"
+    );
+    for a in &attempts {
+        assert!(matches!(a.outcome, AttemptOutcome::Success { .. }));
+    }
+}

--- a/eval/session/tests/e2e_session.rs
+++ b/eval/session/tests/e2e_session.rs
@@ -11,25 +11,32 @@ use pyrat_eval::{EvalSession, SessionMode};
 use pyrat_eval_store::{AttemptOutcome, EloOptions, EvalStore};
 
 use crate::common::{
-    embedded_player, fast_orch_config, open_store_with_config, round_robin, round_robin_spec,
-    small_game_config,
+    embedded_player, fast_orch_config, round_robin, round_robin_spec, small_game_config,
 };
 
 #[tokio::test]
 async fn round_robin_two_mockbots_finishes_with_durable_rows() {
     let store = Arc::new(Mutex::new(EvalStore::open_in_memory().unwrap()));
-    let game_config_id = open_store_with_config(&store);
-
     let players = vec![embedded_player("a"), embedded_player("b")];
 
-    let tid = EvalSession::create_tournament(store.clone(), round_robin_spec(), players.clone())
-        .await
-        .expect("create_tournament");
+    // create_tournament now ensures the game_config row internally.
+    let created =
+        EvalSession::create_tournament(store.clone(), round_robin_spec(), players.clone())
+            .await
+            .expect("create_tournament");
 
-    let planner = round_robin(players, small_game_config(), game_config_id, tid, 1);
+    let planner = round_robin(
+        players,
+        small_game_config(),
+        created.game_config_id.clone(),
+        created.tournament_id,
+        1,
+    );
     let session = EvalSession::start(
         store.clone(),
-        SessionMode { tournament_id: tid },
+        SessionMode {
+            tournament_id: created.tournament_id,
+        },
         planner,
         fast_orch_config(),
         EloOptions::new("a"),
@@ -39,7 +46,10 @@ async fn round_robin_two_mockbots_finishes_with_durable_rows() {
 
     session.join().await;
 
-    let attempts = store.lock().get_attempts(tid, None).unwrap();
+    let attempts = store
+        .lock()
+        .get_attempts(created.tournament_id, None)
+        .unwrap();
     // 2 players × 1 game per pair = 1 matchup.
     assert_eq!(
         attempts.len(),
@@ -55,21 +65,29 @@ async fn round_robin_two_mockbots_finishes_with_durable_rows() {
 #[tokio::test]
 async fn three_player_round_robin_records_three_attempts() {
     let store = Arc::new(Mutex::new(EvalStore::open_in_memory().unwrap()));
-    let game_config_id = open_store_with_config(&store);
     let players = vec![
         embedded_player("a"),
         embedded_player("b"),
         embedded_player("c"),
     ];
 
-    let tid = EvalSession::create_tournament(store.clone(), round_robin_spec(), players.clone())
-        .await
-        .unwrap();
+    let created =
+        EvalSession::create_tournament(store.clone(), round_robin_spec(), players.clone())
+            .await
+            .unwrap();
 
-    let planner = round_robin(players, small_game_config(), game_config_id, tid, 1);
+    let planner = round_robin(
+        players,
+        small_game_config(),
+        created.game_config_id,
+        created.tournament_id,
+        1,
+    );
     let session = EvalSession::start(
         store.clone(),
-        SessionMode { tournament_id: tid },
+        SessionMode {
+            tournament_id: created.tournament_id,
+        },
         planner,
         fast_orch_config(),
         EloOptions::new("a"),
@@ -78,7 +96,10 @@ async fn three_player_round_robin_records_three_attempts() {
     .unwrap();
     session.join().await;
 
-    let attempts = store.lock().get_attempts(tid, None).unwrap();
+    let attempts = store
+        .lock()
+        .get_attempts(created.tournament_id, None)
+        .unwrap();
     assert_eq!(
         attempts.len(),
         3,

--- a/eval/session/tests/e2e_session.rs
+++ b/eval/session/tests/e2e_session.rs
@@ -7,7 +7,7 @@ mod common;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
-use pyrat_eval::{EvalSession, SessionMode};
+use pyrat_eval::{EvalSession, SessionConfig, SessionMode};
 use pyrat_eval_store::{AttemptOutcome, EloOptions, EvalStore};
 
 use crate::common::{
@@ -40,6 +40,7 @@ async fn round_robin_two_mockbots_finishes_with_durable_rows() {
         planner,
         fast_orch_config(),
         EloOptions::new("a"),
+        SessionConfig::default(),
     )
     .await
     .expect("session start");
@@ -91,6 +92,7 @@ async fn three_player_round_robin_records_three_attempts() {
         planner,
         fast_orch_config(),
         EloOptions::new("a"),
+        SessionConfig::default(),
     )
     .await
     .unwrap();

--- a/eval/session/tests/resume.rs
+++ b/eval/session/tests/resume.rs
@@ -44,6 +44,8 @@ async fn resume_skips_completed_matchups() {
                 format: "round_robin".into(),
                 target_games_per_matchup: Some(1),
                 params_json: "{}".into(),
+                game_config_id: game_config_id.clone(),
+                tournament_seed: 0xC0FFEE,
             })
             .unwrap();
         for (slot, p) in [&p1, &p2, &p3].iter().enumerate() {

--- a/eval/session/tests/resume.rs
+++ b/eval/session/tests/resume.rs
@@ -1,0 +1,120 @@
+//! Resume reconstruction: after planting partial attempt rows in the
+//! store, the planner should re-issue exactly the missing matchups.
+
+mod common;
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use pyrat_eval::{
+    mapping::synthetic_attempt, matchup_seed, MatchupKey, MatchupOutcome, Planner, TournamentState,
+};
+use pyrat_eval_store::{EvalStore, NewAttemptOutcome, NewPlayer, NewTournament};
+use pyrat_orchestrator::MatchIdAllocator;
+
+use crate::common::{embedded_player, open_store_with_config, round_robin, small_game_config};
+
+/// Helper to plant a success row directly into the store, then verify the
+/// planner reconstructs `TournamentState.history` from it on resume.
+#[tokio::test]
+async fn resume_skips_completed_matchups() {
+    let store = Arc::new(Mutex::new(EvalStore::open_in_memory().unwrap()));
+    let game_config_id = open_store_with_config(&store);
+
+    let p1 = embedded_player("a");
+    let p2 = embedded_player("b");
+    let p3 = embedded_player("c");
+
+    // Register players + tournament + participants.
+    let tid = {
+        let s = store.lock();
+        for p in [&p1, &p2, &p3] {
+            s.register_player(&NewPlayer {
+                id: p.id.clone(),
+                display_name: p.id.clone(),
+                agent_id: Some(p.id.clone()),
+                version: None,
+                command: None,
+                metadata_json: None,
+            })
+            .unwrap();
+        }
+        let tid = s
+            .create_tournament(&NewTournament {
+                format: "round_robin".into(),
+                target_games_per_matchup: Some(1),
+                params_json: "{}".into(),
+            })
+            .unwrap();
+        for (slot, p) in [&p1, &p2, &p3].iter().enumerate() {
+            s.add_tournament_player(tid, &p.id, slot as i64).unwrap();
+        }
+        tid
+    };
+
+    // Plant one success row for (a, b): that pair is "done".
+    let seed_ab = matchup_seed(0xC0FFEE, "a", "b", &game_config_id, 0);
+    let attempt = synthetic_attempt(
+        tid,
+        &game_config_id,
+        "a",
+        "b",
+        seed_ab,
+        0,
+        0,
+        "1970-01-01 00:01:00",
+        NewAttemptOutcome::Success {
+            player1_score: 1.0,
+            player2_score: 0.0,
+            turns: 5,
+            started_at: "1970-01-01 00:00:00".into(),
+        },
+    );
+    store.lock().record_attempt(&attempt).unwrap();
+
+    // Reconstruct state and ask the planner what to issue.
+    let attempts = store.lock().get_attempts(tid, None).unwrap();
+    let mut state = TournamentState::empty(tid);
+    for a in &attempts {
+        state.fold_attempt(a);
+    }
+
+    // Sanity: history shows the (a, b) matchup as Success.
+    let key_ab = MatchupKey {
+        player1_id: "a".into(),
+        player2_id: "b".into(),
+        game_config_id: game_config_id.clone(),
+        repetition_index: 0,
+    };
+    assert!(matches!(
+        state.history.get(&key_ab).unwrap()[0].outcome,
+        MatchupOutcome::Success { .. }
+    ));
+
+    // Planner with all three players, target=1: should issue (a,c) and (b,c) only.
+    let mut planner = round_robin(
+        vec![p1, p2, p3],
+        small_game_config(),
+        game_config_id.clone(),
+        tid,
+        1,
+    );
+    let alloc = MatchIdAllocator::new();
+    let batch = planner.next_batch(&state, 100, &mut || alloc.allocate());
+
+    let mut pairs: Vec<_> = batch
+        .iter()
+        .map(|m| {
+            (
+                m.descriptor.player1_id.clone(),
+                m.descriptor.player2_id.clone(),
+            )
+        })
+        .collect();
+    pairs.sort();
+    assert_eq!(
+        pairs,
+        vec![("a".into(), "c".into()), ("b".into(), "c".into()),],
+        "planner should re-issue exactly the two missing matchups",
+    );
+}

--- a/eval/session/tests/resume.rs
+++ b/eval/session/tests/resume.rs
@@ -7,12 +7,15 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 use pyrat_eval::{
-    mapping::synthetic_attempt, matchup_seed, MatchupKey, MatchupOutcome, Planner, TournamentState,
+    mapping::synthetic_attempt, matchup_seed, EvalSession, MatchupKey, MatchupOutcome, Planner,
+    SessionConfig, SessionMode, TournamentSpec, TournamentState,
 };
-use pyrat_eval_store::{EvalStore, NewAttemptOutcome, NewPlayer, NewTournament};
+use pyrat_eval_store::{EloOptions, EvalStore, NewAttemptOutcome, NewPlayer, NewTournament};
 use pyrat_orchestrator::MatchIdAllocator;
 
-use crate::common::{embedded_player, open_store_with_config, round_robin, small_game_config};
+use crate::common::{
+    embedded_player, fast_orch_config, open_store_with_config, round_robin, small_game_config,
+};
 
 /// Helper to plant a success row directly into the store, then verify the
 /// planner reconstructs `TournamentState.history` from it on resume.
@@ -119,4 +122,94 @@ async fn resume_skips_completed_matchups() {
         vec![("a".into(), "c".into()), ("b".into(), "c".into()),],
         "planner should re-issue exactly the two missing matchups",
     );
+}
+
+/// Regression test: subscribing to a resumed session immediately after
+/// `start` should see non-empty standings in the snapshot, because Elo
+/// gets recomputed *before* the watch is populated.
+///
+/// Before this fix, the run loop did the initial recompute as its first
+/// step, so a subscriber landing between `start` returning and the loop's
+/// first iteration saw empty standings.
+#[tokio::test]
+async fn subscribe_immediately_after_resume_sees_standings() {
+    let store = Arc::new(Mutex::new(EvalStore::open_in_memory().unwrap()));
+    let players = vec![embedded_player("a"), embedded_player("b")];
+
+    // Bootstrap a tournament and plant ONE success row directly so the
+    // resumed state has something to recompute Elo from.
+    let spec = TournamentSpec {
+        format: "round_robin".into(),
+        target_games_per_matchup: Some(1),
+        params_json: "{}".into(),
+        game_config: small_game_config(),
+        tournament_seed: 0xC0FFEE,
+    };
+    let created = EvalSession::create_tournament(store.clone(), spec, players.clone())
+        .await
+        .expect("create_tournament");
+
+    let seed = matchup_seed(0xC0FFEE, "a", "b", &created.game_config_id, 0);
+    store
+        .lock()
+        .record_attempt(&synthetic_attempt(
+            created.tournament_id,
+            &created.game_config_id,
+            "a",
+            "b",
+            seed,
+            0,
+            0,
+            "1970-01-01 00:01:00",
+            NewAttemptOutcome::Success {
+                player1_score: 1.0,
+                player2_score: 0.0,
+                turns: 5,
+                started_at: "1970-01-01 00:00:00".into(),
+            },
+        ))
+        .unwrap();
+
+    let planner = round_robin(
+        players,
+        small_game_config(),
+        created.game_config_id.clone(),
+        created.tournament_id,
+        1,
+    );
+    let session = EvalSession::start(
+        store.clone(),
+        SessionMode {
+            tournament_id: created.tournament_id,
+        },
+        planner,
+        fast_orch_config(),
+        EloOptions::new("a"),
+        SessionConfig::default(),
+    )
+    .await
+    .expect("session start");
+
+    // Immediately subscribe — *before* yielding to the run loop. Snapshot
+    // must already reflect the post-resume Elo recompute, not empty
+    // standings.
+    let (snapshot, _rx) = session.subscribe();
+    assert!(
+        !snapshot.standings.is_empty(),
+        "resume snapshot must include recomputed standings"
+    );
+    // Anchor player "a" should be at the rating system's anchor value.
+    let a_rating = snapshot
+        .standings
+        .iter()
+        .find(|r| r.player_id == "a")
+        .expect("anchor player should appear in standings");
+    // EloOptions::new(<anchor>) defaults to 1000.0 for the anchor.
+    assert!(
+        (a_rating.elo - 1000.0).abs() < 0.01,
+        "anchor Elo should be 1000.0, got {}",
+        a_rating.elo
+    );
+
+    session.shutdown().await.expect("shutdown");
 }

--- a/eval/session/tests/resume.rs
+++ b/eval/session/tests/resume.rs
@@ -122,6 +122,221 @@ async fn resume_skips_completed_matchups() {
         vec![("a".into(), "c".into()), ("b".into(), "c".into()),],
         "planner should re-issue exactly the two missing matchups",
     );
+
+    // Tighten: every re-issued matchup should have attempt_index=0 (no
+    // prior rows for these pairs) and the canonical seed derived from
+    // tournament_seed + pair + game_config_id + repetition.
+    for matchup in &batch {
+        assert_eq!(
+            matchup.descriptor.attempt_index, 0,
+            "fresh slot (no prior rows) should use attempt_index=0"
+        );
+        let expected_seed = matchup_seed(
+            0xC0FFEE,
+            &matchup.descriptor.player1_id,
+            &matchup.descriptor.player2_id,
+            &game_config_id,
+            matchup.descriptor.repetition_index,
+        );
+        assert_eq!(
+            matchup.descriptor.seed, expected_seed,
+            "seed should be the canonical matchup_seed of the pair"
+        );
+    }
+}
+
+/// Kill-9 case: a matchup whose attempt previously failed durably must
+/// be re-issued at attempt_index=N+1 with the same canonical seed.
+///
+/// "Durably failed" means there IS a Failure row in the store. The
+/// planner sees one entry in history with outcome Failure and bumps to
+/// the next attempt index.
+#[tokio::test]
+async fn resume_retries_durably_failed_matchup_at_next_attempt_index() {
+    let store = Arc::new(Mutex::new(EvalStore::open_in_memory().unwrap()));
+    let game_config_id = open_store_with_config(&store);
+
+    let p1 = embedded_player("a");
+    let p2 = embedded_player("b");
+
+    let tid = {
+        let s = store.lock();
+        for p in [&p1, &p2] {
+            s.register_player(&NewPlayer {
+                id: p.id.clone(),
+                display_name: p.id.clone(),
+                agent_id: Some(p.id.clone()),
+                version: None,
+                command: None,
+                metadata_json: None,
+            })
+            .unwrap();
+        }
+        let tid = s
+            .create_tournament(&NewTournament {
+                format: "round_robin".into(),
+                target_games_per_matchup: Some(1),
+                params_json: "{}".into(),
+                game_config_id: game_config_id.clone(),
+                tournament_seed: 0xC0FFEE,
+            })
+            .unwrap();
+        s.add_tournament_player(tid, &p1.id, 0).unwrap();
+        s.add_tournament_player(tid, &p2.id, 1).unwrap();
+        tid
+    };
+
+    // Plant a durable Failure row at attempt_index=0.
+    let seed_ab = matchup_seed(0xC0FFEE, "a", "b", &game_config_id, 0);
+    let attempt = synthetic_attempt(
+        tid,
+        &game_config_id,
+        "a",
+        "b",
+        seed_ab,
+        0,
+        0,
+        "1970-01-01 00:01:00",
+        NewAttemptOutcome::Failure {
+            failure_reason: "spawn_failed".into(),
+            started_at: None,
+        },
+    );
+    store.lock().record_attempt(&attempt).unwrap();
+
+    let attempts = store.lock().get_attempts(tid, None).unwrap();
+    let mut state = TournamentState::empty(tid);
+    for a in &attempts {
+        state.fold_attempt(a);
+    }
+
+    let mut planner = round_robin(
+        vec![p1, p2],
+        small_game_config(),
+        game_config_id.clone(),
+        tid,
+        1,
+    );
+    let alloc = MatchIdAllocator::new();
+    let batch = planner.next_batch(&state, 100, &mut || alloc.allocate());
+
+    assert_eq!(batch.len(), 1, "expected single retry");
+    let m = &batch[0];
+    assert_eq!(
+        m.descriptor.attempt_index, 1,
+        "durable failure → retry at attempt_index=1"
+    );
+    assert_eq!(
+        m.descriptor.seed, seed_ab,
+        "seed must be the same canonical seed across retries"
+    );
+}
+
+/// Kill-9 case proper: no row exists at all (the original match was
+/// lost without a write). The planner must re-issue at attempt_index=0
+/// with the canonical seed — the same seeded game the original would
+/// have played.
+///
+/// This is the failure mode the durability invariant exists to handle:
+/// `match_attempts` is empty for this matchup, so a fresh `TournamentState`
+/// reconstructed from rows has no entry for it, and the planner treats
+/// it as never-issued.
+#[tokio::test]
+async fn resume_re_issues_kill9_matchup_at_attempt_zero_with_canonical_seed() {
+    let store = Arc::new(Mutex::new(EvalStore::open_in_memory().unwrap()));
+    let game_config_id = open_store_with_config(&store);
+
+    let p1 = embedded_player("a");
+    let p2 = embedded_player("b");
+    let p3 = embedded_player("c");
+
+    let tid = {
+        let s = store.lock();
+        for p in [&p1, &p2, &p3] {
+            s.register_player(&NewPlayer {
+                id: p.id.clone(),
+                display_name: p.id.clone(),
+                agent_id: Some(p.id.clone()),
+                version: None,
+                command: None,
+                metadata_json: None,
+            })
+            .unwrap();
+        }
+        let tid = s
+            .create_tournament(&NewTournament {
+                format: "round_robin".into(),
+                target_games_per_matchup: Some(1),
+                params_json: "{}".into(),
+                game_config_id: game_config_id.clone(),
+                tournament_seed: 0xC0FFEE,
+            })
+            .unwrap();
+        for (slot, p) in [&p1, &p2, &p3].iter().enumerate() {
+            s.add_tournament_player(tid, &p.id, slot as i64).unwrap();
+        }
+        tid
+    };
+
+    // Plant a success for (a, b) only. (a, c) and (b, c) have NO rows —
+    // simulating kill-9 mid-match for those two pairs.
+    let seed_ab = matchup_seed(0xC0FFEE, "a", "b", &game_config_id, 0);
+    store
+        .lock()
+        .record_attempt(&synthetic_attempt(
+            tid,
+            &game_config_id,
+            "a",
+            "b",
+            seed_ab,
+            0,
+            0,
+            "1970-01-01 00:01:00",
+            NewAttemptOutcome::Success {
+                player1_score: 1.0,
+                player2_score: 0.0,
+                turns: 5,
+                started_at: "1970-01-01 00:00:00".into(),
+            },
+        ))
+        .unwrap();
+
+    let attempts = store.lock().get_attempts(tid, None).unwrap();
+    let mut state = TournamentState::empty(tid);
+    for a in &attempts {
+        state.fold_attempt(a);
+    }
+
+    let mut planner = round_robin(
+        vec![p1, p2, p3],
+        small_game_config(),
+        game_config_id.clone(),
+        tid,
+        1,
+    );
+    let alloc = MatchIdAllocator::new();
+    let batch = planner.next_batch(&state, 100, &mut || alloc.allocate());
+
+    // Both kill-9 pairs should be re-issued at attempt_index=0 with the
+    // canonical seed they would have used originally.
+    assert_eq!(batch.len(), 2, "expected (a,c) and (b,c) to be re-issued");
+    for matchup in &batch {
+        assert_eq!(
+            matchup.descriptor.attempt_index, 0,
+            "kill-9 matchup with no prior row should use attempt_index=0"
+        );
+        let canonical_seed = matchup_seed(
+            0xC0FFEE,
+            &matchup.descriptor.player1_id,
+            &matchup.descriptor.player2_id,
+            &game_config_id,
+            matchup.descriptor.repetition_index,
+        );
+        assert_eq!(
+            matchup.descriptor.seed, canonical_seed,
+            "kill-9 retry must replay the same canonical seed"
+        );
+    }
 }
 
 /// Regression test: subscribing to a resumed session immediately after

--- a/eval/session/tests/resume.rs
+++ b/eval/session/tests/resume.rs
@@ -85,12 +85,7 @@ async fn resume_skips_completed_matchups() {
     }
 
     // Sanity: history shows the (a, b) matchup as Success.
-    let key_ab = MatchupKey {
-        player1_id: "a".into(),
-        player2_id: "b".into(),
-        game_config_id: game_config_id.clone(),
-        repetition_index: 0,
-    };
+    let key_ab = MatchupKey::from_pair("a", "b", &game_config_id, 0);
     assert!(matches!(
         state.history.get(&key_ab).unwrap()[0].outcome,
         MatchupOutcome::Success { .. }

--- a/eval/session/tests/shutdown.rs
+++ b/eval/session/tests/shutdown.rs
@@ -9,12 +9,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use parking_lot::Mutex;
-use pyrat_eval::{EvalSession, SessionConfig, SessionMode};
+use pyrat_eval::{EvalSession, SessionConfig, SessionMode, TournamentSpec};
 use pyrat_eval_store::{EloOptions, EvalStore};
 
-use crate::common::{
-    embedded_player, fast_orch_config, round_robin, round_robin_spec, small_game_config,
-};
+use crate::common::{embedded_player, fast_orch_config, round_robin, small_game_config};
 
 #[tokio::test]
 async fn shutdown_returns_promptly_with_pending_matchups() {
@@ -28,10 +26,19 @@ async fn shutdown_returns_promptly_with_pending_matchups() {
         embedded_player("e"),
     ];
 
-    let created =
-        EvalSession::create_tournament(store.clone(), round_robin_spec(), players.clone())
-            .await
-            .expect("create_tournament");
+    // Spec target must match the planner's target_per_pair below or
+    // `start` rejects the planner via TournamentMismatch.
+    const TARGET: u32 = 50;
+    let spec = TournamentSpec {
+        format: "round_robin".into(),
+        target_games_per_matchup: Some(TARGET),
+        params_json: "{}".into(),
+        game_config: small_game_config(),
+        tournament_seed: 0xC0FFEE,
+    };
+    let created = EvalSession::create_tournament(store.clone(), spec, players.clone())
+        .await
+        .expect("create_tournament");
 
     let planner = round_robin(
         players,
@@ -41,7 +48,7 @@ async fn shutdown_returns_promptly_with_pending_matchups() {
         // Many games per pair so the planner has plenty of pending work
         // when we call shutdown. The point is to prove `shutdown` doesn't
         // wait for natural completion.
-        50,
+        TARGET,
     );
     let session = EvalSession::start(
         store.clone(),

--- a/eval/session/tests/shutdown.rs
+++ b/eval/session/tests/shutdown.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use parking_lot::Mutex;
-use pyrat_eval::{EvalSession, SessionMode};
+use pyrat_eval::{EvalSession, SessionConfig, SessionMode};
 use pyrat_eval_store::{EloOptions, EvalStore};
 
 use crate::common::{
@@ -51,6 +51,7 @@ async fn shutdown_returns_promptly_with_pending_matchups() {
         planner,
         fast_orch_config(),
         EloOptions::new("a"),
+        SessionConfig::default(),
     )
     .await
     .expect("session start");

--- a/eval/session/tests/shutdown.rs
+++ b/eval/session/tests/shutdown.rs
@@ -1,0 +1,66 @@
+//! `EvalSession::shutdown` must return within a bounded time even when the
+//! run loop is suspended on `driver_rx.recv()`. Regression test for the
+//! prior shape where `shutdown` deadlocked because `orch.abort()` only
+//! cancelled the orchestrator's root token and never dropped `driver_tx`.
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::Mutex;
+use pyrat_eval::{EvalSession, SessionMode};
+use pyrat_eval_store::{EloOptions, EvalStore};
+
+use crate::common::{
+    embedded_player, fast_orch_config, round_robin, round_robin_spec, small_game_config,
+};
+
+#[tokio::test]
+async fn shutdown_returns_promptly_with_pending_matchups() {
+    let store = Arc::new(Mutex::new(EvalStore::open_in_memory().unwrap()));
+    // Many players → many matchups still pending after we ask to shut down.
+    let players = vec![
+        embedded_player("a"),
+        embedded_player("b"),
+        embedded_player("c"),
+        embedded_player("d"),
+        embedded_player("e"),
+    ];
+
+    let created =
+        EvalSession::create_tournament(store.clone(), round_robin_spec(), players.clone())
+            .await
+            .expect("create_tournament");
+
+    let planner = round_robin(
+        players,
+        small_game_config(),
+        created.game_config_id,
+        created.tournament_id,
+        // Many games per pair so the planner has plenty of pending work
+        // when we call shutdown. The point is to prove `shutdown` doesn't
+        // wait for natural completion.
+        50,
+    );
+    let session = EvalSession::start(
+        store.clone(),
+        SessionMode {
+            tournament_id: created.tournament_id,
+        },
+        planner,
+        fast_orch_config(),
+        EloOptions::new("a"),
+    )
+    .await
+    .expect("session start");
+
+    // Before the fix this would deadlock: the run loop blocks on
+    // `driver_rx.recv().await`, `orch.abort()` only cancels the root token,
+    // `driver_tx` stays alive via `self.orch: Arc<Orchestrator>`, and
+    // `is_done && idle` never fires because there's pending planner work.
+    tokio::time::timeout(Duration::from_secs(5), session.shutdown())
+        .await
+        .expect("shutdown should not hang")
+        .expect("shutdown result");
+}

--- a/eval/session/tests/subscribe.rs
+++ b/eval/session/tests/subscribe.rs
@@ -1,0 +1,140 @@
+//! Atomicity of `EvalSession::subscribe`. The contract is "snapshot +
+//! tail with no gap": the returned snapshot reflects state at some time
+//! T, and the returned receiver gets every event published strictly
+//! after T. Nothing falls into a gap between them.
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::Mutex;
+use pyrat_eval::{EvalSession, SessionConfig, SessionEvent, SessionMode};
+use pyrat_eval_store::{EloOptions, EvalStore};
+
+use crate::common::{
+    embedded_player, fast_orch_config, round_robin, round_robin_spec, small_game_config,
+};
+
+/// After subscribing, the receiver is guaranteed to see
+/// `TournamentFinished` once the run loop publishes it. If subscribe
+/// dropped any tail event the receiver would miss the terminal and
+/// this would never observe it.
+#[tokio::test]
+async fn subscribe_does_not_drop_tail_terminal() {
+    let store = Arc::new(Mutex::new(EvalStore::open_in_memory().unwrap()));
+    let players = vec![embedded_player("a"), embedded_player("b")];
+
+    let created =
+        EvalSession::create_tournament(store.clone(), round_robin_spec(), players.clone())
+            .await
+            .expect("create_tournament");
+
+    let planner = round_robin(
+        players,
+        small_game_config(),
+        created.game_config_id,
+        created.tournament_id,
+        1,
+    );
+    let session = EvalSession::start(
+        store.clone(),
+        SessionMode {
+            tournament_id: created.tournament_id,
+        },
+        planner,
+        fast_orch_config(),
+        EloOptions::new("a"),
+        SessionConfig::default(),
+    )
+    .await
+    .expect("session start");
+
+    // Subscribe before the tournament finishes. The (snapshot, rx) pair
+    // is atomic — every event after this point lands in rx.
+    let (_snapshot, mut rx) = session.subscribe();
+
+    // Drive the run loop forward; the tournament has exactly one matchup.
+    // We poll `rx` rather than calling `join`, because `join` would also
+    // consume the run loop handle — we want to see events arrive on the
+    // receiver independently.
+    let mut events = Vec::new();
+    loop {
+        match tokio::time::timeout(Duration::from_secs(5), rx.recv()).await {
+            Ok(Ok(ev)) => {
+                let is_terminal = matches!(ev, SessionEvent::TournamentFinished);
+                events.push(ev);
+                if is_terminal {
+                    break;
+                }
+            },
+            Ok(Err(_)) => panic!("broadcast closed before TournamentFinished arrived"),
+            Err(_) => panic!("timed out waiting for events (got: {events:?})"),
+        }
+    }
+
+    assert!(
+        matches!(events.last(), Some(SessionEvent::TournamentFinished)),
+        "TournamentFinished must be the terminal event observed; got {events:?}"
+    );
+
+    session.shutdown().await.expect("shutdown");
+}
+
+/// Subscribing twice from the same session yields independent receivers
+/// that both see the same tail. Pins the "broadcast" semantic — every
+/// late subscriber gets every subsequent event, not just the next one.
+#[tokio::test]
+async fn two_subscribers_see_same_tail() {
+    let store = Arc::new(Mutex::new(EvalStore::open_in_memory().unwrap()));
+    let players = vec![embedded_player("a"), embedded_player("b")];
+
+    let created =
+        EvalSession::create_tournament(store.clone(), round_robin_spec(), players.clone())
+            .await
+            .expect("create_tournament");
+    let planner = round_robin(
+        players,
+        small_game_config(),
+        created.game_config_id,
+        created.tournament_id,
+        1,
+    );
+    let session = EvalSession::start(
+        store.clone(),
+        SessionMode {
+            tournament_id: created.tournament_id,
+        },
+        planner,
+        fast_orch_config(),
+        EloOptions::new("a"),
+        SessionConfig::default(),
+    )
+    .await
+    .expect("session start");
+
+    let (_snap_a, rx_a) = session.subscribe();
+    let (_snap_b, rx_b) = session.subscribe();
+
+    // Each receiver independently observes TournamentFinished. If
+    // subscribe accidentally consumed events from a shared queue rather
+    // than broadcasting, one receiver would block forever.
+    let drain = |mut rx: tokio::sync::broadcast::Receiver<SessionEvent>| async move {
+        loop {
+            match tokio::time::timeout(Duration::from_secs(5), rx.recv()).await {
+                Ok(Ok(SessionEvent::TournamentFinished)) => return Ok(()),
+                Ok(Ok(_)) => continue,
+                Ok(Err(e)) => return Err(format!("rx closed: {e:?}")),
+                Err(_) => return Err("timeout".into()),
+            }
+        }
+    };
+
+    let (a, b) = tokio::join!(drain(rx_a.resubscribe()), drain(rx_b.resubscribe()));
+    a.expect("rx_a should see TournamentFinished");
+    b.expect("rx_b should see TournamentFinished");
+    drop(rx_a);
+    drop(rx_b);
+
+    session.shutdown().await.expect("shutdown");
+}

--- a/eval/session/tests/validate.rs
+++ b/eval/session/tests/validate.rs
@@ -1,0 +1,236 @@
+//! `EvalSession::start` cross-checks the planner against the stored
+//! tournament spec on resume. Any divergence (players, game_config_id,
+//! tournament_seed, target_games_per_matchup) must surface as
+//! `SessionError::TournamentMismatch` before the run loop is launched.
+
+mod common;
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use pyrat_eval::{EvalSession, SessionConfig, SessionError, SessionMode};
+use pyrat_eval_store::{EloOptions, EvalStore};
+
+use crate::common::{
+    embedded_player, fast_orch_config, round_robin, round_robin_spec, small_game_config,
+};
+
+/// Assert that the result is `Err(TournamentMismatch(reason))` and the
+/// reason string contains `expected_substr`. `EvalSession` doesn't impl
+/// `Debug`, so `expect_err` is unavailable; this helper unwraps via
+/// pattern matching instead.
+async fn expect_mismatch_containing<F, Fut>(builder: F, expected_substr: &str)
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<EvalSession, SessionError>>,
+{
+    match builder().await {
+        Err(SessionError::TournamentMismatch(reason)) => {
+            assert!(
+                reason.contains(expected_substr),
+                "expected '{expected_substr}' in mismatch reason, got: {reason}"
+            );
+        },
+        Err(other) => panic!("expected TournamentMismatch, got {other:?}"),
+        Ok(_session) => panic!("expected TournamentMismatch, got Ok"),
+    }
+}
+
+/// Stored spec: players `[a, b]` at seed 0xC0FFEE. Planner with players
+/// `[a, c]` should be rejected.
+#[tokio::test]
+async fn rejects_planner_with_different_players() {
+    let store = Arc::new(Mutex::new(EvalStore::open_in_memory().unwrap()));
+    let stored_players = vec![embedded_player("a"), embedded_player("b")];
+
+    let created = EvalSession::create_tournament(store.clone(), round_robin_spec(), stored_players)
+        .await
+        .expect("create_tournament");
+    // Player "c" never registered for this tournament — would silently
+    // append rows for an off-roster player without this guard.
+    store
+        .lock()
+        .register_player(&pyrat_eval_store::NewPlayer {
+            id: "c".into(),
+            display_name: "c".into(),
+            agent_id: Some("c".into()),
+            version: None,
+            command: None,
+            metadata_json: None,
+        })
+        .unwrap();
+
+    let drifted_players = vec![embedded_player("a"), embedded_player("c")];
+    let planner = round_robin(
+        drifted_players,
+        small_game_config(),
+        created.game_config_id,
+        created.tournament_id,
+        1,
+    );
+    expect_mismatch_containing(
+        || {
+            EvalSession::start(
+                store.clone(),
+                SessionMode {
+                    tournament_id: created.tournament_id,
+                },
+                planner,
+                fast_orch_config(),
+                EloOptions::new("a"),
+                SessionConfig::default(),
+            )
+        },
+        "players",
+    )
+    .await;
+}
+
+/// Stored seed is 0xC0FFEE; planner with seed 0xDEAD is rejected.
+#[tokio::test]
+async fn rejects_planner_with_different_tournament_seed() {
+    let store = Arc::new(Mutex::new(EvalStore::open_in_memory().unwrap()));
+    let players = vec![embedded_player("a"), embedded_player("b")];
+    let created =
+        EvalSession::create_tournament(store.clone(), round_robin_spec(), players.clone())
+            .await
+            .expect("create_tournament");
+
+    let planner = pyrat_eval::RoundRobinPlanner::new(pyrat_eval::RoundRobinPlannerConfig {
+        players,
+        game_config: small_game_config(),
+        game_config_id: created.game_config_id,
+        timing: crate::common::fast_timing(),
+        tournament_id: created.tournament_id,
+        target_per_pair: 1,
+        max_failures_per_pair: 3,
+        tournament_seed: 0xDEAD, // diverges from spec's 0xC0FFEE
+    });
+
+    expect_mismatch_containing(
+        || {
+            EvalSession::start(
+                store.clone(),
+                SessionMode {
+                    tournament_id: created.tournament_id,
+                },
+                planner,
+                fast_orch_config(),
+                EloOptions::new("a"),
+                SessionConfig::default(),
+            )
+        },
+        "tournament_seed",
+    )
+    .await;
+}
+
+/// Stored game_config_id is content-hashed from `small_game_config`;
+/// planner with a different game_config_id is rejected.
+#[tokio::test]
+async fn rejects_planner_with_different_game_config_id() {
+    let store = Arc::new(Mutex::new(EvalStore::open_in_memory().unwrap()));
+    let players = vec![embedded_player("a"), embedded_player("b")];
+    let created =
+        EvalSession::create_tournament(store.clone(), round_robin_spec(), players.clone())
+            .await
+            .expect("create_tournament");
+
+    let planner = round_robin(
+        players,
+        small_game_config(),
+        "wrong-config-id".to_string(),
+        created.tournament_id,
+        1,
+    );
+
+    expect_mismatch_containing(
+        || {
+            EvalSession::start(
+                store.clone(),
+                SessionMode {
+                    tournament_id: created.tournament_id,
+                },
+                planner,
+                fast_orch_config(),
+                EloOptions::new("a"),
+                SessionConfig::default(),
+            )
+        },
+        "game_config_id",
+    )
+    .await;
+}
+
+/// Stored target_games_per_matchup is 1; planner with target 5 is rejected.
+#[tokio::test]
+async fn rejects_planner_with_different_target_per_pair() {
+    let store = Arc::new(Mutex::new(EvalStore::open_in_memory().unwrap()));
+    let players = vec![embedded_player("a"), embedded_player("b")];
+    let created =
+        EvalSession::create_tournament(store.clone(), round_robin_spec(), players.clone())
+            .await
+            .expect("create_tournament");
+
+    let planner = round_robin(
+        players,
+        small_game_config(),
+        created.game_config_id,
+        created.tournament_id,
+        5, // diverges from spec's Some(1)
+    );
+
+    expect_mismatch_containing(
+        || {
+            EvalSession::start(
+                store.clone(),
+                SessionMode {
+                    tournament_id: created.tournament_id,
+                },
+                planner,
+                fast_orch_config(),
+                EloOptions::new("a"),
+                SessionConfig::default(),
+            )
+        },
+        "target_games_per_matchup",
+    )
+    .await;
+}
+
+/// Happy path: a planner that matches the stored spec resumes cleanly.
+#[tokio::test]
+async fn accepts_matching_planner() {
+    let store = Arc::new(Mutex::new(EvalStore::open_in_memory().unwrap()));
+    let players = vec![embedded_player("a"), embedded_player("b")];
+    let created =
+        EvalSession::create_tournament(store.clone(), round_robin_spec(), players.clone())
+            .await
+            .expect("create_tournament");
+
+    let planner = round_robin(
+        players,
+        small_game_config(),
+        created.game_config_id,
+        created.tournament_id,
+        1,
+    );
+
+    let session = match EvalSession::start(
+        store.clone(),
+        SessionMode {
+            tournament_id: created.tournament_id,
+        },
+        planner,
+        fast_orch_config(),
+        EloOptions::new("a"),
+        SessionConfig::default(),
+    )
+    .await
+    {
+        Ok(s) => s,
+        Err(e) => panic!("matching planner should be accepted: {e:?}"),
+    };
+
+    session.shutdown().await.expect("shutdown");
+}

--- a/eval/session/tests/validate.rs
+++ b/eval/session/tests/validate.rs
@@ -198,6 +198,60 @@ async fn rejects_planner_with_different_target_per_pair() {
     .await;
 }
 
+/// Format mismatch: a `GauntletPlanner` whose `expected_players()` happens
+/// to slot-match a stored `round_robin` tournament's participants would
+/// pass the player + target + seed + config checks. The format guard is
+/// what catches this — otherwise the gauntlet would run challenger-vs-each
+/// pairings and silently skip opponent-vs-opponent matchups, fragmenting
+/// the tournament's history.
+#[tokio::test]
+async fn rejects_gauntlet_planner_for_round_robin_tournament() {
+    let store = Arc::new(Mutex::new(EvalStore::open_in_memory().unwrap()));
+    let players = vec![
+        embedded_player("a"),
+        embedded_player("b"),
+        embedded_player("c"),
+    ];
+    // Stored spec is round_robin (format = "round_robin"), players [a, b, c],
+    // target_games_per_matchup = 1.
+    let created =
+        EvalSession::create_tournament(store.clone(), round_robin_spec(), players.clone())
+            .await
+            .expect("create_tournament");
+
+    // Gauntlet planner with the same id, same game_config_id, same seed,
+    // same total players in slot order ([challenger, opponents..]), same
+    // target. The only divergence is format.
+    let planner = pyrat_eval::GauntletPlanner::new(pyrat_eval::GauntletPlannerConfig {
+        challenger: players[0].clone(),
+        opponents: vec![players[1].clone(), players[2].clone()],
+        game_config: small_game_config(),
+        game_config_id: created.game_config_id,
+        timing: crate::common::fast_timing(),
+        tournament_id: created.tournament_id,
+        target_each: 1,
+        max_failures_per_pair: 3,
+        tournament_seed: 0xC0FFEE,
+    });
+
+    expect_mismatch_containing(
+        || {
+            EvalSession::start(
+                store.clone(),
+                SessionMode {
+                    tournament_id: created.tournament_id,
+                },
+                planner,
+                fast_orch_config(),
+                EloOptions::new("a"),
+                SessionConfig::default(),
+            )
+        },
+        "format",
+    )
+    .await;
+}
+
 /// Happy path: a planner that matches the stored spec resumes cleanly.
 #[tokio::test]
 async fn accepts_matching_planner() {

--- a/eval/store/src/lib.rs
+++ b/eval/store/src/lib.rs
@@ -9,6 +9,7 @@ pub use elo::{
 };
 pub use store::{
     aggregate_pairs, head_to_head_from_attempt_records, head_to_head_from_results, EvalStore,
+    TxStore,
 };
 pub use types::{
     AddTournamentPlayerError, AttemptKey, AttemptOutcome, AttemptRecord, AttemptStatus,

--- a/eval/store/src/lib.rs
+++ b/eval/store/src/lib.rs
@@ -12,7 +12,8 @@ pub use store::{
 };
 pub use types::{
     AddTournamentPlayerError, AttemptKey, AttemptOutcome, AttemptRecord, AttemptStatus,
-    DeletePlayerError, EvalError, GameConfigRecord, GameResultRecord, NewAttempt,
-    NewAttemptOutcome, NewGameResult, NewPlayer, NewTournament, PlayerRecord, RecordAttemptError,
-    RegisterPlayerError, ResultFilter, TournamentId, TournamentParticipant, TournamentRecord,
+    CreateTournamentError, DeletePlayerError, EvalError, GameConfigRecord, GameResultRecord,
+    NewAttempt, NewAttemptOutcome, NewGameResult, NewPlayer, NewTournament, PlayerRecord,
+    RecordAttemptError, RegisterPlayerError, ResultFilter, TournamentId, TournamentParticipant,
+    TournamentRecord,
 };

--- a/eval/store/src/lib.rs
+++ b/eval/store/src/lib.rs
@@ -7,7 +7,9 @@ pub use elo::{
     compute_elo, compute_elo_with_uncertainty, elo_from_winrate, win_expectancy, EloError,
     EloOptions, EloRating, EloResult, EloUncertainty, HeadToHead,
 };
-pub use store::{head_to_head_from_attempt_records, head_to_head_from_results, EvalStore};
+pub use store::{
+    aggregate_pairs, head_to_head_from_attempt_records, head_to_head_from_results, EvalStore,
+};
 pub use types::{
     AddTournamentPlayerError, AttemptKey, AttemptOutcome, AttemptRecord, AttemptStatus,
     DeletePlayerError, EvalError, GameConfigRecord, GameResultRecord, NewAttempt,

--- a/eval/store/src/schema.rs
+++ b/eval/store/src/schema.rs
@@ -1,3 +1,16 @@
+// Migration 3 rebuilds the tournaments tables to add `game_config_id` and
+// `tournament_seed` columns. The session crate needs these so resume can
+// validate the planner against the stored tournament identity.
+//
+// SQLite's `ALTER TABLE ADD COLUMN` cannot add a `NOT NULL REFERENCES`
+// column (NOT NULL requires a non-NULL default; REFERENCES requires a NULL
+// default). The canonical alternative is to rebuild the table.
+//
+// Because the dependent tables (`match_attempts`, `tournament_players`) are
+// also empty when `tournaments` is empty (their FKs prevent orphan rows),
+// dropping + recreating all three in one transaction is safe with foreign
+// keys enabled. No PRAGMA toggle needed for the empty-table case.
+
 use rusqlite::Connection;
 
 use crate::EvalError;
@@ -93,7 +106,65 @@ CREATE INDEX idx_attempts_tournament ON match_attempts(tournament_id);
 CREATE INDEX idx_attempts_matchup    ON match_attempts(tournament_id, player1_id, player2_id);
 ";
 
-const MIGRATIONS: &[(u32, &str)] = &[(1, MIGRATION_1), (2, MIGRATION_2)];
+const MIGRATION_3: &str = "
+DROP TABLE match_attempts;
+DROP TABLE tournament_players;
+DROP TABLE tournaments;
+
+CREATE TABLE tournaments (
+    id                       INTEGER PRIMARY KEY AUTOINCREMENT,
+    format                   TEXT    NOT NULL,
+    target_games_per_matchup INTEGER,
+    params_json              TEXT    NOT NULL,
+    game_config_id           TEXT    NOT NULL REFERENCES game_configs(id),
+    tournament_seed          INTEGER NOT NULL,
+    created_at               TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE tournament_players (
+    tournament_id INTEGER NOT NULL REFERENCES tournaments(id) ON DELETE CASCADE,
+    player_id     TEXT    NOT NULL REFERENCES players(id) ON DELETE RESTRICT,
+    slot          INTEGER NOT NULL,
+    PRIMARY KEY (tournament_id, player_id),
+    UNIQUE (tournament_id, slot)
+);
+
+CREATE TABLE match_attempts (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    tournament_id    INTEGER NOT NULL REFERENCES tournaments(id) ON DELETE CASCADE,
+    game_config_id   TEXT    NOT NULL REFERENCES game_configs(id),
+    player1_id       TEXT    NOT NULL REFERENCES players(id) ON DELETE RESTRICT,
+    player2_id       TEXT    NOT NULL REFERENCES players(id) ON DELETE RESTRICT,
+    seed             INTEGER NOT NULL,
+    repetition_index INTEGER NOT NULL DEFAULT 0,
+    attempt_index    INTEGER NOT NULL,
+    status           TEXT    NOT NULL,
+    player1_score    REAL,
+    player2_score    REAL,
+    turns            INTEGER,
+    failure_reason   TEXT,
+    started_at       TEXT,
+    finished_at      TEXT NOT NULL,
+    UNIQUE (tournament_id, game_config_id, player1_id, player2_id, repetition_index, attempt_index),
+    CHECK (status IN ('success', 'failure')),
+    CHECK (
+        (status = 'success' AND player1_score IS NOT NULL
+                            AND player2_score IS NOT NULL
+                            AND turns          IS NOT NULL
+                            AND failure_reason IS NULL
+                            AND started_at     IS NOT NULL)
+     OR (status = 'failure' AND failure_reason IS NOT NULL
+                            AND player1_score  IS NULL
+                            AND player2_score  IS NULL
+                            AND turns          IS NULL)
+    )
+);
+
+CREATE INDEX idx_attempts_tournament ON match_attempts(tournament_id);
+CREATE INDEX idx_attempts_matchup    ON match_attempts(tournament_id, player1_id, player2_id);
+";
+
+const MIGRATIONS: &[(u32, &str)] = &[(1, MIGRATION_1), (2, MIGRATION_2), (3, MIGRATION_3)];
 
 pub fn initialize(conn: &mut Connection) -> Result<(), EvalError> {
     // PRAGMAs are per-connection. `foreign_keys` cannot be set inside a
@@ -103,10 +174,34 @@ pub fn initialize(conn: &mut Connection) -> Result<(), EvalError> {
     let current: u32 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
     for &(version, sql) in MIGRATIONS {
         if version > current {
+            // Pre-flight checks must run before opening the transaction so a
+            // refusal returns a typed error without a half-applied state.
+            pre_migration_check(conn, version)?;
+
             let tx = conn.transaction()?;
             tx.execute_batch(sql)?;
             tx.execute_batch(&format!("PRAGMA user_version = {version}"))?;
             tx.commit()?;
+        }
+    }
+    Ok(())
+}
+
+/// Per-migration sanity checks. Migration 3 drops and recreates the
+/// tournament tables; refuse if any pre-migration tournaments exist,
+/// since we cannot synthesize `game_config_id` or `tournament_seed`
+/// for them.
+fn pre_migration_check(conn: &Connection, version: u32) -> Result<(), EvalError> {
+    if version == 3 {
+        let count: i64 = conn.query_row("SELECT COUNT(*) FROM tournaments", [], |r| r.get(0))?;
+        if count > 0 {
+            return Err(EvalError::MigrationBlocked {
+                version,
+                message:
+                    "tournaments table contains pre-migration rows; refusing to silently corrupt \
+                     (no automatic backfill for game_config_id and tournament_seed)"
+                        .into(),
+            });
         }
     }
     Ok(())

--- a/eval/store/src/store.rs
+++ b/eval/store/src/store.rs
@@ -7,9 +7,10 @@ use crate::elo::HeadToHead;
 use crate::schema;
 use crate::types::{
     AddTournamentPlayerError, AttemptKey, AttemptOutcome, AttemptRecord, AttemptStatus,
-    DeletePlayerError, EvalError, GameConfigRecord, GameResultRecord, NewAttempt,
-    NewAttemptOutcome, NewGameResult, NewPlayer, NewTournament, PlayerRecord, RecordAttemptError,
-    RegisterPlayerError, ResultFilter, TournamentId, TournamentParticipant, TournamentRecord,
+    CreateTournamentError, DeletePlayerError, EvalError, GameConfigRecord, GameResultRecord,
+    NewAttempt, NewAttemptOutcome, NewGameResult, NewPlayer, NewTournament, PlayerRecord,
+    RecordAttemptError, RegisterPlayerError, ResultFilter, TournamentId, TournamentParticipant,
+    TournamentRecord,
 };
 
 /// SQLite-backed store for game results, players, tournaments, and match
@@ -278,19 +279,51 @@ impl EvalStore {
         rows.collect::<Result<Vec<_>, _>>().map_err(EvalError::from)
     }
 
-    pub fn create_tournament(&self, t: &NewTournament) -> Result<TournamentId, EvalError> {
-        self.conn.execute(
-            "INSERT INTO tournaments (format, target_games_per_matchup, params_json)
-             VALUES (?1, ?2, ?3)",
-            params![t.format, t.target_games_per_matchup, t.params_json],
-        )?;
+    pub fn create_tournament(
+        &self,
+        t: &NewTournament,
+    ) -> Result<TournamentId, CreateTournamentError> {
+        // Typed pre-check on the FK gives a clearer error than the generic
+        // SQL constraint violation the FK would throw on its own.
+        let exists: bool = self
+            .conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM game_configs WHERE id = ?1)",
+                params![t.game_config_id],
+                |row| row.get(0),
+            )
+            .map_err(EvalError::from)?;
+        if !exists {
+            return Err(CreateTournamentError::GameConfigNotFound(
+                t.game_config_id.clone(),
+            ));
+        }
+        // SQLite INTEGER is signed; mask the high bit to fit. Matches the
+        // pattern used by `matchup_seed` and validated by `record_attempt`.
+        let seed_i64 = (t.tournament_seed & i64::MAX as u64) as i64;
+        self.conn
+            .execute(
+                "INSERT INTO tournaments
+                   (format, target_games_per_matchup, params_json,
+                    game_config_id, tournament_seed)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![
+                    t.format,
+                    t.target_games_per_matchup,
+                    t.params_json,
+                    t.game_config_id,
+                    seed_i64,
+                ],
+            )
+            .map_err(EvalError::from)?;
         Ok(TournamentId(self.conn.last_insert_rowid()))
     }
 
     pub fn get_tournament(&self, id: TournamentId) -> Result<Option<TournamentRecord>, EvalError> {
         self.conn
             .query_row(
-                "SELECT id, format, target_games_per_matchup, params_json, created_at
+                "SELECT id, format, target_games_per_matchup, params_json,
+                        game_config_id, tournament_seed, created_at
                    FROM tournaments WHERE id = ?1",
                 params![id.0],
                 read_tournament_row,
@@ -301,7 +334,8 @@ impl EvalStore {
 
     pub fn list_tournaments(&self) -> Result<Vec<TournamentRecord>, EvalError> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, format, target_games_per_matchup, params_json, created_at
+            "SELECT id, format, target_games_per_matchup, params_json,
+                    game_config_id, tournament_seed, created_at
                FROM tournaments ORDER BY id",
         )?;
         let rows = stmt.query_map([], read_tournament_row)?;
@@ -510,12 +544,15 @@ fn read_player_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<PlayerRecord> {
 }
 
 fn read_tournament_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TournamentRecord> {
+    let seed_i64: i64 = row.get(5)?;
     Ok(TournamentRecord {
         id: TournamentId(row.get(0)?),
         format: row.get(1)?,
         target_games_per_matchup: row.get(2)?,
         params_json: row.get(3)?,
-        created_at: row.get(4)?,
+        game_config_id: row.get(4)?,
+        tournament_seed: seed_i64 as u64,
+        created_at: row.get(6)?,
     })
 }
 
@@ -682,6 +719,8 @@ mod tests {
                 format: "round-robin".into(),
                 target_games_per_matchup: Some(10),
                 params_json: "{}".into(),
+                game_config_id: config_id.clone(),
+                tournament_seed: 0xC0FFEE,
             })
             .unwrap();
         store.add_tournament_player(tid, "alice", 0).unwrap();
@@ -1032,9 +1071,9 @@ mod tests {
     }
 
     #[test]
-    fn migration_fresh_db_ends_at_user_version_2() {
+    fn migration_fresh_db_ends_at_latest_user_version() {
         let store = EvalStore::open_in_memory().unwrap();
-        assert_eq!(user_version(&store), 2);
+        assert_eq!(user_version(&store), 3);
 
         let tables: Vec<String> = store
             .conn
@@ -1055,6 +1094,21 @@ mod tests {
             assert!(
                 tables.contains(&expected.to_string()),
                 "missing table: {expected}; have {tables:?}"
+            );
+        }
+        // Migration 3 added `game_config_id` and `tournament_seed` to tournaments.
+        let cols: Vec<String> = store
+            .conn
+            .prepare("SELECT name FROM pragma_table_info('tournaments')")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        for expected in ["game_config_id", "tournament_seed"] {
+            assert!(
+                cols.contains(&expected.to_string()),
+                "migration 3 should have added {expected} to tournaments: have {cols:?}"
             );
         }
     }
@@ -1087,10 +1141,9 @@ mod tests {
         assert_eq!(v, 0);
 
         let store = EvalStore::from_connection(conn).unwrap();
-        assert_eq!(user_version(&store), 2);
+        assert_eq!(user_version(&store), 3);
 
-        // Migration 1 (CREATE IF NOT EXISTS) is a no-op; migration 2 adds
-        // the new tables and columns. Confirm the v2 surface is present.
+        // Migration 2 added these columns to players. Confirm they exist.
         let cols: Vec<String> = store
             .conn
             .prepare("SELECT name FROM pragma_table_info('players')")
@@ -1114,14 +1167,118 @@ mod tests {
         let v: u32 = conn
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .unwrap();
-        assert_eq!(v, 2);
+        assert_eq!(v, 3);
         // Second run on the same connection: each migration's `version > current`
         // guard makes the loop a no-op. Must not error.
         schema::initialize(&mut conn).unwrap();
         let v: u32 = conn
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .unwrap();
-        assert_eq!(v, 2);
+        assert_eq!(v, 3);
+    }
+
+    /// Migration 3 refuses to run if `tournaments` has pre-migration rows,
+    /// since we cannot synthesize the new NOT NULL columns for them.
+    #[test]
+    fn migration_3_refuses_when_v2_tournaments_nonempty() {
+        // Build a DB at user_version=2 with one tournament row.
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        // Run migrations 1 and 2 by capping with a manual user_version bump.
+        // Simpler: open at v3, drop the table contents reset trick. Instead
+        // we build a fresh v2 schema by hand.
+        conn.execute_batch(
+            "CREATE TABLE players (id TEXT PRIMARY KEY, display_name TEXT NOT NULL,
+                                   created_at TEXT NOT NULL DEFAULT (datetime('now')));
+             CREATE TABLE game_configs (id TEXT PRIMARY KEY, config_json TEXT NOT NULL);
+             CREATE TABLE game_results (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                game_config_id TEXT NOT NULL REFERENCES game_configs(id),
+                player1_id TEXT NOT NULL REFERENCES players(id) ON DELETE CASCADE,
+                player2_id TEXT NOT NULL REFERENCES players(id) ON DELETE CASCADE,
+                player1_score REAL NOT NULL, player2_score REAL NOT NULL,
+                turns INTEGER NOT NULL,
+                played_at TEXT NOT NULL DEFAULT (datetime('now'))
+             );
+             CREATE TABLE tournaments (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                format TEXT NOT NULL,
+                target_games_per_matchup INTEGER,
+                params_json TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+             );
+             CREATE TABLE tournament_players (
+                tournament_id INTEGER NOT NULL REFERENCES tournaments(id) ON DELETE CASCADE,
+                player_id TEXT NOT NULL REFERENCES players(id) ON DELETE RESTRICT,
+                slot INTEGER NOT NULL,
+                PRIMARY KEY (tournament_id, player_id),
+                UNIQUE (tournament_id, slot)
+             );
+             CREATE TABLE match_attempts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                tournament_id INTEGER NOT NULL REFERENCES tournaments(id) ON DELETE CASCADE,
+                game_config_id TEXT NOT NULL REFERENCES game_configs(id),
+                player1_id TEXT NOT NULL REFERENCES players(id) ON DELETE RESTRICT,
+                player2_id TEXT NOT NULL REFERENCES players(id) ON DELETE RESTRICT,
+                seed INTEGER NOT NULL,
+                repetition_index INTEGER NOT NULL DEFAULT 0,
+                attempt_index INTEGER NOT NULL,
+                status TEXT NOT NULL,
+                player1_score REAL, player2_score REAL, turns INTEGER,
+                failure_reason TEXT, started_at TEXT,
+                finished_at TEXT NOT NULL
+             );
+             PRAGMA user_version = 2;
+             INSERT INTO tournaments (format, params_json) VALUES ('rr', '{}');",
+        )
+        .unwrap();
+        let err = schema::initialize(&mut conn).unwrap_err();
+        match err {
+            EvalError::MigrationBlocked { version, message } => {
+                assert_eq!(version, 3);
+                assert!(
+                    message.contains("pre-migration rows"),
+                    "unexpected message: {message}"
+                );
+            },
+            other => panic!("expected MigrationBlocked, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn create_tournament_rejects_missing_game_config() {
+        let store = EvalStore::open_in_memory().unwrap();
+        match store.create_tournament(&NewTournament {
+            format: "rr".into(),
+            target_games_per_matchup: None,
+            params_json: "{}".into(),
+            game_config_id: "nonexistent".into(),
+            tournament_seed: 0,
+        }) {
+            Err(CreateTournamentError::GameConfigNotFound(id)) => {
+                assert_eq!(id, "nonexistent");
+            },
+            other => panic!("expected GameConfigNotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn create_tournament_round_trips_seed_and_config_id() {
+        let store = EvalStore::open_in_memory().unwrap();
+        let cid = store.ensure_game_config(&sample_config()).unwrap();
+        let tid = store
+            .create_tournament(&NewTournament {
+                format: "rr".into(),
+                target_games_per_matchup: Some(2),
+                params_json: "{}".into(),
+                game_config_id: cid.clone(),
+                tournament_seed: 0xDEAD_BEEF_CAFE_FACE,
+            })
+            .unwrap();
+        let t = store.get_tournament(tid).unwrap().unwrap();
+        assert_eq!(t.game_config_id, cid);
+        // High bit is masked at the store boundary.
+        assert_eq!(t.tournament_seed, 0xDEAD_BEEF_CAFE_FACE & i64::MAX as u64);
     }
 
     #[test]
@@ -1397,11 +1554,14 @@ mod tests {
         let store = EvalStore::open_in_memory().unwrap();
         setup_players(&store);
         store.ensure_player("carol", "Carol").unwrap();
+        let cid = store.ensure_game_config(&sample_config()).unwrap();
         let tid = store
             .create_tournament(&NewTournament {
                 format: "round-robin".into(),
                 target_games_per_matchup: None,
                 params_json: "{}".into(),
+                game_config_id: cid,
+                tournament_seed: 0,
             })
             .unwrap();
         store.add_tournament_player(tid, "alice", 0).unwrap();
@@ -1474,6 +1634,8 @@ mod tests {
                 format: "gauntlet".into(),
                 target_games_per_matchup: None,
                 params_json: "{}".into(),
+                game_config_id: cid.clone(),
+                tournament_seed: 0xDEAD_BEEF,
             })
             .unwrap();
         store.add_tournament_player(other, "alice", 0).unwrap();

--- a/eval/store/src/store.rs
+++ b/eval/store/src/store.rs
@@ -64,71 +64,13 @@ impl EvalStore {
     ///   field names.
     /// - Row exists with identical identity: no-op success.
     pub fn register_player(&self, p: &NewPlayer) -> Result<(), RegisterPlayerError> {
-        let existing = self
-            .conn
-            .query_row(
-                "SELECT agent_id, version, command, metadata_json
-                 FROM players WHERE id = ?1",
-                params![p.id],
-                |row| {
-                    Ok(ExistingIdentity {
-                        agent_id: row.get(0)?,
-                        version: row.get(1)?,
-                        command: row.get(2)?,
-                        metadata_json: row.get(3)?,
-                    })
-                },
-            )
-            .optional()?;
-
-        match existing {
-            None => {
-                self.conn.execute(
-                    "INSERT INTO players (id, display_name, agent_id, version, command, metadata_json)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                    params![p.id, p.display_name, p.agent_id, p.version, p.command, p.metadata_json],
-                )?;
-            },
-            Some(ex) => {
-                let mut conflicts = Vec::new();
-                check_conflict(&mut conflicts, "agent_id", &ex.agent_id, &p.agent_id);
-                check_conflict(&mut conflicts, "version", &ex.version, &p.version);
-                check_conflict(&mut conflicts, "command", &ex.command, &p.command);
-                check_conflict(
-                    &mut conflicts,
-                    "metadata_json",
-                    &ex.metadata_json,
-                    &p.metadata_json,
-                );
-                if !conflicts.is_empty() {
-                    return Err(RegisterPlayerError::IdentityConflict {
-                        id: p.id.clone(),
-                        fields: conflicts,
-                    });
-                }
-                self.conn.execute(
-                    "UPDATE players
-                       SET agent_id      = COALESCE(agent_id, ?1),
-                           version       = COALESCE(version, ?2),
-                           command       = COALESCE(command, ?3),
-                           metadata_json = COALESCE(metadata_json, ?4)
-                     WHERE id = ?5",
-                    params![p.agent_id, p.version, p.command, p.metadata_json, p.id],
-                )?;
-            },
-        }
-        Ok(())
+        register_player_on(&self.conn, p)
     }
 
     /// Insert a game config (keyed by content hash) if it doesn't already exist.
     /// Returns the content hash used as the ID.
     pub fn ensure_game_config(&self, config: &GameConfigRecord) -> Result<String, EvalError> {
-        let (id, json) = config.content_hash_with_json();
-        self.conn.execute(
-            "INSERT OR IGNORE INTO game_configs (id, config_json) VALUES (?1, ?2)",
-            params![id, json],
-        )?;
-        Ok(id)
+        ensure_game_config_on(&self.conn, config)
     }
 
     /// Append a game result. Returns the autoincrement row ID.
@@ -283,40 +225,7 @@ impl EvalStore {
         &self,
         t: &NewTournament,
     ) -> Result<TournamentId, CreateTournamentError> {
-        // Typed pre-check on the FK gives a clearer error than the generic
-        // SQL constraint violation the FK would throw on its own.
-        let exists: bool = self
-            .conn
-            .query_row(
-                "SELECT EXISTS(SELECT 1 FROM game_configs WHERE id = ?1)",
-                params![t.game_config_id],
-                |row| row.get(0),
-            )
-            .map_err(EvalError::from)?;
-        if !exists {
-            return Err(CreateTournamentError::GameConfigNotFound(
-                t.game_config_id.clone(),
-            ));
-        }
-        // SQLite INTEGER is signed; mask the high bit to fit. Matches the
-        // pattern used by `matchup_seed` and validated by `record_attempt`.
-        let seed_i64 = (t.tournament_seed & i64::MAX as u64) as i64;
-        self.conn
-            .execute(
-                "INSERT INTO tournaments
-                   (format, target_games_per_matchup, params_json,
-                    game_config_id, tournament_seed)
-                 VALUES (?1, ?2, ?3, ?4, ?5)",
-                params![
-                    t.format,
-                    t.target_games_per_matchup,
-                    t.params_json,
-                    t.game_config_id,
-                    seed_i64,
-                ],
-            )
-            .map_err(EvalError::from)?;
-        Ok(TournamentId(self.conn.last_insert_rowid()))
+        create_tournament_on(&self.conn, t)
     }
 
     pub fn get_tournament(&self, id: TournamentId) -> Result<Option<TournamentRecord>, EvalError> {
@@ -362,36 +271,7 @@ impl EvalStore {
         player_id: &str,
         slot: i64,
     ) -> Result<(), AddTournamentPlayerError> {
-        let already_in: bool = self.conn.query_row(
-            "SELECT EXISTS(SELECT 1 FROM tournament_players
-                            WHERE tournament_id = ?1 AND player_id = ?2)",
-            params![tournament_id.0, player_id],
-            |row| row.get(0),
-        )?;
-        if already_in {
-            return Err(AddTournamentPlayerError::PlayerAlreadyInTournament {
-                tournament_id,
-                player_id: player_id.to_string(),
-            });
-        }
-        let slot_taken: bool = self.conn.query_row(
-            "SELECT EXISTS(SELECT 1 FROM tournament_players
-                            WHERE tournament_id = ?1 AND slot = ?2)",
-            params![tournament_id.0, slot],
-            |row| row.get(0),
-        )?;
-        if slot_taken {
-            return Err(AddTournamentPlayerError::SlotTaken {
-                tournament_id,
-                slot,
-            });
-        }
-        self.conn.execute(
-            "INSERT INTO tournament_players (tournament_id, player_id, slot)
-             VALUES (?1, ?2, ?3)",
-            params![tournament_id.0, player_id, slot],
-        )?;
-        Ok(())
+        add_tournament_player_on(&self.conn, tournament_id, player_id, slot)
     }
 
     pub fn get_tournament_players(
@@ -528,6 +408,234 @@ impl EvalStore {
     ) -> Result<Vec<HeadToHead>, EvalError> {
         let attempts = self.get_attempts(tournament_id, Some(AttemptStatus::Success))?;
         Ok(head_to_head_from_attempt_records(&attempts))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Transaction seam
+// ---------------------------------------------------------------------------
+//
+// The four operations bootstrap uses (ensure_game_config, register_player,
+// create_tournament, add_tournament_player) live below as free functions over
+// `&Connection`. `rusqlite::Transaction` derefs to `Connection`, so the same
+// bodies serve both the auto-commit path (each `EvalStore` method) and the
+// transactional path (`TxStore` inside `EvalStore::transaction`). Without
+// this seam, bootstrap could not roll back partial state on a mid-sequence
+// failure.
+
+fn ensure_game_config_on(
+    conn: &Connection,
+    config: &GameConfigRecord,
+) -> Result<String, EvalError> {
+    let (id, json) = config.content_hash_with_json();
+    conn.execute(
+        "INSERT OR IGNORE INTO game_configs (id, config_json) VALUES (?1, ?2)",
+        params![id, json],
+    )?;
+    Ok(id)
+}
+
+fn register_player_on(conn: &Connection, p: &NewPlayer) -> Result<(), RegisterPlayerError> {
+    let existing = conn
+        .query_row(
+            "SELECT agent_id, version, command, metadata_json
+             FROM players WHERE id = ?1",
+            params![p.id],
+            |row| {
+                Ok(ExistingIdentity {
+                    agent_id: row.get(0)?,
+                    version: row.get(1)?,
+                    command: row.get(2)?,
+                    metadata_json: row.get(3)?,
+                })
+            },
+        )
+        .optional()?;
+
+    match existing {
+        None => {
+            conn.execute(
+                "INSERT INTO players (id, display_name, agent_id, version, command, metadata_json)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    p.id,
+                    p.display_name,
+                    p.agent_id,
+                    p.version,
+                    p.command,
+                    p.metadata_json
+                ],
+            )?;
+        },
+        Some(ex) => {
+            let mut conflicts = Vec::new();
+            check_conflict(&mut conflicts, "agent_id", &ex.agent_id, &p.agent_id);
+            check_conflict(&mut conflicts, "version", &ex.version, &p.version);
+            check_conflict(&mut conflicts, "command", &ex.command, &p.command);
+            check_conflict(
+                &mut conflicts,
+                "metadata_json",
+                &ex.metadata_json,
+                &p.metadata_json,
+            );
+            if !conflicts.is_empty() {
+                return Err(RegisterPlayerError::IdentityConflict {
+                    id: p.id.clone(),
+                    fields: conflicts,
+                });
+            }
+            conn.execute(
+                "UPDATE players
+                   SET agent_id      = COALESCE(agent_id, ?1),
+                       version       = COALESCE(version, ?2),
+                       command       = COALESCE(command, ?3),
+                       metadata_json = COALESCE(metadata_json, ?4)
+                 WHERE id = ?5",
+                params![p.agent_id, p.version, p.command, p.metadata_json, p.id],
+            )?;
+        },
+    }
+    Ok(())
+}
+
+fn create_tournament_on(
+    conn: &Connection,
+    t: &NewTournament,
+) -> Result<TournamentId, CreateTournamentError> {
+    // Typed pre-check on the FK gives a clearer error than the generic
+    // SQL constraint violation the FK would throw on its own.
+    let exists: bool = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM game_configs WHERE id = ?1)",
+            params![t.game_config_id],
+            |row| row.get(0),
+        )
+        .map_err(EvalError::from)?;
+    if !exists {
+        return Err(CreateTournamentError::GameConfigNotFound(
+            t.game_config_id.clone(),
+        ));
+    }
+    // SQLite INTEGER is signed; reject high-bit seeds at the boundary
+    // so the caller's `tournament_seed` and the stored seed are always
+    // bit-identical.
+    let seed_i64 =
+        i64::try_from(t.tournament_seed).map_err(|_| CreateTournamentError::SeedOutOfRange {
+            seed: t.tournament_seed,
+        })?;
+    conn.execute(
+        "INSERT INTO tournaments
+           (format, target_games_per_matchup, params_json,
+            game_config_id, tournament_seed)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![
+            t.format,
+            t.target_games_per_matchup,
+            t.params_json,
+            t.game_config_id,
+            seed_i64,
+        ],
+    )
+    .map_err(EvalError::from)?;
+    Ok(TournamentId(conn.last_insert_rowid()))
+}
+
+fn add_tournament_player_on(
+    conn: &Connection,
+    tournament_id: TournamentId,
+    player_id: &str,
+    slot: i64,
+) -> Result<(), AddTournamentPlayerError> {
+    let already_in: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM tournament_players
+                        WHERE tournament_id = ?1 AND player_id = ?2)",
+        params![tournament_id.0, player_id],
+        |row| row.get(0),
+    )?;
+    if already_in {
+        return Err(AddTournamentPlayerError::PlayerAlreadyInTournament {
+            tournament_id,
+            player_id: player_id.to_string(),
+        });
+    }
+    let slot_taken: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM tournament_players
+                        WHERE tournament_id = ?1 AND slot = ?2)",
+        params![tournament_id.0, slot],
+        |row| row.get(0),
+    )?;
+    if slot_taken {
+        return Err(AddTournamentPlayerError::SlotTaken {
+            tournament_id,
+            slot,
+        });
+    }
+    conn.execute(
+        "INSERT INTO tournament_players (tournament_id, player_id, slot)
+         VALUES (?1, ?2, ?3)",
+        params![tournament_id.0, player_id, slot],
+    )?;
+    Ok(())
+}
+
+/// View of [`EvalStore`] inside a transaction. Exposes the four operations
+/// bootstrap composes. The same SQL bodies serve both the auto-commit path
+/// (each `EvalStore` method) and the transactional path; `TxStore` just
+/// routes them through a [`rusqlite::Transaction`] borrow instead of the
+/// owned `Connection`.
+///
+/// Two lifetimes: `'tx` borrows the transaction, `'conn` is the connection
+/// the transaction itself borrows from. Collapsing to one lifetime
+/// over-constrains callers.
+pub struct TxStore<'tx, 'conn> {
+    tx: &'tx rusqlite::Transaction<'conn>,
+}
+
+impl<'tx, 'conn> TxStore<'tx, 'conn> {
+    pub fn ensure_game_config(&self, config: &GameConfigRecord) -> Result<String, EvalError> {
+        ensure_game_config_on(self.tx, config)
+    }
+
+    pub fn register_player(&self, p: &NewPlayer) -> Result<(), RegisterPlayerError> {
+        register_player_on(self.tx, p)
+    }
+
+    pub fn create_tournament(
+        &self,
+        t: &NewTournament,
+    ) -> Result<TournamentId, CreateTournamentError> {
+        create_tournament_on(self.tx, t)
+    }
+
+    pub fn add_tournament_player(
+        &self,
+        tournament_id: TournamentId,
+        player_id: &str,
+        slot: i64,
+    ) -> Result<(), AddTournamentPlayerError> {
+        add_tournament_player_on(self.tx, tournament_id, player_id, slot)
+    }
+}
+
+impl EvalStore {
+    /// Run a closure inside a SQLite transaction. The closure gets a
+    /// `TxStore` exposing the same four operations bootstrap needs; on
+    /// `Ok` the transaction commits, on `Err` (or panic) it rolls back.
+    ///
+    /// The closure's error type `E` only needs `From<EvalError>` — concrete
+    /// errors from `register_player`/`create_tournament`/`add_tournament_player`
+    /// convert via the caller's own `From` impls (e.g. `SessionError`
+    /// already has `#[from]` for each).
+    pub fn transaction<F, T, E>(&mut self, f: F) -> Result<T, E>
+    where
+        F: FnOnce(&TxStore<'_, '_>) -> Result<T, E>,
+        E: From<EvalError>,
+    {
+        let tx = self.conn.transaction().map_err(EvalError::from)?;
+        let store = TxStore { tx: &tx };
+        let out = f(&store)?;
+        tx.commit().map_err(EvalError::from)?;
+        Ok(out)
     }
 }
 
@@ -1266,19 +1374,40 @@ mod tests {
     fn create_tournament_round_trips_seed_and_config_id() {
         let store = EvalStore::open_in_memory().unwrap();
         let cid = store.ensure_game_config(&sample_config()).unwrap();
+        // i64::MAX is the largest value that round-trips through the
+        // signed INTEGER column without truncation.
         let tid = store
             .create_tournament(&NewTournament {
                 format: "rr".into(),
                 target_games_per_matchup: Some(2),
                 params_json: "{}".into(),
                 game_config_id: cid.clone(),
-                tournament_seed: 0xDEAD_BEEF_CAFE_FACE,
+                tournament_seed: i64::MAX as u64,
             })
             .unwrap();
         let t = store.get_tournament(tid).unwrap().unwrap();
         assert_eq!(t.game_config_id, cid);
-        // High bit is masked at the store boundary.
-        assert_eq!(t.tournament_seed, 0xDEAD_BEEF_CAFE_FACE & i64::MAX as u64);
+        // Seed round-trips bit-identically — no masking.
+        assert_eq!(t.tournament_seed, i64::MAX as u64);
+    }
+
+    #[test]
+    fn create_tournament_rejects_high_bit_seed() {
+        let store = EvalStore::open_in_memory().unwrap();
+        let cid = store.ensure_game_config(&sample_config()).unwrap();
+        let seed = 1u64 << 63;
+        match store.create_tournament(&NewTournament {
+            format: "rr".into(),
+            target_games_per_matchup: None,
+            params_json: "{}".into(),
+            game_config_id: cid,
+            tournament_seed: seed,
+        }) {
+            Err(CreateTournamentError::SeedOutOfRange { seed: got }) => {
+                assert_eq!(got, seed);
+            },
+            other => panic!("expected SeedOutOfRange, got {other:?}"),
+        }
     }
 
     #[test]

--- a/eval/store/src/store.rs
+++ b/eval/store/src/store.rs
@@ -614,7 +614,14 @@ pub fn head_to_head_from_attempt_records(attempts: &[AttemptRecord]) -> Vec<Head
     }))
 }
 
-fn aggregate_pairs<'a, I>(iter: I) -> Vec<HeadToHead>
+/// Aggregate `(p1, p2, p1_score, p2_score)` tuples into per-pair head-to-head
+/// records. Pair order is canonicalized lex-min/lex-max so two attempts
+/// with players in opposite slots collapse into the same `HeadToHead`.
+///
+/// Public because consumers fold their own in-memory tournament state into
+/// head-to-heads for Elo (e.g. `pyrat-eval`'s `TournamentState::head_to_head`)
+/// and re-implementing this would be drift-prone.
+pub fn aggregate_pairs<'a, I>(iter: I) -> Vec<HeadToHead>
 where
     I: IntoIterator<Item = (&'a String, &'a String, f64, f64)>,
 {

--- a/eval/store/src/types.rs
+++ b/eval/store/src/types.rs
@@ -102,6 +102,12 @@ pub struct TournamentRecord {
     pub target_games_per_matchup: Option<u32>,
     /// Opaque planner-defined config. The store does not validate this field.
     pub params_json: String,
+    /// Content-hashed id of the `game_configs` row this tournament uses.
+    /// Validated at insert time and on resume.
+    pub game_config_id: String,
+    /// Seed fed into the planner's `matchup_seed` derivation. Stored as i64
+    /// with the high bit masked off (see `NewTournament.tournament_seed`).
+    pub tournament_seed: u64,
     pub created_at: String,
 }
 
@@ -110,6 +116,15 @@ pub struct NewTournament {
     pub format: String,
     pub target_games_per_matchup: Option<u32>,
     pub params_json: String,
+    /// Must reference an existing `game_configs.id`. The store validates this
+    /// up front and returns `CreateTournamentError::GameConfigNotFound` for a
+    /// missing config.
+    pub game_config_id: String,
+    /// Tournament-level seed for `matchup_seed`. SQLite's INTEGER is signed;
+    /// the high bit is masked off at the store boundary (matching the
+    /// `matchup_seed` precedent), so callers can pass any `u64` without
+    /// knowing about `i64::MAX`.
+    pub tournament_seed: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -219,6 +234,11 @@ pub enum EvalError {
 
     #[error("json error: {0}")]
     Json(#[from] serde_json::Error),
+
+    /// A migration refused to run because pre-flight state was unsafe to
+    /// upgrade automatically. The operator must manually backfill or wipe.
+    #[error("migration {version} blocked: {message}")]
+    MigrationBlocked { version: u32, message: String },
 }
 
 /// Tournament-context player insert errors.
@@ -242,6 +262,23 @@ pub enum DeletePlayerError {
     /// tournaments first, or bump the player id.
     #[error("player is referenced by tournament history (tournaments: {tournament_ids:?})")]
     InTournamentHistory { tournament_ids: Vec<TournamentId> },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CreateTournamentError {
+    #[error(transparent)]
+    Db(#[from] EvalError),
+
+    /// `NewTournament.game_config_id` does not reference an existing row in
+    /// `game_configs`. The caller must `ensure_game_config(...)` first.
+    #[error("game_config_id {0:?} does not exist in game_configs")]
+    GameConfigNotFound(String),
+}
+
+impl From<rusqlite::Error> for CreateTournamentError {
+    fn from(e: rusqlite::Error) -> Self {
+        CreateTournamentError::Db(EvalError::Db(e))
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/eval/store/src/types.rs
+++ b/eval/store/src/types.rs
@@ -120,10 +120,12 @@ pub struct NewTournament {
     /// up front and returns `CreateTournamentError::GameConfigNotFound` for a
     /// missing config.
     pub game_config_id: String,
-    /// Tournament-level seed for `matchup_seed`. SQLite's INTEGER is signed;
-    /// the high bit is masked off at the store boundary (matching the
-    /// `matchup_seed` precedent), so callers can pass any `u64` without
-    /// knowing about `i64::MAX`.
+    /// Tournament-level seed for `matchup_seed`. Must be `<= i64::MAX`:
+    /// SQLite's INTEGER column is signed, and a high-bit seed would not
+    /// round-trip without silent truncation. `create_tournament` rejects
+    /// out-of-range seeds with `CreateTournamentError::SeedOutOfRange`
+    /// rather than masking, so the value the caller passes always equals
+    /// the value the row stores.
     pub tournament_seed: u64,
 }
 
@@ -273,6 +275,13 @@ pub enum CreateTournamentError {
     /// `game_configs`. The caller must `ensure_game_config(...)` first.
     #[error("game_config_id {0:?} does not exist in game_configs")]
     GameConfigNotFound(String),
+
+    /// `NewTournament.tournament_seed` exceeds `i64::MAX`. SQLite's INTEGER
+    /// is signed, so values with the high bit set cannot round-trip
+    /// without truncation. Reject at the boundary instead of silently
+    /// masking so the caller's seed and the stored seed always agree.
+    #[error("tournament_seed {seed} exceeds i64::MAX; SQLite INTEGER is signed")]
+    SeedOutOfRange { seed: u64 },
 }
 
 impl From<rusqlite::Error> for CreateTournamentError {

--- a/eval/store/src/types.rs
+++ b/eval/store/src/types.rs
@@ -105,8 +105,10 @@ pub struct TournamentRecord {
     /// Content-hashed id of the `game_configs` row this tournament uses.
     /// Validated at insert time and on resume.
     pub game_config_id: String,
-    /// Seed fed into the planner's `matchup_seed` derivation. Stored as i64
-    /// with the high bit masked off (see `NewTournament.tournament_seed`).
+    /// Seed fed into the planner's `matchup_seed` derivation. Bounded at
+    /// insert time to `<= i64::MAX` (see `NewTournament.tournament_seed`),
+    /// so this value round-trips bit-identically with what the caller
+    /// passed.
     pub tournament_seed: u64,
     pub created_at: String,
 }


### PR DESCRIPTION
## Motivation

The store landed in a previous PR with the durable half: tournaments, `match_attempts`, typed errors. Nothing drives it yet. The orchestrator can run matches concurrently and the store can record outcomes, but there's no layer that decides which matchups to issue, persists their terminals, and recovers state across a restart.

The hard part is keeping runtime state and the durable record byte-equivalent. Anything in `TournamentState.history` has to correspond to a row in `match_attempts`, and vice versa. Without that invariant, a `kill -9` mid-match leaves runtime ahead of the store, and resume re-issues the wrong work.

## Solution

New crate `pyrat-eval` at `eval/session/`. Seven modules, each owning one concern:

```
descriptor   EvalMatchDescriptor — tournament-context match identity
state        TournamentState + four-rule apply contract
plan         Planner trait, RoundRobin + Gauntlet, stateless seed derivation
observation  DriverEvent -> planner-facing projection
mapping      type-conversion glue (configs, timestamps, failure reasons)
store_sink   MatchSink impl that writes match_attempts rows
session      two-phase API: create_tournament then start
```

### The durability invariant

There's one load-bearing rule across `state.apply` and `store_sink`:

```
MatchFailed { durable_record: false }
  -> remove from in_flight, do nothing else
  -> no history entry, no Elo recompute, no row in match_attempts
```

This keeps runtime state and the store byte-equivalent. On resume, the planner sees no row for the lost attempt at that `attempt_index` and silently re-issues at the same index. The lost run becomes a silent retry. The honest framing: we don't claim \"row absence means never-started\"; we claim \"lost runs are silent retries.\" A documented v1 punt is to add `attempts.status='in_flight'` rows for forensic visibility, but v1 doesn't.

### Stateless seed derivation

Same matchup key always produces the same seed, regardless of scheduling order, parallelism, or resume:

```rust
fn matchup_seed(tournament_seed, p1, p2, game_config_id, repetition_index) -> u64 {
    let mut h = Sha256::new();
    h.update(tournament_seed.to_le_bytes());
    h.update(p1.as_bytes());
    h.update(p2.as_bytes());
    h.update(game_config_id.as_bytes());
    h.update(repetition_index.to_le_bytes());
    let bytes = h.finalize();
    let raw = u64::from_le_bytes(bytes[..8].try_into().unwrap());
    raw & (i64::MAX as u64)  // SQLite INTEGER is signed i64
}
```

`attempt_index` is deliberately *not* in the derivation: retries replay the exact same seeded match. A deterministic engine bug at turn 50 fails every retry — that's correct, the planner stops after `max_failures_per_pair`. Retries help with flaky environmental failures (subprocess handshake blips), not with deterministic bugs.

### Two-phase session API

```rust
let tid = EvalSession::create_tournament(&store, spec, players).await?;
let planner = RoundRobinPlanner::new(tid, ...);
let session = EvalSession::start(&store, SessionMode { tournament_id: tid }, planner, ...).await?;
```

The two phases resolve a chicken-and-egg: the planner needs `tournament_id` at construction, but a single-call API would have the session allocating it inside the call.

The session exposes three subscription surfaces:

- `state()` — `watch::Receiver<TournamentState>` for snapshots
- `events()` — `broadcast::Receiver<SessionEvent>` for the lossless lifecycle tail
- `live_events()` — `broadcast::Receiver<OrchestratorEvent>` for per-turn detail (lossy, GUI consumers)

`subscribe()` returns `(TournamentState, broadcast::Receiver<SessionEvent>)` atomically, so consumers see a state snapshot followed by every subsequent event.

### Beyond the original PR 5 plan

The first nine commits added correctness fixes the original plan didn't anticipate. They're scoped tight and each gets its own commit:

- **Tournament bootstrap now owns the game config end-to-end.** `EvalSession::create_tournament` calls `ensure_game_config` and surfaces the resolved `game_config_id`. A schema migration adds `NOT NULL game_config_id` and `tournament_seed` to `tournaments` via table-rebuild (SQLite `ALTER` can't add `NOT NULL REFERENCES`). Before this fix, the first match terminal hit an FK violation, the orchestrator demoted to `durable_record=false`, and the planner re-issued forever.

- **`shutdown` no longer deadlocks.** A `CancellationToken` preempts both the run loop's `driver_rx.recv()` and any in-flight `submit().await`. `shutdown` cancels, awaits the loop, then reclaims the orchestrator via `Arc::try_unwrap` and calls its consuming `shutdown().await` for graceful drain. Drain only happens when the session owns the last `Arc<Orchestrator>` clone — documented.

- **Persistent sink-flush failures abort the session.** Without this, a read-only DB or repeated `AttemptAlreadyExists` loops forever (the failure stays `durable_record=false`, so `max_failures_per_pair` never fires). A per-`MatchupKey` counter of consecutive `SinkFlushError` terminals trips a configurable threshold (default 5) and aborts with `SessionError::PersistentSinkFlushError`. Other terminals reset the counter, so transient hiccups don't decay it.

- **`spawn_blocking` panics surface as typed errors.** `SessionError::TaskPanicked { what, message }` replaces `.expect(\"panicked\")` in bootstrap and reconstruction so callers can match on it.

- **Planner validates against the stored tournament on resume.** New required `Planner` trait accessors (`expected_players`, `expected_game_config_id`, `expected_tournament_seed`, `expected_target_per_pair`). Mismatches return `SessionError::TournamentMismatch` with a precise reason. Without this, a drifted planner would silently append rows against an existing tournament_id, fragmenting standings.

- **Elo recomputes on initial state before publishing to the watch.** A `subscribe()` between `start` returning and the run loop's first iteration used to see a resumed snapshot with empty standings.

- **`MatchupKey` is canonical at construction.** Two constructors (`from_descriptor`, `from_pair`) lex-sort player ids internally. Scores are canonicalized to match, in both `apply()` (live) and `fold_attempt` (resume).

### Plan deviations folded into the brief

Captured in `.mt/briefs/eval/plan.md` and `.mt/log.md` (2026-05-07):

- `MatchupHistory` carries success scores (so `recompute_elo` works from history without re-querying the store).
- `Planner::next_batch` takes `&mut dyn FnMut() -> MatchId` instead of `&MatchIdAllocator` (keeps the planner orchestrator-agnostic).
- `Observation::from_driver_event` returns `Option<Observation>` (drift-safe under `#[non_exhaustive]`).
- New `mapping` module (not in the original plan) folds smear-risk conversions into one place: `GameConfig -> GameConfigRecord`, `MatchOutcome/MatchFailure -> NewAttempt`, `FailureReason -> String`, `SystemTime -> SQLite \"YYYY-MM-DD HH:MM:SS\"`. Inlines Howard Hinnant's `civil_from_days` to avoid a `time` / `chrono` dep.
- Dropped `last_recompute_at: Instant` (YAGNI) and the redundant `tournament_id` field on `StoreSink` (the descriptor carries it).
- `aggregate_pairs` made `pub` in `pyrat-eval-store` and reused, instead of duplicated.

## Test Plan

```
cargo test -p pyrat-eval
cargo test -p pyrat-eval-store
cargo clippy --all-targets --all-features -- -D warnings -A non-local-definitions
cargo fmt --all -- --check
```

Coverage:

- **45 lib tests** in `pyrat-eval` covering: planner round-robin behavior, capacity caps, pending-set anti-double-issue, retry attempt-index advance, non-durable retry-at-same-index, max-failures-per-pair termination, seed determinism; all four `state.apply` arms including the `durable_record == false` no-history rule; head-to-head pair normalization with score canonicalization; mapping for game configs, timestamps, failure reasons, success/failure projection; store sink success / failure-durable / failure-non-durable / descriptor round-trip; persistent-sink-failure guard (unit + e2e with `AlwaysFailingSink`).

- **Integration tests** in `eval/session/tests/`:
  - `resume.rs` — plant a success row, reconstruct state, assert `next_batch` returns exactly the missing matchups. Tightened to assert every re-issued matchup's `attempt_index=0` and canonical seed. Added a retry-after-durable-failure case (planted Failure -> retry at `attempt_index=1`, same seed) and a kill-9 case (planted nothing -> re-issue at `attempt_index=0`).
  - `e2e_session.rs` — real `EvalSession` with embedded `MockBot` factories, real orchestrator, real in-memory store. 2-player target-1 and 3-player target-1; both terminate with all-success durable rows.
  - `shutdown.rs` — 5 players × 50 games-per-pair (plenty of pending work); `shutdown()` returns within 5 seconds. Before the deadlock fix this hung.
  - `subscribe.rs` — `subscribe` before the run loop finishes and `TournamentFinished` still arrives in the tail; two subscribers see the same tail.
  - `validate.rs` — four mismatch cases (players, tournament_seed, game_config_id, target_games_per_matchup) each return `SessionError::TournamentMismatch` with the right substring; happy-path accept.

92 `pyrat-eval-store` tests still pass (added one covering the new public `aggregate_pairs`).