### PR TITLE
Ladder standings with uncertainty: elo_stderr in results JSON, redesigned page, 15 games

### DIFF
--- a/botpack/ladder.toml
+++ b/botpack/ladder.toml
@@ -9,7 +9,11 @@
 
 seed = 7
 format = "round_robin"
-target_games_per_matchup = 5
+# 15 games/matchup: stderr shrinks ~1/sqrt(G); 5 left ~±200-360 (95%) per
+# bot, wide enough that Bradley-Terry stretched the bottom pair by 300+
+# Elo off a 5-game direct sample (a 100-game duel showed them dead even).
+# Runtime is search-game-bound: worst case ~42 min, inside the CI timeout.
+target_games_per_matchup = 15
 max_failures_per_pair = 1
 max_parallel = 2
 

--- a/eval/session/src/bin/pyrat-eval/tournament_run.rs
+++ b/eval/session/src/bin/pyrat-eval/tournament_run.rs
@@ -11,6 +11,7 @@
 //!   re-derived from the user's flags/config and *verified* against the
 //!   store (the store carries results and identity, not bot commands).
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
@@ -23,7 +24,7 @@ use pyrat_eval::{
     SessionError, SessionMode, TournamentMismatch, TournamentParams, TournamentSpec,
     TournamentState,
 };
-use pyrat_eval_store::{EloOptions, EvalStore, TournamentId};
+use pyrat_eval_store::{compute_elo_with_uncertainty, EloOptions, EvalStore, TournamentId};
 use pyrat_host::wire::TimingMode;
 use pyrat_orchestrator::{DirectoryWriter, MatchSink, ReplaySink, SinkRole, Timing};
 use serde::Serialize;
@@ -169,7 +170,11 @@ pub async fn run_tournament_main(
         .await
         .map_err(|e| with_resume_hint(&e.to_string(), &resolved.store_path, tournament_id))?;
 
-    render_standings(&final_state, resolved.results_json.as_deref())
+    render_standings(
+        &final_state,
+        resolved.results_json.as_deref(),
+        &build_elo_options(&resolved),
+    )
 }
 
 /// Append resume guidance to a session-phase error. By this point the
@@ -292,7 +297,7 @@ struct ResultsJson<'a> {
     tournament_id: i64,
     status: &'a str,
     attempts: AttemptsCount,
-    standings: Vec<StandingsRow<'a>>,
+    standings: &'a [StandingsEntry],
 }
 
 #[derive(Serialize)]
@@ -301,20 +306,60 @@ pub(crate) struct AttemptsCount {
     pub(crate) failure: u64,
 }
 
+/// One final-standings row: Elo with its standard error (conditional on
+/// the anchor, whose own stderr is near-zero) and games played.
 #[derive(Serialize)]
