### PR TITLE
fix(engine): keep observations in sync with game state

### DIFF
--- a/engine/python/pyrat_engine/env.py
+++ b/engine/python/pyrat_engine/env.py
@@ -7,8 +7,6 @@ from gymnasium.spaces import Box, Discrete
 from gymnasium.spaces import Dict as SpaceDict
 from pettingzoo.utils.env import AgentID, ParallelEnv
 
-from pyrat_engine.core import ObservationHandler as PyObservationHandler
-
 if TYPE_CHECKING:
     from pyrat_engine.core.builder import GameConfig
     from pyrat_engine.core.types import Direction
@@ -60,11 +58,10 @@ class PyRatEnv(ParallelEnv):  # type: ignore[misc]
 
         self.possible_agents = ["player_1", "player_2"]
 
-        # Create game state and observation handler
+        # PyRat owns the canonical observation state.
         self.game = config.create(seed)
         width = config.width
         height = config.height
-        self.obs_handler = PyObservationHandler(self.game)
         cheese_count = len(self.game.cheese_positions())
         max_turns = self.game.max_turns
 
@@ -109,8 +106,8 @@ class PyRatEnv(ParallelEnv):  # type: ignore[misc]
         self.game.reset(seed)
 
         observations = {
-            "player_1": self.obs_handler.get_observation(self.game, True),
-            "player_2": self.obs_handler.get_observation(self.game, False),
+            "player_1": self.game.get_observation(True),
+            "player_2": self.game.get_observation(False),
         }
         infos: dict[str, Any] = {agent: {} for agent in self.agents}
 
@@ -131,7 +128,7 @@ class PyRatEnv(ParallelEnv):  # type: ignore[misc]
         prev_p2_score = self.game.player2_score
 
         # Process moves
