### PR TITLE
Add botpack Elo ladder: committed spec, CI workflow, gh-pages standings

### DIFF
--- a/.github/workflows/ladder.yml
+++ b/.github/workflows/ladder.yml
@@ -1,0 +1,142 @@
+name: Botpack Ladder
+
+# Recomputes the botpack Elo ladder from scratch under the conditions pinned
+# in botpack/ladder.toml, and publishes standings to gh-pages.
+#
+# Two jobs on purpose: `run` executes bot code and gets read-only permissions;
+# `deploy` only touches the rendered artifact and is gated to pushes on main.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    # Pre-merge test path (workflow_dispatch is unavailable until this file is
+    # on the default branch). Filtered to everything that can shift results.
+    paths:
+      - '.github/workflows/ladder.yml'
+      - 'tools/render_ladder.py'
+      - 'botpack/**'
+      - 'eval/**'
+      - 'sdk/**'
+      - 'server/**'
+      - 'interface/**'
+      - 'engine/**'
+      - 'Cargo.lock'
+      - 'pyproject.toml'
+      - 'uv.lock'
+  workflow_dispatch:
+
+concurrency:
+  group: ladder-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  run:
+    name: Run ladder tournament
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache cargo registry
+      uses: actions/cache@v5
+      with:
+        path: ~/.cargo/registry
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
+
+    - name: Cache cargo index
+      uses: actions/cache@v5
+      with:
+        path: ~/.cargo/git
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
+
+    - name: Cache cargo build
+      uses: actions/cache@v5
+      with:
+        path: target
+        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('Cargo.lock') }}
+
+    - name: Cache botpack builds
+      # The botpack crates are isolated workspaces, so the root target cache
+      # never covers them. Key on their lockfiles plus the SDK path-dependency
+      # tree (sdk -> bot-api/wire/protocol/interface/engine).
+      uses: actions/cache@v5
+      with:
+        path: |
+          botpack/greedy/target
+          botpack/smart-random/target
+          botpack/search/target
+        key: ${{ runner.os }}-botpack-target-${{ hashFiles('botpack/*/Cargo.lock', 'sdk/**', 'server/wire/**', 'server/protocol/**', 'interface/**', 'engine/**') }}
+        restore-keys: |
+          ${{ runner.os }}-botpack-target-
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        cache-dependency-glob: |
+          pyproject.toml
+          sdk/python/pyproject.toml
+
+    - name: Sync workspace dependencies
+      run: uv sync --all-extras
+
+    - name: Build SDK Python extension
+      run: uv run --directory sdk/python maturin develop --release
+
+    - name: Build pyrat-eval
+      run: cargo build --release -p pyrat-eval
+
+    - name: Build botpack bots
+      # Pre-build so build failures surface here, not as match startup timeouts.
+      run: |
+        for bot in greedy smart-random search; do
+          (cd "botpack/$bot" && cargo build --release)
+        done
+
+    - name: Run tournament
+      run: cargo run --release -p pyrat-eval -- tournament run --config botpack/ladder.toml --results-json ladder-results.json
+
+    - name: Render standings
+      run: uv run python tools/render_ladder.py ladder-results.json site | tee -a "$GITHUB_STEP_SUMMARY"
+
+    - name: Upload standings
+      uses: actions/upload-artifact@v4
+      with:
+        name: ladder-site
+        path: site/
+
+  deploy:
+    name: Publish to gh-pages
+    runs-on: ubuntu-latest
+    needs: run
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+
+    steps:
+    - name: Download standings
+      uses: actions/download-artifact@v4
+      with:
+        name: ladder-site
+        path: site
+
+    - name: Deploy to gh-pages
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./site

--- a/.gitignore
+++ b/.gitignore
@@ -297,6 +297,10 @@ rust-project.json
 # GUI (Tauri + React)
 node_modules/
 gui/dist/
+
+# pyrat-eval local rating stores (default store paths)
+ratings.db
+botpack/ladder.db
 gui/src-tauri/gen/
 
 # End of https://www.toptal.com/developers/gitignore/api/rust,rust-analyzer,jetbrains+all,python

