### PR TITLE
bench(engine): add reliable performance baselines

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,6 +54,9 @@ jobs:
     - name: Run engine tests
       run: cargo test -p pyrat-rust --lib --no-default-features --verbose
 
+    - name: Smoke-test engine benchmarks
+      run: cargo bench -p pyrat-rust --bench game_benchmarks --no-default-features -- --test
+
     - name: Run wire tests
       run: cargo test -p pyrat-wire --verbose
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,14 +55,24 @@ jobs:
           pyproject.toml
           engine/pyproject.toml
 
-    - name: Sync workspace dependencies
-      run: uv sync --all-extras
+    - name: Create isolated engine environment
+      run: |
+        uv venv --no-project --python "${{ matrix.python-version }}" engine/.venv
+        uv pip install --python engine/.venv/bin/python "maturin>=1.4,<2.0"
 
     - name: Build Rust extension
-      run: uv run --directory engine maturin develop --release
+      working-directory: engine
+      env:
+        VIRTUAL_ENV: ${{ github.workspace }}/engine/.venv
+      run: .venv/bin/maturin develop --release --uv --extras dev
 
     - name: Run Engine tests
-      run: uv run --directory engine pytest python/tests -v
+      working-directory: engine
+      run: .venv/bin/pytest python/tests -v
+
+    - name: Smoke-test Python benchmarks
+      working-directory: engine
+      run: .venv/bin/python python/benchmarks/benchmark_engine.py --smoke --json -
 
   test-sdk-python:
     name: SDK Python Tests (Python ${{ matrix.python-version }})

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # PyRat Monorepo Makefile
 
-.PHONY: all engine gui examples test bench clean help sync lint lint-engine lint-sdk-python test-engine test-sdk-python test-wire test-host test-eval-cli test-eval test-orch generate-wire fmt fmt-gui check check-gui dev-setup test-botpack
+.PHONY: all engine gui examples test bench bench-python bench-smoke clean help sync lint lint-engine lint-sdk-python test-engine test-sdk-python test-wire test-host test-eval-cli test-eval test-orch generate-wire fmt fmt-gui check check-gui dev-setup test-botpack
 
 # Default target
 all: sync engine
@@ -79,9 +79,22 @@ test-botpack:
 
 # Benchmarking
 bench:
-	@echo "Running benchmarks..."
-	@echo "Note: Requires Python environment activated"
+	@echo "Running Rust engine benchmarks..."
 	cargo bench -p pyrat-rust --bench game_benchmarks
+
+bench-python:
+	@echo "Building the release Python extension..."
+	uv run --directory engine maturin develop --release
+	@echo "Running Python boundary benchmarks..."
+	uv run --directory engine python python/benchmarks/benchmark_engine.py
+
+bench-smoke:
+	@echo "Smoke-testing Rust engine benchmarks..."
+	cargo bench -p pyrat-rust --bench game_benchmarks --no-default-features -- --test
+	@echo "Building the release Python extension..."
+	uv run --directory engine maturin develop --release
+	@echo "Smoke-testing Python boundary benchmarks..."
+	uv run --directory engine python python/benchmarks/benchmark_engine.py --smoke --json -
 
 # Code quality
 fmt: fmt-gui
@@ -168,7 +181,9 @@ help:
 	@echo "  lint-sdk-python  - Lint SDK Python code"
 	@echo ""
 	@echo "Other:"
-	@echo "  bench              - Run performance benchmarks"
+	@echo "  bench              - Run the Rust engine benchmark matrix"
+	@echo "  bench-python       - Build release bindings and run Python benchmarks"
+	@echo "  bench-smoke        - Functionally smoke-test both benchmark surfaces"
 	@echo "  generate-wire      - Regenerate FlatBuffers code (requires flatc)"
 	@echo "  clean              - Remove build artifacts"
 	@echo "  help               - Show this help message"

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -52,9 +52,16 @@ make test-engine
 - **Rust module**: `pyrat_engine._core`
 
 ## Performance Notes
-- `cargo bench` runs criterion benchmarks (game init + full game across preset sizes and wall/mud combos)
-- `cargo run --bin profile_game --release --no-default-features` prints a throughput table for all scenarios
-- `cargo run --bin profile_game --release --no-default-features -- <size>/<combo>` runs a single scenario in a tight loop for profiling (e.g. `default/default`, `large/walls_only`)
+- `cargo bench -p pyrat-rust --bench game_benchmarks` runs the Criterion cost matrix for creation,
+  maze and cheese generation, topology compilation, turns, make/unmake, and complete episodes.
+- `uv run --directory engine maturin develop --release` followed by
+  `uv run --directory engine python python/benchmarks/benchmark_engine.py` measures the real Python
+  creation, reset, observation, `PyRat.step`, and `PyRatEnv.step` boundaries.
+- `make bench-smoke` functionally executes both harnesses without a timing threshold.
+- `cargo run --bin profile_game --release --no-default-features` prints a throughput table for all
+  scenarios.
+- `cargo run --bin profile_game --release --no-default-features -- <size>/<combo>` runs a single
+  scenario in a tight loop for profiling (e.g. `medium/classic`, `large/walls_only`).
 - The per-turn hot path is documented in `rust/src/game/game_logic.rs` (module-level doc comment)
 
 ### Profiling with samply

--- a/engine/README.md
+++ b/engine/README.md
@@ -265,7 +265,34 @@ All re-exported from the crate root (`use pyrat::*`):
 
 ### Performance
 
-The engine processes 10+ million moves per second on standard configurations (benchmarked with criterion on an M-series Mac). Run `cargo bench -p pyrat-rust --bench game_benchmarks` to measure on your hardware.
+Performance measurements use two surfaces so Rust work and Python-boundary work stay separate.
+Neither surface applies a wall-clock pass/fail threshold.
+
+The Criterion matrix measures random and fixed creation, maze and cheese generation, topology
+compilation, turns, make/unmake, and complete episodes:
+
+```bash
+cargo bench -p pyrat-rust --bench game_benchmarks
+
+# Focus one reproducible scenario
+cargo bench -p pyrat-rust --bench game_benchmarks -- process_turn/classic/medium/21x15
+```
+
+The Python harness must use a release extension. It measures creation, reset, paired observations,
+`PyRat.step`, and `PyRatEnv.step`, and can retain raw samples plus host and interpreter metadata:
+
+```bash
+uv run --directory engine maturin develop --release
+uv run --directory engine python python/benchmarks/benchmark_engine.py
+uv run --directory engine python python/benchmarks/benchmark_engine.py \
+  --json ../target/python-engine-benchmark.json
+```
+
+Run both harnesses functionally, without asserting speed, with:
+
+```bash
+make bench-smoke
+```
 
 ## Game rules
 