-        game_over, collected = self.game.step(
+        game_over, _ = self.game.step(
             actions["player_1"],
             actions["player_2"],
         )
@@ -148,8 +145,8 @@ class PyRatEnv(ParallelEnv):  # type: ignore[misc]
 
         # Update observations
         observations = {
-            "player_1": self.obs_handler.get_observation(self.game, True),
-            "player_2": self.obs_handler.get_observation(self.game, False),
+            "player_1": self.game.get_observation(True),
+            "player_2": self.game.get_observation(False),
         }
 
         terminations = {

--- a/engine/python/tests/test_env.py
+++ b/engine/python/tests/test_env.py
@@ -82,6 +82,56 @@ def test_env_step() -> None:
         assert 0 <= obs.player_position.y < TEST_GAME_HEIGHT
 
 
+def test_env_reset_uses_the_game_owned_observation_state() -> None:
+    """Reset observations match the game's regenerated topology and cheese."""
+    config = GameConfig.classic(7, 5, 5)
+    env = PyRatEnv(config, seed=42)
+
+    observations, _ = env.reset(seed=123)
+
+    for agent, is_player_one in (("player_1", True), ("player_2", False)):
+        expected = env.game.get_observation(is_player_one)
+        actual = observations[agent]
+        np.testing.assert_array_equal(actual.cheese_matrix, expected.cheese_matrix)
+        np.testing.assert_array_equal(actual.movement_matrix, expected.movement_matrix)
+        assert actual.cheese_matrix.shape == (7, 5)
+        assert actual.movement_matrix.shape == (7, 5, 4)
+        assert actual.cheese_matrix.dtype == np.uint8
+        assert actual.movement_matrix.dtype == np.int8
+
+    np.testing.assert_array_equal(
+        observations["player_1"].cheese_matrix,
+        observations["player_2"].cheese_matrix,
+    )
+    np.testing.assert_array_equal(
+        observations["player_1"].movement_matrix,
+        observations["player_2"].movement_matrix,
+    )
+
+
+def test_env_step_updates_collected_cheese() -> None:
+    """The environment observes cheese removed by its game step."""
+    config = (
+        GameBuilder(3, 3)
+        .with_open_maze()
+        .with_custom_positions((0, 0), (2, 2))
+        .with_custom_cheese([(1, 0), (0, 2)])
+        .build()
+    )
+    env = PyRatEnv(config)
+    env.reset()
+
+    observations, *_ = env.step(
+        {
+            "player_1": Direction.RIGHT,
+            "player_2": Direction.STAY,
+        }
+    )
+
+    assert observations["player_1"].cheese_matrix[1, 0] == 0
+    assert observations["player_2"].cheese_matrix[1, 0] == 0
+
+
 def test_env_symmetry() -> None:
     """Test symmetric observations between players."""
     env = PyRatEnv(_test_config())

--- a/engine/python/tests/test_game.py
+++ b/engine/python/tests/test_game.py
@@ -9,8 +9,41 @@ This tests the game state implementation including:
 """
 # ruff: noqa: PLR2004
 
+import numpy as np
 import pytest
-from pyrat_engine import GameBuilder, GameConfig
+from pyrat_engine import Direction, GameBuilder, GameConfig
+
+
+def _movement_matrix_from_public_state(game):
+    """Reconstruct movement observations without using their cached matrix."""
+
+    def edge(first, second):
+        return tuple(sorted((first, second)))
+
+    walls = {
+        edge((wall.pos1.x, wall.pos1.y), (wall.pos2.x, wall.pos2.y))
+        for wall in game.wall_entries()
+    }
+    mud = {
+        edge((entry.pos1.x, entry.pos1.y), (entry.pos2.x, entry.pos2.y)): entry.value
+        for entry in game.mud_entries()
+    }
+    matrix = np.zeros((game.width, game.height, 4), dtype=np.int8)
+
+    for x in range(game.width):
+        for y in range(game.height):
+            for direction, (dx, dy) in enumerate(((0, 1), (1, 0), (0, -1), (-1, 0))):
+                target = (x + dx, y + dy)
+                if not (0 <= target[0] < game.width and 0 <= target[1] < game.height):
+                    matrix[x, y, direction] = -1
+                    continue
+
+                passage = edge((x, y), target)
+                matrix[x, y, direction] = (
+                    -1 if passage in walls else mud.get(passage, 0)
+                )
+
+    return matrix
 
 
 class TestGameCreation:
@@ -327,6 +360,76 @@ class TestResetSymmetry:
         assert game.width == 21
         assert game.height == 15
         assert len(game.cheese_positions()) > 0
+
+
+class TestObservationCoherence:
+    """Observation matrices stay synchronized with every game mutation path."""
+
+    def test_reset_rebuilds_movement_and_cheese_matrices(self):
+        config = GameConfig.classic(7, 5, 5)
+        game = config.create(seed=42)
+        before = game.get_observation(True)
+        before_movement = before.movement_matrix.copy()
+        before_cheese = before.cheese_matrix.copy()
+
+        game.reset(seed=123)
+        after = game.get_observation(True)
+        expected_cheese = np.zeros((game.width, game.height), dtype=np.uint8)
+        for position in game.cheese_positions():
+            expected_cheese[position.x, position.y] = 1
+
+        # These seeds exercise both regenerated topology and regenerated cheese.
+        assert not np.array_equal(before.movement_matrix, after.movement_matrix)
+        assert not np.array_equal(before.cheese_matrix, after.cheese_matrix)
+
+        np.testing.assert_array_equal(
+            after.movement_matrix,
+            _movement_matrix_from_public_state(game),
+        )
+        np.testing.assert_array_equal(after.cheese_matrix, expected_cheese)
+        np.testing.assert_array_equal(before.movement_matrix, before_movement)
+        np.testing.assert_array_equal(before.cheese_matrix, before_cheese)
+
+    def test_nested_make_unmake_tracks_only_changed_cheese(self):
+        config = (
+            GameBuilder(3, 3)
+            .with_open_maze()
+            .with_custom_positions((0, 0), (2, 2))
+            .with_custom_cheese([(1, 0), (2, 0)])
+            .build()
+        )
+        game = config.create()
+        original = game.get_observation(True)
+
+        first_undo = game.make_move(Direction.RIGHT, Direction.STAY)
+        after_first = game.get_observation(True)
+        assert after_first.cheese_matrix[1, 0] == 0
+        assert after_first.cheese_matrix[2, 0] == 1
+
+        second_undo = game.make_move(Direction.RIGHT, Direction.STAY)
+        after_second = game.get_observation(True)
+        assert after_second.cheese_matrix[1, 0] == 0
+        assert after_second.cheese_matrix[2, 0] == 0
+
+        # Previously returned observations remain snapshots.
+        assert original.cheese_matrix[1, 0] == 1
+        assert original.cheese_matrix[2, 0] == 1
+
+        game.unmake_move(second_undo)
+        after_second_undo = game.get_observation(True)
+        assert after_second_undo.cheese_matrix[1, 0] == 0
+        assert after_second_undo.cheese_matrix[2, 0] == 1
+
+        game.unmake_move(first_undo)
+        after_first_undo = game.get_observation(True)
+        np.testing.assert_array_equal(
+            after_first_undo.cheese_matrix,
+            original.cheese_matrix,
+        )
+        assert after_first.cheese_matrix[1, 0] == 0
+        assert after_first.cheese_matrix[2, 0] == 1
+        assert after_second.cheese_matrix[1, 0] == 0
+        assert after_second.cheese_matrix[2, 0] == 0
 
 
 class TestEffectiveMoves:

--- a/engine/rust/src/bindings/game.rs
+++ b/engine/rust/src/bindings/game.rs
@@ -747,6 +747,8 @@ impl PyRat {
         })?;
 
         let undo = self.game.make_move(p1_dir, p2_dir);
+        self.observation_handler
+            .update_collected_cheese(&undo.collected_cheese);
         Ok(PyMoveUndo { inner: undo })
     }
 
@@ -756,16 +758,18 @@ impl PyRat {
     /// `make_move()` call. Undo objects must be applied in LIFO order.
     fn unmake_move(&mut self, undo: &PyMoveUndo) {
         self.game.unmake_move(undo.inner.clone());
-        // Need full refresh after unmake
-        self.observation_handler.refresh_cheese(&self.game);
+        for &pos in &undo.inner.collected_cheese {
+            self.observation_handler.restore_cheese(pos);
+        }
     }
 
     /// Reset the game state using the stored config.
     #[pyo3(signature = (seed=None))]
     fn reset(&mut self, seed: Option<u64>) -> PyResult<()> {
-        self.game = self.config.create(seed).map_err(PyValueError::new_err)?;
-        // Need full refresh after reset
-        self.observation_handler.refresh_cheese(&self.game);
+        let game = self.config.create(seed).map_err(PyValueError::new_err)?;
+        let observation_handler = ObservationHandler::new(&game);
+        self.game = game;
+        self.observation_handler = observation_handler;
         Ok(())
     }
 


### PR DESCRIPTION
## Motivation

`PyRat` already owned the observation state for a game, but `PyRatEnv` created a second observation
handler and read from that instead. Game steps updated the handler inside `PyRat`, while the
environment kept reading its stale copy. Collected cheese could remain visible after a step.

Reset had a similar split inside `PyRat`: it replaced the game state and refreshed cached cheese,
but kept the movement matrix from the previous maze. `make_move` also changed cheese without
updating observations. These paths need one source of truth before later observation caching or
fusion work can be safe.

## Solution

`PyRatEnv` now gets both player observations directly from its `PyRat`. `make_move` clears the
cheese collected by that move, `unmake_move` restores only the cheese carried by its undo record,
and reset builds a new game and complete observation handler before installing either one.

The public `ObservationHandler` remains available for compatibility. Observation values, non-square
matrix shapes and dtypes, player orientation, and the snapshot lifetime of previously returned
NumPy arrays stay unchanged.

The fresh same-host benchmark comparison was:

| Path | `main` | This branch | Change |
|---|---:|---:|---:|
| Random reset | 1.532 ms | 1.550 ms | +1.1% |
| Fixed-topology reset | 13.896 us | 18.447 us | +4.55 us |
| `PyRatEnv.step` | 691.7 ns | 663.0 ns | -4.1% |

The fixed-topology reset now pays to rebuild movement constraints, which is the correctness work
this change adds. Random reset remains within run variation because maze generation dominates it.
Creation and direct `PyRat.step` were also unchanged within the run's variation.

## Test Plan

```text
cargo test -p pyrat-rust --lib --no-default-features       # 107 passed
uv run --directory engine pytest python/tests -q           # 224 passed
cargo fmt --all -- --check
uv run ruff check engine/python
uv run --directory engine mypy python/pyrat_engine --ignore-missing-imports
cargo clippy -p pyrat-rust --all-targets --no-default-features -- -D warnings
cargo clippy --all-targets --all-features -- -D warnings -A non-local-definitions
cargo bench -p pyrat-rust --bench game_benchmarks --no-default-features -- --test
uv run --directory engine python python/benchmarks/benchmark_engine.py --smoke --json -
```