--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ cargo run -p pyrat-eval -- tournament run \
   --bot smart_random=botpack/smart-random \
   --format round-robin --games 5
 
-# Committed spec: a TOML file. Flags override config values.
-cargo run -p pyrat-eval -- tournament run --config ladder.toml
+# Committed spec: a TOML file. Flags override config values. The botpack
+# ladder spec is one of these:
+cargo run -p pyrat-eval -- tournament run --config botpack/ladder.toml
 
 # Materialize the resolved spec to disk for source control:
 cargo run -p pyrat-eval -- tournament run --bot ... --save-as ladder.toml
@@ -121,6 +122,14 @@ id = "smart_random"
 command = "cargo run --release"
 working_dir = "../botpack/smart-random"
 ```
+
+## Botpack ladder
+
+The botpack bots play each other in CI on every merge to main. Standings live at:
+
+**https://mintiti.github.io/pyrat-rust/**
+
+The conditions are pinned in [`botpack/ladder.toml`](botpack/ladder.toml), and the table is recomputed from scratch each run, so it always reflects the bots as they are on `main`.
 
 ## The game
 

--- a/botpack/README.md
+++ b/botpack/README.md
@@ -33,6 +33,16 @@ Listed from simplest to most complex.
 
 Looking for a specific SDK feature? The source code is the documentation: each bot's comments explain the strategy reasoning and SDK usage.
 
+## Ladder
+
+The bots above play each other in CI on every merge to main. Elo standings live at https://mintiti.github.io/pyrat-rust/.
+
+Match conditions are pinned in [`ladder.toml`](ladder.toml), and standings are recomputed from scratch each run. To reproduce locally, from the repo root:
+
+```bash
+cargo run -p pyrat-eval -- tournament run --config botpack/ladder.toml
+```
+
 ## bot.toml
 
 Every bot has a `bot.toml` that describes how to run it:

--- a/botpack/ladder.toml
+++ b/botpack/ladder.toml
@@ -1,0 +1,66 @@
+# Botpack ladder — committed spec, run by CI on merge to main (.github/workflows/ladder.yml).
+#
+# Fresh store each run, fixed seed: the seed pins mazes, cheese, and schedule,
+# so standings reflect current bot code only. Bots use their own unseeded RNG,
+# so standings can wobble slightly between runs on identical code.
+#
+# All behavior-shaping values are pinned here on purpose: the committed spec
+# must not silently change if CLI defaults drift.
+
+seed = 7
+format = "round_robin"
+target_games_per_matchup = 5
+max_failures_per_pair = 1
+max_parallel = 2
+
+[game]
+# 11x9, 13 cheese, 150 max turns.
+preset = "tiny"
+
+[timing]
+# Tight budgets are the pinned "ladder conditions": both search bots deepen
+# until should_stop() every turn and in preprocess, so they consume whatever
+# budget they're given. 9 of 15 pairings involve a search bot — the per-turn
+# budget drives total runtime.
+move_timeout_ms = 200
+preprocessing_timeout_ms = 2000
+configure_timeout_ms = 5000
+network_grace_ms = 50
+# Botpack crates live outside the root workspace, so a cold `cargo run
+# --release` builds the SDK dep tree. CI pre-builds the bots, but keep margin
+# (same lesson as eval/session/tests/cli_run_tournament.rs).
+startup_timeout_ms = 120000
+
+[elo]
+anchor = "smart-random"
+anchor_elo = 1000.0
+
+[[players]]
+id = "greedy"
+command = "cargo run --release"
+working_dir = "greedy"
+
+[[players]]
+id = "smart-random"
+command = "cargo run --release"
+working_dir = "smart-random"
+
+[[players]]
+id = "search"
+command = "cargo run --release"
+working_dir = "search"
+
+[[players]]
+id = "greedy-py"
+command = "uv run python bot.py"
+working_dir = "greedy-py"
+
+[[players]]
+id = "smart-random-py"
+command = "uv run python bot.py"
+working_dir = "smart-random-py"
+
+[[players]]
+id = "search-py"
+command = "uv run python bot.py"
+working_dir = "search-py"