-struct StandingsRow<'a> {
-    player_id: &'a str,
+struct StandingsEntry {
+    player_id: String,
     elo: f64,
+    elo_stderr: f64,
+    games: u32,
+}
+
+/// Recompute Elo from history with uncertainty, once, at render time.
+/// The session's live standings deliberately skip the covariance work
+/// (they refresh on every MatchFinished); the final table pays for it
+/// a single time here. Same history, same options — identical ratings.
+fn compute_final_standings(state: &TournamentState, options: &EloOptions) -> Vec<StandingsEntry> {
+    let h2h = state.head_to_head();
+    let Ok((result, uncertainty)) = compute_elo_with_uncertainty(&h2h, options) else {
+        // Mirrors the session's recompute: no records or a disconnected
+        // player graph means no standings (the caller prints the hint).
+        return Vec::new();
+    };
+    let mut games: HashMap<&str, u32> = HashMap::new();
+    for r in &h2h {
+        *games.entry(r.player_a.as_str()).or_default() += r.total();
+        *games.entry(r.player_b.as_str()).or_default() += r.total();
+    }
+    let mut entries: Vec<StandingsEntry> = result
+        .ratings
+        .iter()
+        .map(|r| StandingsEntry {
+            player_id: r.player_id.clone(),
+            elo: r.elo,
+            elo_stderr: uncertainty.stderr(&r.player_id).unwrap_or(0.0),
+            games: games.get(r.player_id.as_str()).copied().unwrap_or(0),
+        })
+        .collect();
+    entries.sort_by(|a, b| {
+        b.elo
+            .partial_cmp(&a.elo)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    entries
 }
 
 fn render_standings(
     state: &TournamentState,
     results_json_path: Option<&Path>,
+    elo_options: &EloOptions,
 ) -> Result<AttemptsCount, Box<dyn std::error::Error>> {
     let counts = count_attempts(state);
-    print_table(state, &counts);
+    let standings = compute_final_standings(state, elo_options);
+    print_table(state, &counts, &standings);
     if let Some(path) = results_json_path {
-        write_results_json(state, &counts, path)?;
+        write_results_json(state, &counts, &standings, path)?;
     }
     Ok(counts)
 }
@@ -333,7 +378,7 @@ fn count_attempts(state: &TournamentState) -> AttemptsCount {
     AttemptsCount { success, failure }
 }
 
-fn print_table(state: &TournamentState, counts: &AttemptsCount) {
+fn print_table(state: &TournamentState, counts: &AttemptsCount, standings: &[StandingsEntry]) {
     let TournamentId(id) = state.tournament_id;
     println!("Tournament {id} — finished");
     println!(
@@ -341,7 +386,6 @@ fn print_table(state: &TournamentState, counts: &AttemptsCount) {
         counts.success, counts.failure
     );
     println!();
-    let mut standings = state.standings.clone();
     if standings.is_empty() {
         // Names the cause so the user knows where to look. The common case
         // is `success == 0 && failure > 0` (every matchup hit the retry
@@ -353,24 +397,21 @@ fn print_table(state: &TournamentState, counts: &AttemptsCount) {
         );
         return;
     }
-    standings.sort_by(|a, b| {
-        b.elo
-            .partial_cmp(&a.elo)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
     let max_id = standings
         .iter()
         .map(|r| r.player_id.len())
         .max()
         .unwrap_or(9);
     let id_width = max_id.max("player_id".len());
-    println!("  rank  {:<id_width$}      elo", "player_id");
-    for (i, rating) in standings.iter().enumerate() {
+    println!("  rank  {:<id_width$}      elo    ±err  games", "player_id");
+    for (i, r) in standings.iter().enumerate() {
         println!(
-            "  {:>4}  {:<id_width$}  {:>8.1}",
+            "  {:>4}  {:<id_width$}  {:>8.1}  {:>6.1}  {:>5}",
             i + 1,
-            rating.player_id,
-            rating.elo
+            r.player_id,
+            r.elo,
+            r.elo_stderr,
+            r.games
         );
     }
 }
@@ -378,22 +419,10 @@ fn print_table(state: &TournamentState, counts: &AttemptsCount) {
 fn write_results_json(
     state: &TournamentState,
     counts: &AttemptsCount,
+    standings: &[StandingsEntry],
     path: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let TournamentId(id) = state.tournament_id;
-    let mut standings = state.standings.clone();
-    standings.sort_by(|a, b| {
-        b.elo
-            .partial_cmp(&a.elo)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
-    let rows: Vec<_> = standings
-        .iter()
-        .map(|r| StandingsRow {
-            player_id: &r.player_id,
-            elo: r.elo,
-        })
-        .collect();
     // "finished" with zero successes means every matchup exhausted its
     // retry budget — a script consuming this JSON must be able to tell
     // that apart from a real result set.
@@ -409,7 +438,7 @@ fn write_results_json(
             success: counts.success,
             failure: counts.failure,
         },
-        standings: rows,
+        standings,
     };
     if let Some(parent) = path.parent() {
         if !parent.as_os_str().is_empty() {
@@ -561,28 +590,39 @@ mod tests {
 
     #[test]
     fn results_json_includes_tournament_id_and_standings_descending() {
-        use pyrat_eval::TournamentState;
-        use pyrat_eval_store::EloRating;
+        use pyrat_eval::{MatchupKey, MatchupOutcome, TournamentState};
         let tmp = tempfile::tempdir().expect("tempdir");
         let path = tmp.path().join("results.json");
 
         let mut state = TournamentState::empty(TournamentId(11));
-        state.standings = vec![
-            EloRating {
-                player_id: "loser".into(),
-                elo: 800.0,
+        // Canonical key order is lexicographic: player1 = "loser". Three
+        // winner wins, one draw, one failure (skipped by Elo and games).
+        let key = MatchupKey::from_pair("winner", "loser", "gc", 0);
+        let success = |s1: f64, s2: f64| pyrat_eval::MatchupAttempt {
+            attempt_index: 0,
+            outcome: MatchupOutcome::Success {
+                player1_score: s1,
+                player2_score: s2,
             },
-            EloRating {
-                player_id: "winner".into(),
-                elo: 1200.0,
-            },
-        ];
-        let counts = AttemptsCount {
-            success: 4,
-            failure: 1,
         };
+        state.history.insert(
+            key,
+            vec![
+                success(0.0, 1.0),
+                success(0.0, 1.0),
+                success(0.0, 1.0),
+                success(0.5, 0.5),
+                pyrat_eval::MatchupAttempt {
+                    attempt_index: 4,
+                    outcome: MatchupOutcome::Failure,
+                },
+            ],
+        );
+        let counts = count_attempts(&state);
+        let options = EloOptions::new("loser".to_string()).anchor_elo(1000.0);
+        let standings = compute_final_standings(&state, &options);
 
-        write_results_json(&state, &counts, &path).expect("write");
+        write_results_json(&state, &counts, &standings, &path).expect("write");
         let raw = std::fs::read_to_string(&path).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
 
@@ -593,6 +633,18 @@ mod tests {
         // Standings sorted descending by elo.
         assert_eq!(parsed["standings"][0]["player_id"], "winner");
         assert_eq!(parsed["standings"][1]["player_id"], "loser");
+        // Anchor pins at 1000; the winner sits above it.
+        assert_eq!(parsed["standings"][1]["elo"], 1000.0);
+        assert!(parsed["standings"][0]["elo"].as_f64().unwrap() > 1000.0);
+        // Uncertainty: the anchor's stderr is near-zero (it's the fixed
+        // reference), the winner's is meaningfully larger. Games count
+        // successes only.
+        let anchor_err = parsed["standings"][1]["elo_stderr"].as_f64().unwrap();
+        let winner_err = parsed["standings"][0]["elo_stderr"].as_f64().unwrap();
+        assert!(anchor_err < 1.0, "anchor stderr ~0, got {anchor_err}");
+        assert!(winner_err > anchor_err);
+        assert_eq!(parsed["standings"][0]["games"], 4);
+        assert_eq!(parsed["standings"][1]["games"], 4);
     }
 
     #[test]
@@ -605,7 +657,10 @@ mod tests {
             success: 0,
             failure: 0,
         };
-        write_results_json(&state, &counts, &path).expect("write");
+        let options = EloOptions::new("anyone".to_string()).anchor_elo(1000.0);
+        let standings = compute_final_standings(&state, &options);
+        assert!(standings.is_empty());
+        write_results_json(&state, &counts, &standings, &path).expect("write");
         let parsed: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(parsed["standings"].as_array().unwrap().len(), 0);

--- a/eval/session/tests/cli_run_tournament.rs
+++ b/eval/session/tests/cli_run_tournament.rs
@@ -662,6 +662,12 @@ fn results_json_written_when_flag_set() {
     // both players rated.
     assert_eq!(parsed["attempts"]["success"], 1);
     assert_eq!(parsed["standings"].as_array().unwrap().len(), 2);
+    // Each row carries uncertainty and games alongside the rating.
+    for row in parsed["standings"].as_array().unwrap() {
+        assert!(row["elo"].is_number(), "elo in {row}");
+        assert!(row["elo_stderr"].is_number(), "elo_stderr in {row}");
+        assert_eq!(row["games"], 1, "games in {row}");
+    }
 }
 
 // ── Replay dir ───────────────────────────────────────────────────────

--- a/tools/render_ladder.py
+++ b/tools/render_ladder.py
@@ -16,6 +16,8 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+REPO_URL = "https://github.com/mintiti/pyrat-rust"
+
 PAGE = """<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -23,34 +25,209 @@ PAGE = """<!DOCTYPE html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>PyRat Botpack Ladder</title>
 <style>
-  body {{ font-family: system-ui, sans-serif; max-width: 40rem; margin: 3rem auto; padding: 0 1rem; color: #222; }}
-  table {{ border-collapse: collapse; width: 100%; }}
-  th, td {{ text-align: left; padding: 0.4rem 0.8rem; border-bottom: 1px solid #ddd; }}
-  th {{ border-bottom: 2px solid #222; }}
-  td.num, th.num {{ text-align: right; font-variant-numeric: tabular-nums; }}
-  footer {{ margin-top: 2rem; font-size: 0.85rem; color: #666; }}
-  code {{ background: #f4f4f4; padding: 0.1rem 0.3rem; border-radius: 3px; }}
+  :root {{
+    --bg: #0e1014;
+    --row: #171a21;
+    --row-top: #1d2027;
+    --text: #e8e6e1;
+    --muted: #8a8f98;
+    --cheese: #f4b942;
+    --cheese-dim: #b8862c;
+    --rust: #de9a66;
+    --python: #6da9d8;
+    --whisker: rgba(232, 230, 225, 0.55);
+    --anchor-line: rgba(232, 230, 225, 0.18);
+  }}
+  * {{ box-sizing: border-box; }}
+  body {{
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    max-width: 46rem;
+    margin: 0 auto;
+    padding: 3.5rem 1.25rem 2.5rem;
+  }}
+  header h1 {{
+    font-size: 1.7rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin: 0 0 0.4rem;
+  }}
+  header p {{
+    color: var(--muted);
+    margin: 0 0 2.2rem;
+    font-size: 0.95rem;
+    line-height: 1.5;
+  }}
+  ol.board {{ list-style: none; margin: 0; padding: 0; }}
+  li.row {{
+    display: grid;
+    grid-template-columns: 2rem minmax(11rem, auto) 1fr auto;
+    gap: 0.9rem;
+    align-items: center;
+    background: var(--row);
+    border-radius: 10px;
+    padding: 0.8rem 1.1rem;
+    margin-bottom: 0.5rem;
+  }}
+  li.row.top {{ background: var(--row-top); box-shadow: inset 0 0 0 1px rgba(244, 185, 66, 0.25); }}
+  .rank {{
+    color: var(--muted);
+    font-size: 0.95rem;
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+  }}
+  .row.top .rank {{ color: var(--cheese); font-weight: 700; }}
+  .who {{ display: flex; align-items: baseline; gap: 0.5rem; min-width: 0; }}
+  .name {{ font-weight: 600; font-size: 1.02rem; }}
+  .chip {{
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+    color: var(--bg);
+  }}
+  .chip.rs {{ background: var(--rust); }}
+  .chip.py {{ background: var(--python); }}
+  .games {{ color: var(--muted); font-size: 0.78rem; white-space: nowrap; }}
+  .track {{
+    position: relative;
+    height: 1.5rem;
+    border-radius: 5px;
+    background: rgba(255, 255, 255, 0.04);
+    overflow: hidden;
+  }}
+  .anchorline {{
+    position: absolute;
+    top: 0; bottom: 0;
+    width: 0;
+    border-left: 1px dashed var(--anchor-line);
+  }}
+  .bar {{
+    position: absolute;
+    top: 0.25rem; bottom: 0.25rem;
+    left: 0;
+    border-radius: 0 3px 3px 0;
+    background: linear-gradient(90deg, var(--cheese-dim), var(--cheese));
+    opacity: 0.9;
+  }}
+  .ci {{
+    position: absolute;
+    top: 50%;
+    height: 0;
+    border-top: 2px solid var(--whisker);
+    transform: translateY(-1px);
+  }}
+  .ci::before, .ci::after {{
+    content: "";
+    position: absolute;
+    top: -4px;
+    height: 8px;
+    border-left: 2px solid var(--whisker);
+  }}
+  .ci::before {{ left: 0; }}
+  .ci::after {{ right: 0; }}
+  .elo {{
+    font-variant-numeric: tabular-nums;
+    font-weight: 650;
+    font-size: 1.02rem;
+    text-align: right;
+    white-space: nowrap;
+  }}
+  .elo .pm {{ color: var(--muted); font-weight: 400; font-size: 0.82rem; }}
+  footer {{
+    margin-top: 2.2rem;
+    color: var(--muted);
+    font-size: 0.82rem;
+    line-height: 1.7;
+  }}
+  footer a {{ color: var(--cheese); text-decoration: none; }}
+  footer a:hover {{ text-decoration: underline; }}
+  @media (max-width: 540px) {{
+    li.row {{ grid-template-columns: 1.4rem minmax(0, 1fr) auto; }}
+    .track {{ display: none; }}
+  }}
 </style>
 </head>
 <body>
-<h1>PyRat Botpack Ladder</h1>
-<p>Elo standings of the botpack bots, recomputed from scratch on every merge
-to <code>main</code> under the conditions pinned in
-<code>botpack/ladder.toml</code>.</p>
-<table>
-<thead><tr><th class="num">#</th><th>Bot</th><th class="num">Elo</th></tr></thead>
-<tbody>
+<header>
+  <h1>&#129472; PyRat Botpack Ladder</h1>
+  <p>The <a href="{repo}/tree/main/botpack" style="color:var(--cheese);text-decoration:none">botpack bots</a>,
+  rated against each other under fixed conditions. Recomputed from scratch on
+  every merge to main.</p>
+</header>
+<main>
+<ol class="board">
 {rows}
-</tbody>
-</table>
+</ol>
+</main>
 <footer>
-<p>Updated {date} &middot; commit <code>{sha}</code> &middot;
-{success} games played ({failure} failed attempts) &middot;
-<a href="results.json">results.json</a></p>
+<p>Updated {date} &middot; commit <a href="{repo}/commit/{sha}">{sha_short}</a> &middot;
+{success} games ({failure} failed attempts) &middot; <a href="results.json">results.json</a></p>
+<p>&plusmn; is a ~95% interval (2&times;stderr), conditional on the anchor:
+greedy is pinned at 1000, matching alpharat's scale. The dashed line marks it.
+Conditions live in <a href="{repo}/blob/main/botpack/ladder.toml">ladder.toml</a>.</p>
 </footer>
 </body>
 </html>
 """
+
+ROW = """<li class="row{top}">
+  <span class="rank">{rank}</span>
+  <div class="who"><span class="name">{name}</span><span class="chip {lang}">{lang}</span></div>
+  <div class="track">{anchor}<div class="bar" style="width:{bar_pct:.1f}%"></div>{ci}</div>
+  <div class="elo">{elo}{pm} <span class="games">&middot; {games} games</span></div>
+</li>"""
+
+
+def split_lang(player_id: str) -> tuple[str, str]:
+    """Botpack convention: `-py` suffix marks Python bots, the rest are Rust."""
+    if player_id.endswith("-py"):
+        return player_id[: -len("-py")], "py"
+    return player_id, "rs"
+
+
+def build_rows(standings: list[dict]) -> str:
+    cis = [1.96 * float(r.get("elo_stderr", 0.0)) for r in standings]
+    los = [r["elo"] - ci for r, ci in zip(standings, cis)]
+    his = [r["elo"] + ci for r, ci in zip(standings, cis)]
+    span_lo, span_hi = min(los), max(his)
+    pad = 0.06 * (span_hi - span_lo) or 1.0
+    axis_lo, axis_hi = span_lo - pad, span_hi + pad
+    width = axis_hi - axis_lo
+
+    def pct(v: float) -> float:
+        return max(0.0, min(100.0, 100.0 * (v - axis_lo) / width))
+
+    anchor_html = ""
+    anchor_elo = 1000.0
+    if axis_lo <= anchor_elo <= axis_hi:
+        anchor_html = f'<div class="anchorline" style="left:{pct(anchor_elo):.1f}%"></div>'
+
+    rows = []
+    for rank, (r, ci) in enumerate(zip(standings, cis), start=1):
+        name, lang = split_lang(r["player_id"])
+        ci_html = ""
+        if ci > 0:
+            left, right = pct(r["elo"] - ci), pct(r["elo"] + ci)
+            ci_html = f'<div class="ci" style="left:{left:.1f}%;width:{right - left:.1f}%"></div>'
+        pm = f' <span class="pm">&plusmn;{ci:.0f}</span>' if ci > 0 else ""
+        rows.append(
+            ROW.format(
+                top=" top" if rank == 1 else "",
+                rank=rank,
+                name=html.escape(name),
+                lang=lang,
+                anchor=anchor_html,
+                bar_pct=pct(r["elo"]),
+                ci=ci_html,
+                elo=f"{r['elo']:.0f}",
+                pm=pm,
+                games=r.get("games", "?"),
+            )
+        )
+    return "\n".join(rows)
 
 
 def main() -> int:
@@ -68,31 +245,31 @@ def main() -> int:
 
     standings = results["standings"]
     attempts = results.get("attempts", {})
-    sha = os.environ.get("GITHUB_SHA", "local")[:9]
+    sha = os.environ.get("GITHUB_SHA", "local")
     date = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-
-    rows = "\n".join(
-        f'<tr><td class="num">{rank}</td><td>{html.escape(row["player_id"])}</td>'
-        f'<td class="num">{row["elo"]:.0f}</td></tr>'
-        for rank, row in enumerate(standings, start=1)
-    )
 
     out_dir.mkdir(parents=True, exist_ok=True)
     (out_dir / "index.html").write_text(
         PAGE.format(
-            rows=rows,
+            repo=REPO_URL,
+            rows=build_rows(standings),
             date=date,
             sha=html.escape(sha),
+            sha_short=html.escape(sha[:9]),
             success=attempts.get("success", "?"),
             failure=attempts.get("failure", "?"),
         )
     )
     shutil.copyfile(results_path, out_dir / "results.json")
 
-    print("| # | Bot | Elo |")
-    print("|--:|-----|----:|")
+    print("| # | Bot | Elo | ± | Games |")
+    print("|--:|-----|----:|--:|------:|")
     for rank, row in enumerate(standings, start=1):
-        print(f"| {rank} | {row['player_id']} | {row['elo']:.0f} |")
+        ci = 1.96 * float(row.get("elo_stderr", 0.0))
+        print(
+            f"| {rank} | {row['player_id']} | {row['elo']:.0f} "
+            f"| ±{ci:.0f} | {row.get('games', '?')} |"
+        )
 
     return 0
 


### PR DESCRIPTION
## Motivation

The ladder page showed bare Elo numbers. That hid two things at once: how the bots relate in magnitude, and how much the numbers can be trusted. The second turned out to matter immediately. The published table had the two smart-random bots 300+ Elo apart, which looked like a platform fairness problem. A 100-game direct duel measured them dead even (46% ± 10%, the Python one slightly ahead). The gap was Bradley-Terry stretching a 5-game direct sample: against everyone else their profiles are identical (both lose every game to the greedy and search bots), so the only ordering signal is the tiny head-to-head, and the rating happily amplifies it. Error bars would have said so on the page itself.

## Solution

### Uncertainty in the standings output

Standings rows in `--results-json` (and the stdout table) carry the rating's standard error and game count alongside elo:

```json
{ "player_id": "search", "elo": 897, "elo_stderr": 87.3, "games": 25 }
```

The math already existed (`compute_elo_with_uncertainty`, Bradley-Terry with Hessian stderr). The CLI now runs it once at render time. The session's live standings deliberately keep skipping the covariance work: they refresh on every match finish, the final table pays for it a single time. Same history, same options, identical ratings.

### The page shows the intervals

Each row draws its Elo as a bar on a shared axis with a 95% whisker, a language chip, the games count, and a dashed line at the anchor (greedy = 1000). Overlapping whiskers are the page saying "these two are not resolved" — exactly the smart-random situation. The job-summary table gains ± and games columns.

### 15 games per matchup

At 5 games the intervals ran ±200–360 per bot. 15 tightens them by ~√3 and keeps the worst-case CI runtime (search-game-bound, ~42 min) inside the workflow timeout. Truly tied pairs keep overlapping whiskers at any count, which is the honest answer; resolving near-ties precisely is a job for targeted duels, not the round-robin.

## Test Plan

`cargo test -p pyrat-eval --bin pyrat-eval` (76 tests, including reworked JSON-shape tests that exercise the uncertainty path from history), the extended `results_json_written_when_flag_set` integration test, clippy clean. Full local ladder run: 75/75 games, real stderrs in the JSON, page rendered and eyeballed. The PR-triggered ladder job re-validates end-to-end in CI with the new game count.