--- a/engine/python/benchmarks/benchmark_engine.py
+++ b/engine/python/benchmarks/benchmark_engine.py
@@ -1,0 +1,790 @@
+"""Dependency-free benchmarks for the public Python engine paths.
+
+Build the extension in release mode before trusting the timings:
+
+    uv run --directory engine maturin develop --release
+
+Run the complete medium scenario:
+
+    uv run --directory engine python python/benchmarks/benchmark_engine.py
+
+The harness uses only the Python standard library plus the installed engine. It
+keeps fixture construction, resets for stateful samples, and validation outside
+the measured intervals. Timings are evidence, not test thresholds.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import platform
+import socket
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from functools import partial
+from pathlib import Path
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Sequence,
+    Tuple,
+)
+
+import pyrat_engine
+import pyrat_engine._core as engine_core
+from pyrat_engine import GameBuilder, GameConfig
+from pyrat_engine.env import PyRatEnv
+
+Point = Tuple[int, int]
+Edge = Tuple[Point, Point]
+WallInput = Tuple[Point, Point]
+MudInput = Tuple[Point, Point, int]
+ActionPair = Tuple[int, int]
+EnvironmentAction = Dict[str, int]
+
+CASE_NAMES = (
+    "create/random",
+    "create/fixed",
+    "reset/random",
+    "reset/fixed",
+    "observation/pair",
+    "step/pyrat",
+    "step/env",
+)
+
+SCENARIO_NAME = "medium"
+FIXED_SEED = 0x50595241545F4245
+RANDOM_SEED_BASE = 0xC0DEC0DE12345678
+ACTION_SEED = 0xA17C9E3779B97F4A
+MASK_U64 = (1 << 64) - 1
+
+RANDOM_OPERATIONS_PER_BATCH = 4
+FIXED_OPERATIONS_PER_BATCH = 16
+OBSERVATION_PAIRS_PER_BATCH = 256
+MAX_TRACE_TURNS = 128
+MAX_ADAPTIVE_ITERATIONS = 100_000
+MUD_PERIOD = 10
+MUD_OFFSET = 4
+
+NANOSECONDS_PER_MICROSECOND = 1_000.0
+NANOSECONDS_PER_MILLISECOND = 1_000_000.0
+NANOSECONDS_PER_SECOND = 1_000_000_000.0
+OPERATIONS_PER_KILO = 1_000.0
+OPERATIONS_PER_MEGA = 1_000_000.0
+OPERATIONS_PER_GIGA = 1_000_000_000.0
+
+
+@dataclass(frozen=True)
+class MeasuredBatch:
+    """One operation-only timed block."""
+
+    elapsed_ns: int
+    operations: int
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    """A filterable benchmark case."""
+
+    name: str
+    measure_batch: Callable[[], MeasuredBatch]
+
+
+@dataclass(frozen=True)
+class CreateContext:
+    config: Any
+    seeds: tuple[int, ...]
+    width: int
+    height: int
+
+
+@dataclass(frozen=True)
+class ResetContext:
+    game: Any
+    seeds: tuple[int, ...]
+    width: int
+    height: int
+
+
+@dataclass(frozen=True)
+class ObservationContext:
+    game: Any
+    tokens: tuple[int, ...]
+    width: int
+    height: int
+
+
+@dataclass(frozen=True)
+class StepContext:
+    game: Any
+    seed: int
+    actions: tuple[ActionPair, ...]
+
+
+@dataclass(frozen=True)
+class EnvironmentStepContext:
+    env: PyRatEnv
+    seed: int
+    actions: tuple[EnvironmentAction, ...]
+
+
+@dataclass(frozen=True)
+class CaseResult:
+    """Repeated samples for one benchmark case."""
+
+    name: str
+    operations_per_batch: int
+    iterations_per_sample: int
+    discarded_batches: int
+    samples: tuple[MeasuredBatch, ...]
+
+    def ns_per_operation(self) -> list[float]:
+        return [sample.elapsed_ns / sample.operations for sample in self.samples]
+
+    def summary(self) -> dict[str, float]:
+        values = self.ns_per_operation()
+        median_ns = statistics.median(values)
+        return {
+            "median_ns_per_operation": median_ns,
+            "min_ns_per_operation": min(values),
+            "max_ns_per_operation": max(values),
+            "median_operations_per_second": (NANOSECONDS_PER_SECOND / median_ns),
+        }
+
+    def as_json(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "operations_per_batch": self.operations_per_batch,
+            "iterations_per_sample": self.iterations_per_sample,
+            "discarded_batches": self.discarded_batches,
+            "summary": self.summary(),
+            "samples": [
+                {
+                    "elapsed_ns": sample.elapsed_ns,
+                    "operations": sample.operations,
+                    "ns_per_operation": (sample.elapsed_ns / sample.operations),
+                }
+                for sample in self.samples
+            ],
+        }
+
+
+def _canonical_edge(first: Point, second: Point) -> Edge:
+    return (first, second) if first < second else (second, first)
+
+
+def _fixed_layout(
+    width: int,
+    height: int,
+) -> tuple[tuple[WallInput, ...], tuple[MudInput, ...]]:
+    """Build a stable connected snake maze with classic-like wall and mud load."""
+    all_edges: set[Edge] = set()
+    passages: set[Edge] = set()
+
+    for y in range(height):
+        for x in range(width - 1):
+            edge = _canonical_edge((x, y), (x + 1, y))
+            all_edges.add(edge)
+            passages.add(edge)
+
+    for y in range(height - 1):
+        for x in range(width):
+            all_edges.add(_canonical_edge((x, y), (x, y + 1)))
+
+        connector_x = width - 1 if y % 2 == 0 else 0
+        passages.add(
+            _canonical_edge(
+                (connector_x, y),
+                (connector_x, y + 1),
+            )
+        )
+
+    walls = tuple(sorted(all_edges.difference(passages)))
+    mud: list[MudInput] = []
+    for index, (first, second) in enumerate(sorted(passages)):
+        if index % MUD_PERIOD == MUD_OFFSET:
+            mud.append((first, second, 2 + (index // MUD_PERIOD) % 2))
+
+    return walls, tuple(mud)
+
+
+def _fixed_cheese(width: int, height: int, count: int) -> tuple[Point, ...]:
+    """Keep cheese central so the prepared corner traces collect none."""
+    center_x = width // 2
+    center_y = height // 2
+    player_starts = {(0, 0), (width - 1, height - 1)}
+    candidates = [
+        (x, y)
+        for y in range(height)
+        for x in range(width)
+        if (x, y) not in player_starts
+    ]
+    candidates.sort(
+        key=lambda point: (
+            abs(point[0] - center_x) + abs(point[1] - center_y),
+            point[1],
+            point[0],
+        )
+    )
+
+    if len(candidates) < count:
+        raise RuntimeError("Fixed benchmark scenario does not have enough cheese cells")
+    return tuple(candidates[:count])
+
+
+def _splitmix64(value: int) -> int:
+    value = (value + 0x9E3779B97F4A7C15) & MASK_U64
+    value = ((value ^ (value >> 30)) * 0xBF58476D1CE4E5B9) & MASK_U64
+    value = ((value ^ (value >> 27)) * 0x94D049BB133111EB) & MASK_U64
+    return value ^ (value >> 31)
+
+
+def _prepared_seeds(base: int, count: int) -> tuple[int, ...]:
+    return tuple(_splitmix64(base + index) for index in range(count))
+
+
+def _prepared_actions(seed: int, turns: int) -> tuple[ActionPair, ...]:
+    state = seed
+    actions: list[ActionPair] = []
+    for _ in range(turns):
+        state = _splitmix64(state)
+        player_one = state % 5
+        state = _splitmix64(state)
+        player_two = state % 5
+        actions.append((player_one, player_two))
+    return tuple(actions)
+
+
+def _validate_dimensions(game: Any, width: int, height: int) -> None:
+    if game.width != width or game.height != height:
+        raise RuntimeError(
+            "Benchmark operation returned a game with unexpected dimensions"
+        )
+    # Materialize a value after timing so each produced object is observably used.
+    _ = game.state_hash
+
+
+def _measure_create(context: CreateContext) -> MeasuredBatch:
+    config = context.config
+    seeds = context.seeds
+    last_game = None
+
+    started_ns = time.perf_counter_ns()
+    for seed in seeds:
+        last_game = config.create(seed=seed)
+    elapsed_ns = time.perf_counter_ns() - started_ns
+
+    if last_game is None:
+        raise RuntimeError("Create benchmark did not execute an operation")
+    _validate_dimensions(last_game, context.width, context.height)
+    return MeasuredBatch(elapsed_ns, len(seeds))
+
+
+def _measure_reset(context: ResetContext) -> MeasuredBatch:
+    game = context.game
+    seeds = context.seeds
+
+    started_ns = time.perf_counter_ns()
+    for seed in seeds:
+        game.reset(seed=seed)
+    elapsed_ns = time.perf_counter_ns() - started_ns
+
+    _validate_dimensions(game, context.width, context.height)
+    return MeasuredBatch(elapsed_ns, len(seeds))
+
+
+def _measure_observation_pair(context: ObservationContext) -> MeasuredBatch:
+    game = context.game
+    tokens = context.tokens
+    player_one = None
+    player_two = None
+
+    started_ns = time.perf_counter_ns()
+    for _ in tokens:
+        player_one = game.get_observation(True)
+        player_two = game.get_observation(False)
+    elapsed_ns = time.perf_counter_ns() - started_ns
+
+    if player_one is None or player_two is None:
+        raise RuntimeError("Observation benchmark did not execute an operation")
+    expected_cheese_shape = (context.width, context.height)
+    expected_movement_shape = (context.width, context.height, 4)
+    if player_one.cheese_matrix.shape != expected_cheese_shape:
+        raise RuntimeError("Player-one cheese observation has an unexpected shape")
+    if player_two.movement_matrix.shape != expected_movement_shape:
+        raise RuntimeError("Player-two movement observation has an unexpected shape")
+    return MeasuredBatch(elapsed_ns, len(tokens))
+
+
+def _measure_step(context: StepContext) -> MeasuredBatch:
+    game = context.game
+    actions = context.actions
+
+    # Reset is setup for the trace, so it stays outside the measured interval.
+    game.reset(seed=context.seed)
+    last_result = None
+    started_ns = time.perf_counter_ns()
+    for player_one, player_two in actions:
+        last_result = game.step(player_one, player_two)
+    elapsed_ns = time.perf_counter_ns() - started_ns
+
+    if last_result is None:
+        raise RuntimeError("PyRat.step benchmark did not execute an operation")
+    if last_result[0]:
+        raise RuntimeError("Prepared PyRat.step trace crossed game_over")
+    if game.turn != len(actions):
+        raise RuntimeError(
+            "Prepared PyRat.step trace advanced an unexpected turn count"
+        )
+    if game.player1_score != 0.0 or game.player2_score != 0.0:
+        raise RuntimeError("Prepared PyRat.step trace collected benchmark cheese")
+    return MeasuredBatch(elapsed_ns, len(actions))
+
+
+def _measure_environment_step(
+    context: EnvironmentStepContext,
+) -> MeasuredBatch:
+    env = context.env
+    actions = context.actions
+
+    # Environment reset and its paired observations are separate benchmark work.
+    env.reset(seed=context.seed)
+    last_result = None
+    started_ns = time.perf_counter_ns()
+    for action in actions:
+        last_result = env.step(action)
+    elapsed_ns = time.perf_counter_ns() - started_ns
+
+    if last_result is None:
+        raise RuntimeError("PyRatEnv.step benchmark did not execute an operation")
+    terminations = last_result[2]
+    if any(terminations.values()):
+        raise RuntimeError("Prepared PyRatEnv.step trace crossed termination")
+    if env.game.turn != len(actions):
+        raise RuntimeError(
+            "Prepared PyRatEnv.step trace advanced an unexpected turn count"
+        )
+    if env.game.player1_score != 0.0 or env.game.player2_score != 0.0:
+        raise RuntimeError("Prepared PyRatEnv.step trace collected benchmark cheese")
+    return MeasuredBatch(elapsed_ns, len(actions))
+
+
+def _build_cases() -> list[BenchmarkCase]:
+    random_config = GameConfig.preset(SCENARIO_NAME)
+    width = random_config.width
+    height = random_config.height
+    max_turns = random_config.max_turns
+
+    random_seeds = _prepared_seeds(
+        RANDOM_SEED_BASE,
+        RANDOM_OPERATIONS_PER_BATCH,
+    )
+    random_game = random_config.create(seed=random_seeds[0])
+    cheese_count = len(random_game.cheese_positions())
+
+    walls, mud = _fixed_layout(width, height)
+    cheese = _fixed_cheese(width, height, cheese_count)
+    fixed_config = (
+        GameBuilder(width, height)
+        .with_max_turns(max_turns)
+        .with_custom_maze(walls=list(walls), mud=list(mud))
+        .with_corner_positions()
+        .with_custom_cheese(list(cheese))
+        .build()
+    )
+
+    fixed_seeds = _prepared_seeds(
+        FIXED_SEED,
+        FIXED_OPERATIONS_PER_BATCH,
+    )
+    trace_turns = min(MAX_TRACE_TURNS, max_turns // 2)
+    action_pairs = _prepared_actions(ACTION_SEED, trace_turns)
+    environment_actions = tuple(
+        {
+            "player_1": player_one,
+            "player_2": player_two,
+        }
+        for player_one, player_two in action_pairs
+    )
+
+    create_random = CreateContext(
+        random_config,
+        random_seeds,
+        width,
+        height,
+    )
+    create_fixed = CreateContext(
+        fixed_config,
+        fixed_seeds,
+        width,
+        height,
+    )
+    reset_random = ResetContext(
+        random_game,
+        random_seeds,
+        width,
+        height,
+    )
+    reset_fixed = ResetContext(
+        fixed_config.create(seed=FIXED_SEED),
+        fixed_seeds,
+        width,
+        height,
+    )
+    observation_pair = ObservationContext(
+        fixed_config.create(seed=FIXED_SEED),
+        tuple(range(OBSERVATION_PAIRS_PER_BATCH)),
+        width,
+        height,
+    )
+    step = StepContext(
+        fixed_config.create(seed=FIXED_SEED),
+        FIXED_SEED,
+        action_pairs,
+    )
+    environment_step = EnvironmentStepContext(
+        PyRatEnv(fixed_config, seed=FIXED_SEED),
+        FIXED_SEED,
+        environment_actions,
+    )
+
+    return [
+        BenchmarkCase(
+            "create/random",
+            partial(_measure_create, create_random),
+        ),
+        BenchmarkCase(
+            "create/fixed",
+            partial(_measure_create, create_fixed),
+        ),
+        BenchmarkCase(
+            "reset/random",
+            partial(_measure_reset, reset_random),
+        ),
+        BenchmarkCase(
+            "reset/fixed",
+            partial(_measure_reset, reset_fixed),
+        ),
+        BenchmarkCase(
+            "observation/pair",
+            partial(_measure_observation_pair, observation_pair),
+        ),
+        BenchmarkCase(
+            "step/pyrat",
+            partial(_measure_step, step),
+        ),
+        BenchmarkCase(
+            "step/env",
+            partial(_measure_environment_step, environment_step),
+        ),
+    ]
+
+
+def _record_sample(case: BenchmarkCase, iterations: int) -> MeasuredBatch:
+    elapsed_ns = 0
+    operations = 0
+    for _ in range(iterations):
+        batch = case.measure_batch()
+        elapsed_ns += batch.elapsed_ns
+        operations += batch.operations
+    return MeasuredBatch(elapsed_ns, operations)
+
+
+def _run_case(
+    case: BenchmarkCase,
+    warmup_batches: int,
+    sample_count: int,
+    target_sample_ns: int,
+    smoke: bool,
+) -> CaseResult:
+    discarded: list[MeasuredBatch] = []
+    for _ in range(warmup_batches):
+        discarded.append(case.measure_batch())
+
+    first_batch = discarded[-1]
+    if first_batch.operations <= 0 or first_batch.elapsed_ns <= 0:
+        raise RuntimeError(f"Benchmark case {case.name} returned an empty timed batch")
+
+    if smoke:
+        iterations = 1
+    else:
+        typical_batch_ns = statistics.median(batch.elapsed_ns for batch in discarded)
+        iterations = max(
+            1,
+            math.ceil(target_sample_ns / typical_batch_ns),
+        )
+        iterations = min(iterations, MAX_ADAPTIVE_ITERATIONS)
+
+    samples = tuple(_record_sample(case, iterations) for _ in range(sample_count))
+    return CaseResult(
+        name=case.name,
+        operations_per_batch=first_batch.operations,
+        iterations_per_sample=iterations,
+        discarded_batches=len(discarded),
+        samples=samples,
+    )
+
+
+def _run_git(repo_root: Path, arguments: Sequence[str]) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["git", *arguments],
+            cwd=str(repo_root),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip()
+
+
+def _metadata(
+    repo_root: Path,
+    args: argparse.Namespace,
+    warmup_batches: int,
+    sample_count: int,
+    target_sample_ns: int,
+) -> dict[str, Any]:
+    clock = time.get_clock_info("perf_counter")
+    git_status = _run_git(repo_root, ["status", "--porcelain"])
+    return {
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "scenario": SCENARIO_NAME,
+        "mode": "smoke" if args.smoke else "benchmark",
+        "timing_scope": (
+            "operation-only timed blocks; fixture setup, stateful resets, "
+            "and validation are excluded"
+        ),
+        "configuration": {
+            "warmup_batches": warmup_batches,
+            "sample_count": sample_count,
+            "target_sample_ns": target_sample_ns,
+            "selected_cases": args.case or list(CASE_NAMES),
+        },
+        "git": {
+            "commit": _run_git(repo_root, ["rev-parse", "HEAD"]),
+            "dirty": None if git_status is None else bool(git_status),
+        },
+        "engine": {
+            "version": pyrat_engine.__version__,
+            "extension_path": getattr(engine_core, "__file__", None),
+            "release_build_required": True,
+        },
+        "python": {
+            "implementation": platform.python_implementation(),
+            "version": platform.python_version(),
+            "executable": sys.executable,
+        },
+        "host": {
+            "hostname": socket.gethostname(),
+            "platform": platform.platform(),
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+            "processor": platform.processor(),
+            "cpu_count": os.cpu_count(),
+        },
+        "clock": {
+            "name": "perf_counter",
+            "implementation": clock.implementation,
+            "monotonic": clock.monotonic,
+            "adjustable": clock.adjustable,
+            "resolution_seconds": clock.resolution,
+        },
+        "command": [sys.executable, *sys.argv],
+    }
+
+
+def _build_report(
+    results: Sequence[CaseResult],
+    metadata: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "metadata": metadata,
+        "cases": [result.as_json() for result in results],
+    }
+
+
+def _format_duration(ns_per_operation: float) -> str:
+    if ns_per_operation >= NANOSECONDS_PER_MILLISECOND:
+        return f"{ns_per_operation / NANOSECONDS_PER_MILLISECOND:.3f} ms"
+    if ns_per_operation >= NANOSECONDS_PER_MICROSECOND:
+        return f"{ns_per_operation / NANOSECONDS_PER_MICROSECOND:.3f} us"
+    return f"{ns_per_operation:.1f} ns"
+
+
+def _format_rate(operations_per_second: float) -> str:
+    if operations_per_second >= OPERATIONS_PER_GIGA:
+        return f"{operations_per_second / OPERATIONS_PER_GIGA:.2f}G/s"
+    if operations_per_second >= OPERATIONS_PER_MEGA:
+        return f"{operations_per_second / OPERATIONS_PER_MEGA:.2f}M/s"
+    if operations_per_second >= OPERATIONS_PER_KILO:
+        return f"{operations_per_second / OPERATIONS_PER_KILO:.2f}K/s"
+    return f"{operations_per_second:.2f}/s"
+
+
+def _print_human(
+    results: Sequence[CaseResult],
+    metadata: dict[str, Any],
+) -> None:
+    git = metadata["git"]
+    python = metadata["python"]
+    host = metadata["host"]
+    print("PyRat Python boundary benchmark")
+    print(
+        "Release extension required; build with "
+        "`uv run --directory engine maturin develop --release`."
+    )
+    print(
+        f"commit={git['commit']} dirty={git['dirty']}  "
+        f"python={python['implementation']} {python['version']}  "
+        f"host={host['machine']} {host['system']}"
+    )
+    print()
+    print(
+        f"{'case':<22} {'median':>12} {'ops/s':>12} "
+        f"{'min':>12} {'max':>12} {'samples':>8} {'ops/sample':>12}"
+    )
+    print("-" * 96)
+    for result in results:
+        summary = result.summary()
+        operations_per_sample = result.samples[0].operations
+        print(
+            f"{result.name:<22} "
+            f"{_format_duration(summary['median_ns_per_operation']):>12} "
+            f"{_format_rate(summary['median_operations_per_second']):>12} "
+            f"{_format_duration(summary['min_ns_per_operation']):>12} "
+            f"{_format_duration(summary['max_ns_per_operation']):>12} "
+            f"{len(result.samples):>8} "
+            f"{operations_per_sample:>12}"
+        )
+
+
+def _write_json(path_text: str, report: dict[str, Any]) -> None:
+    path = Path(path_text)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as output:
+        json.dump(report, output, indent=2, sort_keys=True)
+        output.write("\n")
+
+
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("expected an integer") from error
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("expected a positive integer")
+    return parsed
+
+
+def _positive_float(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("expected a number") from error
+    if parsed <= 0.0:
+        raise argparse.ArgumentTypeError("expected a positive number")
+    return parsed
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Benchmark public PyRat Python calls without adding a timing "
+            "dependency or a performance threshold."
+        )
+    )
+    parser.add_argument(
+        "--case",
+        action="append",
+        choices=CASE_NAMES,
+        help="run only this case; repeat to select multiple cases",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=_positive_int,
+        default=3,
+        help="discarded warmup batches per case (default: 3)",
+    )
+    parser.add_argument(
+        "--samples",
+        type=_positive_int,
+        default=15,
+        help="recorded samples per case (default: 15)",
+    )
+    parser.add_argument(
+        "--sample-time-ms",
+        type=_positive_float,
+        default=50.0,
+        help="adaptive operation-only time per sample (default: 50)",
+    )
+    parser.add_argument(
+        "--json",
+        metavar="PATH",
+        help="write JSON alongside human output; use '-' for JSON-only stdout",
+    )
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="run one warmup and one single-batch sample with no speed assertion",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    cases = _build_cases()
+    selected_names = set(args.case or CASE_NAMES)
+    selected_cases = [case for case in cases if case.name in selected_names]
+
+    warmup_batches = 1 if args.smoke else args.warmup
+    sample_count = 1 if args.smoke else args.samples
+    target_sample_ns = int(args.sample_time_ms * NANOSECONDS_PER_MILLISECOND)
+    results = [
+        _run_case(
+            case,
+            warmup_batches,
+            sample_count,
+            target_sample_ns,
+            args.smoke,
+        )
+        for case in selected_cases
+    ]
+
+    repo_root = Path(__file__).resolve().parents[3]
+    metadata = _metadata(
+        repo_root,
+        args,
+        warmup_batches,
+        sample_count,
+        target_sample_ns,
+    )
+    report = _build_report(results, metadata)
+
+    if args.json == "-":
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0
+
+    _print_human(results, metadata)
+    if args.json:
+        _write_json(args.json, report)
+        print()
+        print(f"JSON report: {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/engine/rust/benches/bin/profile_game.rs
+++ b/engine/rust/benches/bin/profile_game.rs
@@ -1,41 +1,61 @@
-use pyrat::bench_scenarios::{create_game, random_direction, COMBOS, SIZES};
-use std::time::{Duration, Instant};
+#[allow(dead_code)]
+#[path = "../support.rs"]
+mod support;
 
-/// Run a scenario for `duration`, returns (total_turns, total_games).
+use std::time::{Duration, Instant};
+use support::{scenario_specs, ActionPair, ScenarioSpec, SeedTape};
+
+/// Run a scenario for `duration`, returning total turns, total games, and
+/// actual elapsed time.
 ///
 /// When `hash` is true, calls `state_hash()` once per turn (simulating a
 /// transposition table lookup in MCTS).
-fn run_scenario(
-    size: &pyrat::bench_scenarios::BoardSize,
-    combo: &pyrat::bench_scenarios::FeatureCombo,
-    duration: Duration,
-    hash: bool,
-) -> (u64, u64) {
-    let mut rng = rand::rng();
+fn run_scenario(spec: ScenarioSpec, duration: Duration, hash: bool) -> (u64, u64, Duration) {
+    let config = spec.random_config();
+    let game_seeds = spec.create_seed_tape();
+    let actions = spec.episode_action_tape();
+    let mut seed_cursor = 0;
     let mut total_turns: u64 = 0;
     let mut total_games: u64 = 0;
-    let mut seed: u64 = 0;
 
-    let deadline = Instant::now() + duration;
+    let started = Instant::now();
+    let deadline = started + duration;
     while Instant::now() < deadline {
-        seed = seed.wrapping_add(1);
-        let mut game = create_game(size, combo, seed);
-        loop {
-            if hash {
-                std::hint::black_box(game.state_hash());
-            }
-            if game
-                .process_turn(random_direction(&mut rng), random_direction(&mut rng))
-                .game_over
-            {
-                break;
-            }
-            total_turns += 1;
-        }
-        total_turns += 1; // count the final turn
+        let seed = next_seed(&game_seeds, &mut seed_cursor);
+        let mut game = config.create(Some(seed)).unwrap();
+        play_episode(&mut game, &actions, hash, &mut total_turns);
         total_games += 1;
     }
-    (total_turns, total_games)
+
+    (total_turns, total_games, started.elapsed())
+}
+
+fn play_episode(
+    game: &mut pyrat::GameState,
+    actions: &[ActionPair],
+    hash: bool,
+    total_turns: &mut u64,
+) {
+    for action in actions {
+        if hash {
+            std::hint::black_box(game.state_hash());
+        }
+        *total_turns += 1;
+        if game.process_turn(action.p1, action.p2).game_over {
+            return;
+        }
+    }
+
+    panic!(
+        "prepared episode action tape did not reach game_over in {} turns",
+        actions.len()
+    );
+}
+
+fn next_seed(seeds: &SeedTape, cursor: &mut usize) -> u64 {
+    let seed = seeds[*cursor];
+    *cursor = (*cursor + 1) % seeds.len();
+    seed
 }
 
 /// Runs all 20 scenarios and prints an aligned throughput table.
@@ -52,82 +72,72 @@ fn run_all(hash: bool) {
     );
     println!("{}", "-".repeat(62));
 
-    for size in SIZES {
-        for combo in COMBOS {
-            let board = format!("{}x{}", size.width, size.height);
-            let (turns, games) = run_scenario(size, combo, duration, hash);
-            let elapsed = duration.as_secs_f64();
-            println!(
-                "{:<12} {:<12} {:>8} {:>14.0} {:>14.0}",
-                size.name,
-                combo.name,
-                board,
-                turns as f64 / elapsed,
-                games as f64 / elapsed,
-            );
-        }
+    for spec in scenario_specs() {
+        let board = format!("{}x{}", spec.size.width, spec.size.height);
+        let (turns, games, elapsed) = run_scenario(spec, duration, hash);
+        let elapsed_seconds = elapsed.as_secs_f64();
+        println!(
+            "{:<12} {:<12} {:>8} {:>14.0} {:>14.0}",
+            spec.size.name,
+            spec.combo.name,
+            board,
+            turns as f64 / elapsed_seconds,
+            games as f64 / elapsed_seconds,
+        );
     }
 }
 
 /// Runs a single scenario in a tight loop (never returns).
 /// Attach a profiler and Ctrl+C to stop.
-fn run_single(scenario: &str) -> ! {
-    let parts: Vec<&str> = scenario.split('/').collect();
-    if parts.len() != 2 {
-        eprintln!("Usage: profile_game <size>/<combo>");
-        eprintln!("  e.g. medium/classic, large/walls_only");
-        std::process::exit(1);
-    }
-
-    let size = SIZES.iter().find(|s| s.name == parts[0]);
-    let combo = COMBOS.iter().find(|c| c.name == parts[1]);
-
-    let (Some(size), Some(combo)) = (size, combo) else {
-        eprintln!("Unknown scenario: {scenario}");
-        eprintln!(
-            "Sizes: {}",
-            SIZES.iter().map(|s| s.name).collect::<Vec<_>>().join(", ")
-        );
-        eprintln!(
-            "Combos: {}",
-            COMBOS.iter().map(|c| c.name).collect::<Vec<_>>().join(", ")
-        );
-        std::process::exit(1);
-    };
-
+fn run_single(spec: ScenarioSpec) -> ! {
     eprintln!(
         "Running {}/{} ({}x{}) — Ctrl+C to stop",
-        size.name, combo.name, size.width, size.height
+        spec.size.name, spec.combo.name, spec.size.width, spec.size.height
     );
 
-    let mut rng = rand::rng();
-    let mut seed: u64 = 0;
+    let config = spec.random_config();
+    let game_seeds = spec.create_seed_tape();
+    let actions = spec.episode_action_tape();
+    let mut seed_cursor = 0;
     loop {
-        seed = seed.wrapping_add(1);
-        let mut game = create_game(size, combo, seed);
-        loop {
-            std::hint::black_box(game.state_hash());
-            if game
-                .process_turn(random_direction(&mut rng), random_direction(&mut rng))
-                .game_over
-            {
-                break;
-            }
-        }
+        let seed = next_seed(&game_seeds, &mut seed_cursor);
+        let mut game = config.create(Some(seed)).unwrap();
+        let mut turns = 0;
+        play_episode(&mut game, &actions, true, &mut turns);
     }
 }
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
-    let hash = args.iter().any(|a| a == "--hash");
+    let hash = args.iter().any(|argument| argument == "--hash");
     let positional: Vec<&str> = args[1..]
         .iter()
-        .filter(|a| !a.starts_with('-'))
-        .map(|s| s.as_str())
+        .filter(|argument| !argument.starts_with('-'))
+        .map(String::as_str)
         .collect();
 
     if let Some(scenario) = positional.first() {
-        run_single(scenario);
+        let Some((size_name, combo_name)) = scenario.split_once('/') else {
+            eprintln!("Usage: profile_game <size>/<combo>");
+            eprintln!("  e.g. medium/classic, large/walls_only");
+            std::process::exit(1);
+        };
+        let Some(spec) = scenario_specs()
+            .into_iter()
+            .find(|spec| spec.size.name == size_name && spec.combo.name == combo_name)
+        else {
+            eprintln!("Unknown scenario: {scenario}");
+            eprintln!(
+                "Scenarios: {}",
+                scenario_specs()
+                    .into_iter()
+                    .map(|spec| format!("{}/{}", spec.size.name, spec.combo.name))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+            std::process::exit(1);
+        };
+        run_single(spec);
     } else {
         run_all(hash);
     }

--- a/engine/rust/benches/game_benchmarks.rs
+++ b/engine/rust/benches/game_benchmarks.rs
@@ -1,96 +1,270 @@
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use pyrat::bench_scenarios::{create_game, random_direction, COMBOS, SIZES};
-use std::hint::black_box;
+mod support;
 
-fn bench_id(
-    size: &pyrat::bench_scenarios::BoardSize,
-    combo: &pyrat::bench_scenarios::FeatureCombo,
-) -> BenchmarkId {
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use pyrat::bench_scenarios::{BoardSize, FeatureCombo, SIZES};
+use pyrat::game::maze_generation::{CheeseGenerator, MazeGenerator};
+use pyrat::game::zobrist;
+use pyrat::{GameState, MoveTable};
+use std::hint::black_box;
+use support::{
+    prepared_scenarios, PreparedScenario, FIXED_CREATE_SEED, SEED_TAPE_LEN, TURN_BATCH_LEN,
+};
+
+fn bench_id(size: &BoardSize, combo: &FeatureCombo) -> BenchmarkId {
     BenchmarkId::new(
         combo.name,
         format!("{}/{}x{}", size.name, size.width, size.height),
     )
 }
 
-fn bench_game_init(c: &mut Criterion) {
-    let mut group = c.benchmark_group("game_init");
-    group.throughput(criterion::Throughput::Elements(1));
+fn size_bench_id(size: &BoardSize) -> BenchmarkId {
+    BenchmarkId::new(
+        "symmetric",
+        format!("{}/{}x{}", size.name, size.width, size.height),
+    )
+}
 
-    for size in SIZES {
-        for combo in COMBOS {
-            group.bench_function(bench_id(size, combo), |b| {
-                let mut seed: u64 = 0;
-                b.iter(|| {
-                    seed = seed.wrapping_add(1);
-                    black_box(create_game(size, combo, seed));
-                });
-            });
-        }
+fn bench_random_create(c: &mut Criterion, scenarios: &[PreparedScenario]) {
+    let mut group = c.benchmark_group("random_create");
+    group.sample_size(20);
+    group.throughput(Throughput::Elements(SEED_TAPE_LEN as u64));
+
+    for scenario in scenarios {
+        group.bench_function(
+            bench_id(scenario.spec.size, scenario.spec.combo),
+            |bencher| {
+                bencher.iter_batched(
+                    || (),
+                    |()| {
+                        let games: [GameState; SEED_TAPE_LEN] = std::array::from_fn(|index| {
+                            scenario
+                                .random_config
+                                .create(Some(scenario.create_seeds[index]))
+                                .unwrap()
+                        });
+                        games
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
     }
     group.finish();
 }
 
-fn bench_process_turn(c: &mut Criterion) {
+fn bench_maze_generation(c: &mut Criterion, scenarios: &[PreparedScenario]) {
+    let mut group = c.benchmark_group("maze_generation");
+    group.sample_size(20);
+    group.throughput(Throughput::Elements(SEED_TAPE_LEN as u64));
+
+    for scenario in scenarios {
+        group.bench_function(
+            bench_id(scenario.spec.size, scenario.spec.combo),
+            |bencher| {
+                bencher.iter_batched(
+                    || {
+                        let generators: [MazeGenerator; SEED_TAPE_LEN] =
+                            std::array::from_fn(|index| {
+                                MazeGenerator::new(
+                                    scenario.spec.maze_config(scenario.maze_seeds[index]),
+                                )
+                            });
+                        generators
+                    },
+                    |generators| generators.map(|mut generator| generator.generate()),
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_cheese_generation(c: &mut Criterion, scenarios: &[PreparedScenario]) {
+    let mut group = c.benchmark_group("cheese_generation");
+    group.throughput(Throughput::Elements(SEED_TAPE_LEN as u64));
+
+    for size in SIZES {
+        let scenario = scenarios
+            .iter()
+            .find(|scenario| {
+                scenario.spec.size.name == size.name && scenario.spec.combo.name == "classic"
+            })
+            .expect("every benchmark size has a prepared classic scenario");
+        let (player1, player2) = scenario.spec.corner_positions();
+        group.bench_function(size_bench_id(size), |bencher| {
+            bencher.iter_batched(
+                || {
+                    let generators: [CheeseGenerator; SEED_TAPE_LEN] =
+                        std::array::from_fn(|index| {
+                            CheeseGenerator::new(
+                                scenario.spec.cheese_config(),
+                                size.width,
+                                size.height,
+                                Some(scenario.cheese_seeds[index]),
+                            )
+                        });
+                    generators
+                },
+                |generators| {
+                    generators.map(|mut generator| generator.generate(player1, player2).unwrap())
+                },
+                BatchSize::LargeInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+fn bench_topology_compilation(c: &mut Criterion, scenarios: &[PreparedScenario]) {
+    let mut group = c.benchmark_group("topology_compilation");
+    group.throughput(Throughput::Elements(1));
+
+    for scenario in scenarios {
+        group.bench_function(
+            bench_id(scenario.spec.size, scenario.spec.combo),
+            |bencher| {
+                bencher.iter_batched(
+                    || (),
+                    |()| {
+                        let move_table = MoveTable::new(
+                            scenario.spec.size.width,
+                            scenario.spec.size.height,
+                            &scenario.walls,
+                        );
+                        let topology_hash = zobrist::maze_hash(
+                            &move_table,
+                            &scenario.mud,
+                            scenario.spec.size.width,
+                            scenario.spec.size.height,
+                        );
+                        (move_table, topology_hash)
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_fixed_create(c: &mut Criterion, scenarios: &[PreparedScenario]) {
+    let mut group = c.benchmark_group("fixed_create");
+    group.throughput(Throughput::Elements(1));
+
+    for scenario in scenarios {
+        group.bench_function(
+            bench_id(scenario.spec.size, scenario.spec.combo),
+            |bencher| {
+                bencher.iter_batched(
+                    || (),
+                    |()| {
+                        scenario
+                            .fixed_config
+                            .create(Some(FIXED_CREATE_SEED))
+                            .unwrap()
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_process_turn(c: &mut Criterion, scenarios: &[PreparedScenario]) {
     let mut group = c.benchmark_group("process_turn");
     group.sample_size(50);
+    group.throughput(Throughput::Elements(TURN_BATCH_LEN as u64));
 
-    for size in SIZES {
-        let turns = u64::from(size.max_turns / 2);
-        group.throughput(criterion::Throughput::Elements(turns));
-
-        for combo in COMBOS {
-            group.bench_function(bench_id(size, combo), |b| {
-                let mut rng = rand::rng();
-                let mut seed: u64 = 0;
-                b.iter_with_setup(
-                    || {
-                        seed = seed.wrapping_add(1);
-                        create_game(size, combo, seed)
-                    },
-                    |mut game| {
-                        for _ in 0..turns {
-                            black_box(game.process_turn(
-                                random_direction(&mut rng),
-                                random_direction(&mut rng),
-                            ));
+    for scenario in scenarios {
+        group.bench_function(
+            bench_id(scenario.spec.size, scenario.spec.combo),
+            |bencher| {
+                bencher.iter_batched_ref(
+                    || scenario.initial_game.clone(),
+                    |game| {
+                        for action in &scenario.turn_actions {
+                            black_box(game.process_turn(action.p1, action.p2));
                         }
+                        black_box(&*game);
                     },
+                    BatchSize::LargeInput,
                 );
-            });
-        }
+            },
+        );
     }
     group.finish();
 }
 
-fn bench_full_game(c: &mut Criterion) {
-    let mut group = c.benchmark_group("full_game");
+fn bench_make_unmake(c: &mut Criterion, scenarios: &[PreparedScenario]) {
+    let mut group = c.benchmark_group("make_unmake");
     group.sample_size(50);
+    group.throughput(Throughput::Elements(TURN_BATCH_LEN as u64));
 
-    for size in SIZES {
-        for combo in COMBOS {
-            group.bench_function(bench_id(size, combo), |b| {
-                let mut rng = rand::rng();
-                let mut seed: u64 = 0;
-                b.iter_with_setup(
-                    || {
-                        seed = seed.wrapping_add(1);
-                        create_game(size, combo, seed)
+    for scenario in scenarios {
+        group.bench_function(
+            bench_id(scenario.spec.size, scenario.spec.combo),
+            |bencher| {
+                bencher.iter_batched_ref(
+                    || scenario.initial_game.clone(),
+                    |game| {
+                        for action in &scenario.turn_actions {
+                            let undo = black_box(game.make_move(action.p1, action.p2));
+                            game.unmake_move(undo);
+                        }
+                        black_box(&*game);
                     },
-                    |mut game| {
-                        while !black_box(
-                            game.process_turn(
-                                random_direction(&mut rng),
-                                random_direction(&mut rng),
-                            ),
-                        )
-                        .game_over
-                        {}
-                    },
+                    BatchSize::LargeInput,
                 );
-            });
-        }
+            },
+        );
     }
     group.finish();
+}
+
+fn bench_full_episode(c: &mut Criterion, scenarios: &[PreparedScenario]) {
+    let mut group = c.benchmark_group("full_episode");
+    group.sample_size(50);
+
+    for scenario in scenarios {
+        group.throughput(Throughput::Elements(scenario.episode_len as u64));
+        group.bench_function(
+            bench_id(scenario.spec.size, scenario.spec.combo),
+            |bencher| {
+                bencher.iter_batched_ref(
+                    || scenario.initial_game.clone(),
+                    |game| {
+                        for action in scenario.episode_actions.iter().take(scenario.episode_len) {
+                            let result = game.process_turn(action.p1, action.p2);
+                            let game_over = result.game_over;
+                            black_box(result);
+                            if game_over {
+                                break;
+                            }
+                        }
+                        black_box(&*game);
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_rust_matrix(c: &mut Criterion) {
+    let scenarios = prepared_scenarios()
+        .unwrap_or_else(|error| panic!("failed to prepare benchmark scenarios: {error}"));
+
+    bench_random_create(c, &scenarios);
+    bench_maze_generation(c, &scenarios);
+    bench_cheese_generation(c, &scenarios);
+    bench_topology_compilation(c, &scenarios);
+    bench_fixed_create(c, &scenarios);
+    bench_process_turn(c, &scenarios);
+    bench_make_unmake(c, &scenarios);
+    bench_full_episode(c, &scenarios);
 }
 
 criterion_group!(
@@ -98,6 +272,6 @@ criterion_group!(
     config = Criterion::default()
         .warm_up_time(std::time::Duration::from_secs(1))
         .measurement_time(std::time::Duration::from_secs(2));
-    targets = bench_game_init, bench_process_turn, bench_full_game
+    targets = bench_rust_matrix
 );
 criterion_main!(benches);

--- a/engine/rust/benches/support.rs
+++ b/engine/rust/benches/support.rs
@@ -1,0 +1,274 @@
+use pyrat::bench_scenarios::{BoardSize, FeatureCombo, COMBOS, SIZES};
+use pyrat::game::maze_generation::{CheeseGenerator, MazeGenerator, WallMap};
+use pyrat::{
+    CheeseConfig, Coordinates, Direction, GameBuilder, GameConfig, GameState, MazeConfig,
+    MazeParams, MudMap,
+};
+use rand::{Rng, RngExt, SeedableRng};
+
+pub(crate) const TURN_BATCH_LEN: usize = 64;
+pub(crate) const SEED_TAPE_LEN: usize = 4;
+pub(crate) const FIXED_CREATE_SEED: u64 = 0x5059_5241_545f_4649;
+
+const ROOT_SEED: u64 = 0x5059_5241_545f_4245;
+const GAME_STREAM: u64 = 0x4741_4d45;
+const MAZE_STREAM: u64 = 0x4d41_5a45;
+const CHEESE_STREAM: u64 = 0x4348_4545_5345;
+const TURN_STREAM: u64 = 0x5455_524e;
+const EPISODE_STREAM: u64 = 0x0045_5049_534f_4445;
+
+pub(crate) type SeedTape = [u64; SEED_TAPE_LEN];
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ActionPair {
+    pub(crate) p1: Direction,
+    pub(crate) p2: Direction,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ScenarioSeeds {
+    pub(crate) game: u64,
+    pub(crate) maze: u64,
+    pub(crate) cheese: u64,
+    pub(crate) turn_actions: u64,
+    pub(crate) episode_actions: u64,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct ScenarioSpec {
+    pub(crate) size: &'static BoardSize,
+    pub(crate) combo: &'static FeatureCombo,
+    pub(crate) seeds: ScenarioSeeds,
+}
+
+pub(crate) struct PreparedScenario {
+    pub(crate) spec: ScenarioSpec,
+    pub(crate) random_config: GameConfig,
+    pub(crate) fixed_config: GameConfig,
+    pub(crate) walls: WallMap,
+    pub(crate) mud: MudMap,
+    pub(crate) initial_game: GameState,
+    pub(crate) create_seeds: SeedTape,
+    pub(crate) maze_seeds: SeedTape,
+    pub(crate) cheese_seeds: SeedTape,
+    pub(crate) turn_actions: Vec<ActionPair>,
+    pub(crate) episode_actions: Vec<ActionPair>,
+    pub(crate) episode_len: usize,
+}
+
+impl ScenarioSpec {
+    pub(crate) fn random_config(self) -> GameConfig {
+        GameBuilder::new(self.size.width, self.size.height)
+            .with_max_turns(self.size.max_turns)
+            .with_random_maze(MazeParams {
+                wall_density: self.combo.wall_density,
+                mud_density: self.combo.mud_density,
+                ..MazeParams::default()
+            })
+            .with_corner_positions()
+            .with_random_cheese(self.size.cheese, true)
+            .build()
+    }
+
+    pub(crate) const fn maze_config(self, seed: u64) -> MazeConfig {
+        MazeConfig {
+            width: self.size.width,
+            height: self.size.height,
+            target_density: self.combo.wall_density,
+            connected: true,
+            symmetry: true,
+            mud_density: self.combo.mud_density,
+            mud_range: 3,
+            seed: Some(seed),
+        }
+    }
+
+    pub(crate) const fn cheese_config(self) -> CheeseConfig {
+        CheeseConfig {
+            count: self.size.cheese,
+            symmetry: true,
+        }
+    }
+
+    pub(crate) const fn corner_positions(self) -> (Coordinates, Coordinates) {
+        (
+            Coordinates::new(0, 0),
+            Coordinates::new(self.size.width - 1, self.size.height - 1),
+        )
+    }
+
+    pub(crate) const fn create_seed_tape(self) -> SeedTape {
+        seed_tape(self.seeds.game)
+    }
+
+    pub(crate) const fn maze_seed_tape(self) -> SeedTape {
+        seed_tape(self.seeds.maze)
+    }
+
+    pub(crate) const fn cheese_seed_tape(self) -> SeedTape {
+        seed_tape(self.seeds.cheese)
+    }
+
+    pub(crate) fn turn_action_tape(self) -> Vec<ActionPair> {
+        action_tape(self.seeds.turn_actions, TURN_BATCH_LEN)
+    }
+
+    pub(crate) fn episode_action_tape(self) -> Vec<ActionPair> {
+        action_tape(self.seeds.episode_actions, usize::from(self.size.max_turns))
+    }
+}
+
+impl PreparedScenario {
+    fn new(spec: ScenarioSpec) -> Result<Self, String> {
+        let random_config = spec.random_config();
+
+        let mut maze_generator = MazeGenerator::new(spec.maze_config(spec.seeds.maze));
+        let (walls, mud) = maze_generator.generate();
+
+        let (player1, player2) = spec.corner_positions();
+        let mut cheese_generator = CheeseGenerator::new(
+            spec.cheese_config(),
+            spec.size.width,
+            spec.size.height,
+            Some(spec.seeds.cheese),
+        );
+        let cheese_positions = cheese_generator.generate(player1, player2)?;
+
+        let fixed_config = GameBuilder::new(spec.size.width, spec.size.height)
+            .with_max_turns(spec.size.max_turns)
+            .with_custom_maze(walls.clone(), mud.clone())
+            .with_custom_positions(player1, player2)
+            .with_custom_cheese(cheese_positions)
+            .build();
+        let initial_game = fixed_config.create(Some(FIXED_CREATE_SEED))?;
+
+        let turn_actions = spec.turn_action_tape();
+        let mut turn_game = initial_game.clone();
+        for (turn, action) in turn_actions.iter().enumerate() {
+            if turn_game.process_turn(action.p1, action.p2).game_over {
+                return Err(format!(
+                    "{}/{} action seed {:#018x} reached game_over at turn {} of {}",
+                    spec.size.name,
+                    spec.combo.name,
+                    spec.seeds.turn_actions,
+                    turn + 1,
+                    TURN_BATCH_LEN
+                ));
+            }
+        }
+
+        let episode_actions = spec.episode_action_tape();
+        let mut episode_game = initial_game.clone();
+        let episode_len = episode_actions
+            .iter()
+            .position(|action| episode_game.process_turn(action.p1, action.p2).game_over)
+            .map_or(0, |index| index + 1);
+        if episode_len == 0 {
+            return Err(format!(
+                "{}/{} episode seed {:#018x} did not reach game_over in {} turns",
+                spec.size.name, spec.combo.name, spec.seeds.episode_actions, spec.size.max_turns
+            ));
+        }
+
+        Ok(Self {
+            spec,
+            random_config,
+            fixed_config,
+            walls,
+            mud,
+            initial_game,
+            create_seeds: spec.create_seed_tape(),
+            maze_seeds: spec.maze_seed_tape(),
+            cheese_seeds: spec.cheese_seed_tape(),
+            turn_actions,
+            episode_actions,
+            episode_len,
+        })
+    }
+}
+
+pub(crate) fn scenario_specs() -> Vec<ScenarioSpec> {
+    SIZES
+        .iter()
+        .flat_map(|size| {
+            COMBOS.iter().map(move |combo| ScenarioSpec {
+                size,
+                combo,
+                seeds: ScenarioSeeds {
+                    game: scenario_seed(size.name, combo.name, GAME_STREAM),
+                    maze: scenario_seed(size.name, combo.name, MAZE_STREAM),
+                    cheese: size_seed(size.name, CHEESE_STREAM),
+                    turn_actions: scenario_seed(size.name, combo.name, TURN_STREAM),
+                    episode_actions: scenario_seed(size.name, combo.name, EPISODE_STREAM),
+                },
+            })
+        })
+        .collect()
+}
+
+pub(crate) fn prepared_scenarios() -> Result<Vec<PreparedScenario>, String> {
+    scenario_specs()
+        .into_iter()
+        .map(PreparedScenario::new)
+        .collect()
+}
+
+fn random_direction(rng: &mut impl Rng) -> Direction {
+    match rng.random_range(0u8..5) {
+        0 => Direction::Up,
+        1 => Direction::Right,
+        2 => Direction::Down,
+        3 => Direction::Left,
+        _ => Direction::Stay,
+    }
+}
+
+fn action_tape(seed: u64, len: usize) -> Vec<ActionPair> {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    (0..len)
+        .map(|_| ActionPair {
+            p1: random_direction(&mut rng),
+            p2: random_direction(&mut rng),
+        })
+        .collect()
+}
+
+const fn seed_tape(seed: u64) -> SeedTape {
+    let mut seeds = [0; SEED_TAPE_LEN];
+    let mut index = 0;
+    while index < SEED_TAPE_LEN {
+        seeds[index] = splitmix64(seed.wrapping_add(index as u64));
+        index += 1;
+    }
+    seeds
+}
+
+fn scenario_seed(size_name: &str, combo_name: &str, stream: u64) -> u64 {
+    named_seed(
+        size_name
+            .bytes()
+            .chain(std::iter::once(b'/'))
+            .chain(combo_name.bytes()),
+        stream,
+    )
+}
+
+fn size_seed(size_name: &str, stream: u64) -> u64 {
+    named_seed(size_name.bytes(), stream)
+}
+
+fn named_seed(bytes: impl Iterator<Item = u8>, stream: u64) -> u64 {
+    let mut value = ROOT_SEED ^ stream;
+    for byte in bytes {
+        value ^= u64::from(byte);
+        value = value.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    splitmix64(value)
+}
+
+const fn splitmix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}

--- a/engine/rust/src/bench_scenarios.rs
+++ b/engine/rust/src/bench_scenarios.rs
@@ -32,7 +32,7 @@ pub const SIZES: &[BoardSize] = &[
     BoardSize {
         name: "small",
         width: 15,
-        height: 11,
+        height: 13,
         cheese: 21,
         max_turns: 200,
     },
@@ -106,4 +106,33 @@ pub fn create_game(size: &BoardSize, combo: &FeatureCombo, seed: u64) -> GameSta
         .build()
         .create(Some(seed))
         .unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::builder::CheeseStrategy;
+    use crate::GameConfig;
+
+    #[test]
+    fn named_sizes_match_engine_presets() {
+        for size in SIZES {
+            let preset = GameConfig::preset(size.name).unwrap();
+            assert_eq!(preset.width(), size.width, "{} width", size.name);
+            assert_eq!(preset.height(), size.height, "{} height", size.name);
+            assert_eq!(
+                preset.max_turns(),
+                size.max_turns,
+                "{} max turns",
+                size.name
+            );
+            match preset.cheese() {
+                CheeseStrategy::Random { count, symmetric } => {
+                    assert_eq!(*count, size.cheese, "{} cheese", size.name);
+                    assert!(*symmetric, "{} cheese symmetry", size.name);
+                },
+                CheeseStrategy::Fixed(_) => panic!("{} preset cheese is fixed", size.name),
+            }
+        }
+    }
 }

--- a/engine/rust/src/game/mod.rs
+++ b/engine/rust/src/game/mod.rs
@@ -7,5 +7,7 @@ pub mod game_logic;
 pub mod maze_generation;
 #[cfg(feature = "python")]
 pub mod observations;
+#[cfg(test)]
+mod semantic_compatibility;
 pub mod types;
 pub mod zobrist;

--- a/engine/rust/src/game/semantic_compatibility.rs
+++ b/engine/rust/src/game/semantic_compatibility.rs
@@ -1,0 +1,255 @@
+use std::collections::HashMap;
+
+use crate::{Coordinates, Direction, GameBuilder, GameState, MudMap};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Edge {
+    first: Coordinates,
+    second: Coordinates,
+}
+
+impl Edge {
+    fn new(first: Coordinates, second: Coordinates) -> Self {
+        if first <= second {
+            Self { first, second }
+        } else {
+            Self {
+                first: second,
+                second: first,
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct MudEdge {
+    edge: Edge,
+    cost: u8,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct TopologyFingerprint {
+    width: u8,
+    height: u8,
+    walls: Vec<Edge>,
+    mud: Vec<MudEdge>,
+}
+
+impl TopologyFingerprint {
+    fn from_game(game: &GameState) -> Self {
+        let mut walls: Vec<_> = game
+            .wall_entries()
+            .into_iter()
+            .map(|wall| Edge::new(wall.pos1, wall.pos2))
+            .collect();
+        walls.sort_unstable();
+        walls.dedup();
+
+        let mut mud: Vec<_> = game
+            .mud_positions()
+            .iter()
+            .map(|((first, second), cost)| MudEdge {
+                edge: Edge::new(first, second),
+                cost,
+            })
+            .collect();
+        mud.sort_unstable();
+        mud.dedup();
+
+        Self {
+            width: game.width(),
+            height: game.height(),
+            walls,
+            mud,
+        }
+    }
+
+    /// Canonical, representation-independent encoding used only by these
+    /// compatibility fixtures.
+    ///
+    /// Layout: dimensions, little-endian wall count, wall endpoints,
+    /// little-endian mud count, then mud endpoints and traversal costs.
+    fn canonical_bytes(&self) -> Vec<u8> {
+        let wall_count = u16::try_from(self.walls.len()).expect("wall fixture count fits in u16");
+        let mud_count = u16::try_from(self.mud.len()).expect("mud fixture count fits in u16");
+        let mut bytes = Vec::with_capacity(6 + self.walls.len() * 4 + self.mud.len() * 5);
+
+        bytes.extend([self.width, self.height]);
+        bytes.extend(wall_count.to_le_bytes());
+        for wall in &self.walls {
+            bytes.extend([wall.first.x, wall.first.y, wall.second.x, wall.second.y]);
+        }
+        bytes.extend(mud_count.to_le_bytes());
+        for mud in &self.mud {
+            bytes.extend([
+                mud.edge.first.x,
+                mud.edge.first.y,
+                mud.edge.second.x,
+                mud.edge.second.y,
+                mud.cost,
+            ]);
+        }
+
+        bytes
+    }
+}
+
+fn coordinate(x: u8, y: u8) -> Coordinates {
+    Coordinates::new(x, y)
+}
+
+fn open_game(seed: u64) -> GameState {
+    GameBuilder::new(3, 3)
+        .with_max_turns(300)
+        .with_open_maze()
+        .with_corner_positions()
+        .with_custom_cheese(vec![
+            coordinate(1, 0),
+            coordinate(1, 1),
+            coordinate(1, 2),
+            coordinate(0, 2),
+            coordinate(2, 0),
+        ])
+        .build()
+        .create(Some(seed))
+        .expect("open compatibility fixture should be valid")
+}
+
+fn add_wall(
+    walls: &mut HashMap<Coordinates, Vec<Coordinates>>,
+    first: Coordinates,
+    second: Coordinates,
+) {
+    walls.entry(first).or_default().push(second);
+    walls.entry(second).or_default().push(first);
+}
+
+fn fixed_game(seed: Option<u64>) -> GameState {
+    let mut walls = HashMap::new();
+    // Intentionally insert some endpoints in reverse canonical order. The
+    // fingerprint describes the resulting topology, not input-map ordering.
+    add_wall(&mut walls, coordinate(1, 0), coordinate(0, 0));
+    add_wall(&mut walls, coordinate(1, 1), coordinate(2, 1));
+    add_wall(&mut walls, coordinate(3, 2), coordinate(3, 1));
+
+    let mut mud = MudMap::new();
+    mud.insert(coordinate(0, 1), coordinate(0, 0), 2);
+    mud.insert(coordinate(3, 2), coordinate(2, 2), 3);
+
+    GameBuilder::new(4, 3)
+        .with_max_turns(300)
+        .with_custom_maze(walls, mud)
+        .with_corner_positions()
+        .with_custom_cheese(vec![
+            coordinate(0, 1),
+            coordinate(1, 1),
+            coordinate(2, 2),
+            coordinate(3, 1),
+            coordinate(1, 2),
+        ])
+        .build()
+        .create(seed)
+        .expect("fixed compatibility fixture should be valid")
+}
+
+#[test]
+fn open_topology_and_state_hash_trace_are_stable() {
+    let mut game = open_game(0);
+    let independently_created = open_game(999);
+    let expected_topology = TopologyFingerprint {
+        width: 3,
+        height: 3,
+        walls: vec![],
+        mud: vec![],
+    };
+
+    assert_eq!(TopologyFingerprint::from_game(&game), expected_topology);
+    assert_eq!(
+        TopologyFingerprint::from_game(&independently_created),
+        expected_topology
+    );
+    assert_eq!(
+        expected_topology.canonical_bytes(),
+        vec![0x03, 0x03, 0x00, 0x00, 0x00, 0x00]
+    );
+
+    assert_eq!(game.state_hash(), 0xEECE_2E0B_481F_A67D);
+    assert_eq!(independently_created.state_hash(), 0xEECE_2E0B_481F_A67D);
+
+    let trace = [
+        (Direction::Right, Direction::Left, 0xEFAF_A981_EBCE_3195),
+        (Direction::Up, Direction::Down, 0xBAF9_7F69_B1EB_FBA3),
+    ];
+    for (turn, (player1, player2, expected_hash)) in trace.into_iter().enumerate() {
+        let result = game.process_turn(player1, player2);
+        assert!(!result.game_over, "open fixture ended on turn {}", turn + 1);
+        assert_eq!(
+            game.state_hash(),
+            expected_hash,
+            "open fixture hash changed on turn {}",
+            turn + 1
+        );
+    }
+}
+
+#[test]
+fn fixed_topology_and_state_hash_trace_are_stable() {
+    let mut game = fixed_game(Some(0));
+    let independently_created = fixed_game(Some(999));
+    let expected_topology = TopologyFingerprint {
+        width: 4,
+        height: 3,
+        walls: vec![
+            Edge::new(coordinate(0, 0), coordinate(1, 0)),
+            Edge::new(coordinate(1, 1), coordinate(2, 1)),
+            Edge::new(coordinate(3, 1), coordinate(3, 2)),
+        ],
+        mud: vec![
+            MudEdge {
+                edge: Edge::new(coordinate(0, 0), coordinate(0, 1)),
+                cost: 2,
+            },
+            MudEdge {
+                edge: Edge::new(coordinate(2, 2), coordinate(3, 2)),
+                cost: 3,
+            },
+        ],
+    };
+
+    assert_eq!(TopologyFingerprint::from_game(&game), expected_topology);
+    assert_eq!(
+        TopologyFingerprint::from_game(&independently_created),
+        expected_topology
+    );
+    assert_eq!(
+        expected_topology.canonical_bytes(),
+        vec![
+            0x04, 0x03, 0x03, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x01, 0x02, 0x01, 0x03, 0x01,
+            0x03, 0x02, 0x02, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x02, 0x02, 0x03, 0x02, 0x03,
+        ]
+    );
+
+    assert_eq!(game.state_hash(), 0xDA23_7467_8CB6_02A2);
+    assert_eq!(independently_created.state_hash(), 0xDA23_7467_8CB6_02A2);
+
+    let trace = [
+        (Direction::Up, Direction::Left, 0xB3B4_19A2_A88C_BD1D),
+        (Direction::Right, Direction::Down, 0x9E48_5CCC_50E5_B2C1),
+        (Direction::Stay, Direction::Stay, 0x853B_6C9A_BDCB_A778),
+        (Direction::Right, Direction::Stay, 0x845C_F2B9_38C9_0D41),
+    ];
+    for (turn, (player1, player2, expected_hash)) in trace.into_iter().enumerate() {
+        let result = game.process_turn(player1, player2);
+        assert!(
+            !result.game_over,
+            "fixed fixture ended on turn {}",
+            turn + 1
+        );
+        assert_eq!(
+            game.state_hash(),
+            expected_hash,
+            "fixed fixture hash changed on turn {}",
+            turn + 1
+        );
+    }
+}


### PR DESCRIPTION
## Motivation

We want to make the engine faster, but first we need numbers we can trust.

The old Rust turn benchmark also timed the work of choosing random moves. Game setup was measured as
one big operation, so it did not show whether the time went into the maze, cheese, or the game
itself. There was no matching benchmark for the calls made from Python.

This PR adds those benchmarks and the safety tests needed for later performance work. It does not
change gameplay or make the engine faster.

## Solution

The Rust benchmarks now time each part separately:

- creating a game from a random setup or an already-built maze;
- generating the maze and cheese;
- preparing the movement data used during a game;
- playing turns, making and undoing moves, and playing a complete game.

Random seeds and player moves are prepared before timing starts. Every run repeats the same work, so
future before-and-after comparisons stay meaningful.

A small Python script measures the real calls made through `pyrat_engine`: creating and resetting a
game, reading observations, calling `PyRat.step`, and calling `PyRatEnv.step`. It prints a readable
summary, can save the raw results as JSON, and has a quick smoke mode for CI.

The new tests record the walls, mud, and state hashes of a few small games. If a later optimization
changes game behavior, these tests should catch it without depending on how the engine stores the
maze internally.

CI only checks that both benchmark tools run successfully. It does not fail builds for being slower,
because shared CI machines are too noisy for useful speed limits. The engine's Python 3.8 and 3.9
jobs now use separate environments, so they really run those Python versions.

### First baseline

Representative results on an ARM64 Mac:

| Work | Time |
|---|---:|
| Create a medium game with a random maze | 1.58 ms |
| Create a medium game from an already-built maze | 11.82 us |
| Play one medium/classic turn | 29.9 ns |
| Make and undo one move | 34.8 ns |
| Play the 300-turn loop | 10.33 us |
| Call `PyRatEnv.step` from Python | 658.9 ns |

These are starting numbers, not speedups. In particular, the old turn benchmark also timed random
move selection, so it cannot be compared directly with the new turn number.

## Test Plan

- Rust unit tests: 107 passed
- Rust formatting and Clippy passed with and without Python features
- `make bench-smoke` ran every Rust benchmark case and all seven Python cases
- Python lint and format checks passed
- The isolated Python 3.8 job passed all 220 engine tests and the benchmark smoke run
- Python 3.9 dependency setup passed