--- a/botpack/ladder.toml
+++ b/botpack/ladder.toml
@@ -32,7 +32,9 @@ network_grace_ms = 50
 startup_timeout_ms = 120000
 
 [elo]
-anchor = "smart-random"
+# greedy at 1000 matches alpharat's benchmark convention, so ratings stay
+# comparable across the ecosystem.
+anchor = "greedy"
 anchor_elo = 1000.0
 
 [[players]]

--- a/sdk/python/pyrat_sdk/bot.py
+++ b/sdk/python/pyrat_sdk/bot.py
@@ -33,6 +33,14 @@ class GameResult(enum.IntEnum):
 
 # ── Context ────────────────────────────────────────────
 
+# Safety margin subtracted from the time budget so that a bot which searches
+# until should_stop() returns its action *before* the host's wall-clock
+# deadline (encode + send must fit in the gap). Mirrors the Rust SDK's
+# MOVE_SAFETY_MARGIN_MS. Without it, a budget-exhausting bot returns past the
+# nominal deadline on every turn and is accepted only thanks to the host's
+# network grace window.
+MOVE_SAFETY_MARGIN_MS = 5
+
 
 class Context:
     """Passed to ``think()`` and ``preprocess()``. Provides timing and info sending."""
@@ -47,8 +55,11 @@ class Context:
         state_hash: int = 0,
     ) -> None:
         self._think_start = time.monotonic()
+        self._budget_ms = timeout_ms
         self._deadline = self._think_start + (
-            86400.0 if timeout_ms == 0 else timeout_ms / 1000.0
+            86400.0
+            if timeout_ms == 0
+            else max(timeout_ms - MOVE_SAFETY_MARGIN_MS, 0) / 1000.0
         )
         self._conn = conn
         self._stop_event = stop_event
@@ -65,6 +76,14 @@ class Context:
         return time.monotonic() >= self._deadline or (
             self._stop_event is not None and self._stop_event.is_set()
         )
+
+    def _budget_exceeded(self) -> bool:
+        """True when think ran past the full time budget, not just the
+        margin-shaved deadline. A bot that searches until should_stop()
+        legitimately returns at the deadline — that is not overshoot."""
+        if self._budget_ms == 0:
+            return False
+        return (time.monotonic() - self._think_start) * 1000.0 > self._budget_ms
 
     def think_elapsed_ms(self) -> int:
         """Milliseconds elapsed since think started."""
@@ -158,7 +177,9 @@ class Bot:
             traceback.print_exc()
             direction = Direction.STAY
 
