### PR TITLE
perf(engine): avoid cheese allocation on ordinary turns

### DIFF
--- a/engine/rust/benches/game_benchmarks.rs
+++ b/engine/rust/benches/game_benchmarks.rs
@@ -223,6 +223,52 @@ fn bench_make_unmake(c: &mut Criterion, scenarios: &[PreparedScenario]) {
     group.finish();
 }
 
+fn bench_make_unmake_no_collection(c: &mut Criterion, scenarios: &[PreparedScenario]) {
+    let mut group = c.benchmark_group("make_unmake_no_collection");
+    group.sample_size(50);
+    group.throughput(Throughput::Elements(TURN_BATCH_LEN as u64));
+
+    for scenario in scenarios {
+        let mut initial_game = scenario.initial_game.clone();
+        let mut collected_positions = Vec::new();
+
+        // Every pair is undone to the same root. Remove only cheese reachable
+        // by this tape so movement and game-over work remain representative.
+        for action in &scenario.turn_actions {
+            let undo = initial_game.make_move(action.p1, action.p2);
+            collected_positions.extend_from_slice(&undo.collected_cheese);
+            initial_game.unmake_move(undo);
+        }
+        for position in collected_positions {
+            initial_game.cheese.take_cheese(position);
+        }
+        initial_game.recompute_state_hash();
+        for action in &scenario.turn_actions {
+            let undo = initial_game.make_move(action.p1, action.p2);
+            assert!(undo.collected_cheese.is_empty());
+            initial_game.unmake_move(undo);
+        }
+
+        group.bench_function(
+            bench_id(scenario.spec.size, scenario.spec.combo),
+            |bencher| {
+                bencher.iter_batched_ref(
+                    || initial_game.clone(),
+                    |game| {
+                        for action in &scenario.turn_actions {
+                            let undo = black_box(game.make_move(action.p1, action.p2));
+                            game.unmake_move(undo);
+                        }
+                        black_box(&*game);
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
 fn bench_full_episode(c: &mut Criterion, scenarios: &[PreparedScenario]) {
     let mut group = c.benchmark_group("full_episode");
     group.sample_size(50);
@@ -264,6 +310,7 @@ fn bench_rust_matrix(c: &mut Criterion) {
     bench_fixed_create(c, &scenarios);
     bench_process_turn(c, &scenarios);
     bench_make_unmake(c, &scenarios);
+    bench_make_unmake_no_collection(c, &scenarios);
     bench_full_episode(c, &scenarios);
 }
 

--- a/engine/rust/src/game/game_logic.rs
+++ b/engine/rust/src/game/game_logic.rs
@@ -283,7 +283,7 @@ impl GameState {
             p2_score: self.player2.score,
             p2_misses: self.player2.misses,
 
-            collected_cheese: Vec::with_capacity(2),
+            collected_cheese: Vec::new(),
             turn: self.turn,
             state_hash: self.state_hash,
         };
@@ -377,7 +377,7 @@ impl GameState {
 
     #[inline]
     pub fn process_cheese_collection(&mut self) -> Vec<Coordinates> {
-        let mut collected = Vec::with_capacity(2);
+        let mut collected = Vec::new();
 
         // Check for simultaneous collection first
         if self.player1.can_collect_cheese()
@@ -982,6 +982,17 @@ mod tests {
         use super::*;
 
         #[test]
+        fn test_no_cheese_collection() {
+            let mut game = create_test_game(Coordinates::new(0, 0), Coordinates::new(2, 2));
+
+            let result = game.process_turn(Direction::Right, Direction::Left);
+
+            assert!(result.collected_cheese.is_empty());
+            assert_eq!(game.player1.score, 0.0);
+            assert_eq!(game.player2.score, 0.0);
+        }
+
+        #[test]
         fn test_basic_cheese_collection() {
             let mut game = create_test_game(Coordinates::new(0, 0), Coordinates::new(2, 2));
 
@@ -993,6 +1004,25 @@ mod tests {
             assert!(result.collected_cheese.contains(&Coordinates::new(1, 0)));
             assert_eq!(game.player1.score, 1.0);
             assert_eq!(game.player2.score, 0.0);
+            assert_eq!(game.cheese.remaining_cheese(), 0);
+        }
+
+        #[test]
+        fn test_two_distinct_cheese_collection() {
+            let mut game = create_test_game(Coordinates::new(0, 0), Coordinates::new(2, 2));
+            let player1_cheese = Coordinates::new(1, 0);
+            let player2_cheese = Coordinates::new(1, 2);
+            game.cheese.place_cheese(player1_cheese);
+            game.cheese.place_cheese(player2_cheese);
+
+            let result = game.process_turn(Direction::Right, Direction::Left);
+
+            assert_eq!(
+                result.collected_cheese,
+                vec![player1_cheese, player2_cheese]
+            );
+            assert_eq!(game.player1.score, 1.0);
+            assert_eq!(game.player2.score, 1.0);
             assert_eq!(game.cheese.remaining_cheese(), 0);
         }
 
@@ -1692,6 +1722,7 @@ mod make_unmake_tests {
 
         // Make a move
         let undo = game.make_move(Direction::Right, Direction::Left);
+        assert!(undo.collected_cheese.is_empty());
 
         // State should be different
         assert_ne!(game.player1.current_pos, initial_state.player1.current_pos);
@@ -1722,6 +1753,7 @@ mod make_unmake_tests {
         let undo = game.make_move(Direction::Right, Direction::Stay);
 
         // Verify cheese was collected
+        assert_eq!(undo.collected_cheese, vec![cheese_pos]);
         assert_eq!(game.cheese.remaining_cheese(), initial_remaining - 1);
         assert_eq!(game.cheese.total_cheese(), initial_cheese_count); // Should be unchanged
         assert_eq!(game.player1.score, 1.0);
@@ -1751,6 +1783,7 @@ mod make_unmake_tests {
         let undo = game.make_move(Direction::Right, Direction::Left);
 
         // Verify simultaneous collection
+        assert_eq!(undo.collected_cheese, vec![cheese_pos]);
         assert_eq!(game.player1.score, 0.5);
         assert_eq!(game.player2.score, 0.5);
         assert!(!game.cheese.has_cheese(cheese_pos));


### PR DESCRIPTION
## Motivation

Most turns do not collect cheese, but collection started with `Vec::with_capacity(2)`, which made the common empty path allocate. `make_move` also created an eagerly reserved placeholder before replacing it with the turn result.

## Solution

The public `Vec<Coordinates>` shapes stay unchanged. Both vectors now start empty and allocate only on the first collected cheese. Collection order, scores, state hashes, and make/unmake restoration behavior are unchanged.

Tests now pin empty, one-piece, two-distinct-piece, and simultaneous collection results, including the cheese carried by undo values.

The existing make/unmake benchmark returns to the same root after every action. Its fixed tape collects cheese on 24 of 64 pairs, so it is useful as a mixed workload but does not isolate the empty path. A new `make_unmake_no_collection` group removes only cheese positions reachable by that tape, verifies every undo is empty, and keeps the same topology, mud, actions, movement, restoration work, and optimizer barriers.

Same-host `classic/medium/21x15` comparisons against `fcd1d2a`:

- `process_turn`: 30.948M → 49.564M operations/s (+60.64%)
- mixed `make_unmake`: roughly +22% to +26% across repeated runs
- `make_unmake_no_collection`: 26.668M → 42.518M pairs/s (+64.11%)

## Test Plan

- `cargo fmt --all -- --check`
- `cargo test -p pyrat-rust --lib --no-default-features` (109 tests)
- `cargo clippy -p pyrat-rust --all-targets --no-default-features -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings -A non-local-definitions`
- `cargo bench -p pyrat-rust --bench game_benchmarks --no-default-features -- --test`
- `git diff --check`