-        if ctx.should_stop():
+        # should_stop() being true here is normal for a bot that searches
+        # until the deadline; only warn on a genuine budget overshoot.
+        if ctx._budget_exceeded():
             print(
                 "think() exceeded time limit. The host may have used STAY.",
                 file=sys.stderr,
@@ -223,7 +244,9 @@ class HivemindBot:
             traceback.print_exc()
             moves = {}
 
-        if ctx.should_stop():
+        # should_stop() being true here is normal for a bot that searches
+        # until the deadline; only warn on a genuine budget overshoot.
+        if ctx._budget_exceeded():
             print(
                 "think() exceeded time limit. The host may have used STAY.",
                 file=sys.stderr,
@@ -365,17 +388,13 @@ def _run_lifecycle(
     # Welcome assigns the player slot.
     welcome = _read_one(conn)
     if welcome.get("kind") != "Welcome":
-        raise ConnectionError(
-            f"expected Welcome, got {welcome.get('kind')!r}"
-        )
+        raise ConnectionError(f"expected Welcome, got {welcome.get('kind')!r}")
     slot = welcome["player_slot"]
 
     # Configure carries options + match config in one message.
     configure = _read_one(conn)
     if configure.get("kind") != "Configure":
-        raise ConnectionError(
-            f"expected Configure, got {configure.get('kind')!r}"
-        )
+        raise ConnectionError(f"expected Configure, got {configure.get('kind')!r}")
     match_config = configure["match_config"]
     for name, value in configure.get("options", []):
         apply_set_option(bot, option_defs, name, value)
@@ -388,9 +407,7 @@ def _run_lifecycle(
 
     go_pre = _read_one(conn)
     if go_pre.get("kind") != "GoPreprocess":
-        raise ConnectionError(
-            f"expected GoPreprocess, got {go_pre.get('kind')!r}"
-        )
+        raise ConnectionError(f"expected GoPreprocess, got {go_pre.get('kind')!r}")
     if go_pre["state_hash"] != state.state_hash:
         print(
             f"[sdk] state_hash mismatch: bot {state.state_hash:#x} "

--- a/sdk/python/tests/test_context.py
+++ b/sdk/python/tests/test_context.py
@@ -24,6 +24,28 @@ def test_zero_timeout_is_infinite():
     assert ctx.should_stop() is False
 
 
+def test_safety_margin_shaves_deadline():
+    """The deadline sits MOVE_SAFETY_MARGIN_MS before the budget, and a budget
+    at or below the margin means an immediate deadline — not an infinite one."""
+    ctx = Context(10_000, MockConnection([]))
+    assert ctx.time_remaining_ms() <= 10_000 - 5
+    ctx = Context(5, MockConnection([]))
+    assert ctx.should_stop() is True
+
+
+def test_budget_exceeded_is_not_should_stop():
+    """A bot returning at the (margin-shaved) deadline has NOT overshot the
+    budget; only running past the full budget counts. Zero budget never does."""
+    ctx = Context(10_000, MockConnection([]))
+    assert ctx._budget_exceeded() is False
+    ctx = Context(1, MockConnection([]))
+    time.sleep(0.01)
+    assert ctx.should_stop() is True
+    assert ctx._budget_exceeded() is True
+    ctx = Context(0, MockConnection([]))
+    assert ctx._budget_exceeded() is False
+
+
 def test_should_stop_flag_only():
     """Future deadline, stop event set -> should_stop returns True."""
     event = threading.Event()

--- a/tools/render_ladder.py
+++ b/tools/render_ladder.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Render botpack ladder standings from pyrat-eval results JSON.
+
+Usage: render_ladder.py <results.json> <out_dir>
+
+Writes <out_dir>/index.html and copies the results JSON to
+<out_dir>/results.json. Prints a markdown table to stdout (the CI workflow
+pipes it into the job summary).
+"""
+
+import html
+import json
+import os
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+PAGE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>PyRat Botpack Ladder</title>
+<style>
+  body {{ font-family: system-ui, sans-serif; max-width: 40rem; margin: 3rem auto; padding: 0 1rem; color: #222; }}
+  table {{ border-collapse: collapse; width: 100%; }}
+  th, td {{ text-align: left; padding: 0.4rem 0.8rem; border-bottom: 1px solid #ddd; }}
+  th {{ border-bottom: 2px solid #222; }}
+  td.num, th.num {{ text-align: right; font-variant-numeric: tabular-nums; }}
+  footer {{ margin-top: 2rem; font-size: 0.85rem; color: #666; }}
+  code {{ background: #f4f4f4; padding: 0.1rem 0.3rem; border-radius: 3px; }}
+</style>
+</head>
+<body>
+<h1>PyRat Botpack Ladder</h1>
+<p>Elo standings of the botpack bots, recomputed from scratch on every merge
+to <code>main</code> under the conditions pinned in
+<code>botpack/ladder.toml</code>.</p>
+<table>
+<thead><tr><th class="num">#</th><th>Bot</th><th class="num">Elo</th></tr></thead>
+<tbody>
+{rows}
+</tbody>
+</table>
+<footer>
+<p>Updated {date} &middot; commit <code>{sha}</code> &middot;
+{success} games played ({failure} failed attempts) &middot;
+<a href="results.json">results.json</a></p>
+</footer>
+</body>
+</html>
+"""
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(__doc__.strip(), file=sys.stderr)
+        return 2
+
+    results_path = Path(sys.argv[1])
+    out_dir = Path(sys.argv[2])
+
+    results = json.loads(results_path.read_text())
+    if results.get("status") != "finished" or not results.get("standings"):
+        print(f"no standings to render (status: {results.get('status')})", file=sys.stderr)
+        return 1
+
+    standings = results["standings"]
+    attempts = results.get("attempts", {})
+    sha = os.environ.get("GITHUB_SHA", "local")[:9]
+    date = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    rows = "\n".join(
+        f'<tr><td class="num">{rank}</td><td>{html.escape(row["player_id"])}</td>'
+        f'<td class="num">{row["elo"]:.0f}</td></tr>'
+        for rank, row in enumerate(standings, start=1)
+    )
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "index.html").write_text(
+        PAGE.format(
+            rows=rows,
+            date=date,
+            sha=html.escape(sha),
+            success=attempts.get("success", "?"),
+            failure=attempts.get("failure", "?"),
+        )
+    )
+    shutil.copyfile(results_path, out_dir / "results.json")
+
+    print("| # | Bot | Elo |")
+    print("|--:|-----|----:|")
+    for rank, row in enumerate(standings, start=1):
+        print(f"| {rank} | {row['player_id']} | {row['elo']:.0f} |")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Motivation

The botpack has six bots and, since the eval package landed, a tournament runner that can rate them — but no actual ladder. Nothing to measure a new bot against, no ranked list for students to climb. This operationalizes the ladder: a committed spec, a CI workflow that recomputes standings on every merge to main, and a published standings page.

## Solution

### The spec is the ladder

`botpack/ladder.toml` pins everything that shapes behavior — game preset, time budgets, seed, Elo anchor — so the standings don't silently drift if CLI defaults change. The seed pins mazes, cheese, and schedule; bots keep their own RNG, so standings can wobble slightly between identical runs.

Each CI run starts from a fresh store and recomputes from scratch. There's no player versioning in the store yet, so results accumulated from old bot versions would pollute Elo. Recomputing keeps the table honest: it always reflects the bots exactly as they are on main.

Tight budgets (200ms moves) are deliberate: the search bots deepen until the budget expires, so the per-turn budget is what drives total runtime (~22 min for 75 games locally).

### Workflow

Two jobs, so bot code never executes with write permissions: `run` (contents: read) plays the tournament and renders the page, `deploy` (contents: write) publishes the artifact to gh-pages, gated to pushes on main. PRs touching the dependency surface (botpack, SDKs, engine, host, eval) get the run job as a pre-merge check. Botpack targets are cached separately — they're isolated workspaces the root cargo cache never covers.

The page is plain stdlib-generated HTML: gh-pages deploys with `.nojekyll`, so markdown would serve raw.

One-time setup after merge: enable GitHub Pages with source `gh-pages` in the repo settings.

### Python SDK: deadline margin + honest timeout warning

Shaking the ladder out surfaced a Python SDK gap (first commit). `Context` had no safety margin on the think deadline, so a bot that searches until `should_stop()` returned past the nominal deadline on every turn — accepted only thanks to the host's network grace window. And the SDK's "think() exceeded time limit" stderr warning fired on `should_stop()`, which is *always* true for a budget-exhausting bot: hundreds of false alarms per tournament while every action was accepted fine (verified via replay records: zero `BotTimeout` events with or without the fix). The margin now mirrors the Rust SDK's 5ms, and the warning fires only on genuine overshoot past the full budget.

## Test Plan

Two full ladder runs locally, fresh stores: 75/75 games each, zero failures, exit 0. Same ordering both times, with rust/py pairs of the same strategy rating close together — same algorithm in either language rates the same, which doubles as a platform-fairness check:

```
rank  bot                 Elo
   1  greedy             1494
   2  greedy-py          1494
   3  search             1204
   4  search-py          1174
   5  smart-random       1000
   6  smart-random-py     876
```

SDK: `uv run --directory sdk/python pytest tests` — 121 tests pass. Renderer exercised on real results JSON.

This PR itself triggers the ladder `run` job (path-filtered pull_request), which gives the CI wall-clock baseline. The deploy job is correctly skipped off-main; the gh-pages publish gets verified on merge.