### PR TITLE
perf(engine): avoid redundant mud lookups

### DIFF
--- a/engine/rust/src/game/builder.rs
+++ b/engine/rust/src/game/builder.rs
@@ -441,8 +441,7 @@ impl GameConfig {
                     mud_range: params.mud_range,
                     seed: Some(rng.random()),
                 };
-                let mut gen = MazeGenerator::new(maze_config);
-                gen.generate()
+                MazeGenerator::new(maze_config).generate_owned()
             },
         };
 

--- a/engine/rust/src/game/maze_generation.rs
+++ b/engine/rust/src/game/maze_generation.rs
@@ -48,6 +48,17 @@ impl MazeGenerator {
 
     /// Generates a complete maze with walls and mud
     pub fn generate(&mut self) -> (WallMap, MudMap) {
+        let walls = self.generate_in_place();
+        (walls, self.mud.clone())
+    }
+
+    /// Generates a complete maze when the caller owns this generator.
+    pub(crate) fn generate_owned(mut self) -> (WallMap, MudMap) {
+        let walls = self.generate_in_place();
+        (walls, self.mud)
+    }
+
+    fn generate_in_place(&mut self) -> WallMap {
         self.generate_initial_layout();
 
         if self.config.connected {
@@ -62,9 +73,7 @@ impl MazeGenerator {
         }
 
         // Convert connections to walls (blocked passages)
-        let walls = self.connections_to_walls();
-
-        (walls, self.mud.clone())
+        self.connections_to_walls()
     }
 
     /// Generates the initial random layout of the maze
@@ -101,7 +110,6 @@ impl MazeGenerator {
 
                         if mud_value > 1 {
                             self.mud.insert(current, next, mud_value);
-                            self.mud.insert(next, current, mud_value);
                         }
 
                         // Handle symmetry exactly as Python
@@ -120,7 +128,6 @@ impl MazeGenerator {
 
                             if mud_value > 1 {
                                 self.mud.insert(sym_current, sym_next, mud_value);
-                                self.mud.insert(sym_next, sym_current, mud_value);
                             }
                         }
                     }
@@ -141,7 +148,6 @@ impl MazeGenerator {
 
                         if mud_value > 1 {
                             self.mud.insert(current, next, mud_value);
-                            self.mud.insert(next, current, mud_value);
                         }
 
                         if self.config.symmetry {
@@ -159,7 +165,6 @@ impl MazeGenerator {
 
                             if mud_value > 1 {
                                 self.mud.insert(sym_current, sym_next, mud_value);
-                                self.mud.insert(sym_next, sym_current, mud_value);
                             }
                         }
                     }
@@ -352,7 +357,6 @@ impl MazeGenerator {
 
             if mud_value > 1 {
                 self.mud.insert(from, to, mud_value);
-                self.mud.insert(to, from, mud_value);
             }
 
             // Handle symmetry exactly as Python
@@ -365,7 +369,6 @@ impl MazeGenerator {
 
                 if mud_value > 1 {
                     self.mud.insert(sym_from, sym_to, mud_value);
-                    self.mud.insert(sym_to, sym_from, mud_value);
                 }
             }
 
@@ -413,16 +416,14 @@ impl MazeGenerator {
         if self.rng.random::<f32>() < self.config.mud_density {
             let mud_value = self.rng.random_range(2..=self.config.mud_range);
 
-            // Add mud both ways for the passage
+            // MudMap stores both orientations for the passage.
             self.mud.insert(from, to, mud_value);
-            self.mud.insert(to, from, mud_value);
 
             // If symmetric, add mud for the symmetric passage
             if self.config.symmetry {
                 let sym_from = self.get_symmetric(from);
                 let sym_to = self.get_symmetric(to);
                 self.mud.insert(sym_from, sym_to, mud_value);
-                self.mud.insert(sym_to, sym_from, mud_value);
             }
         }
     }
@@ -707,6 +708,31 @@ mod tests {
         // Check basic properties
         assert!(!walls.is_empty());
         assert!(mud.len() <= walls.len());
+    }
+
+    #[test]
+    fn owned_generation_matches_borrowed_generation() {
+        let config = MazeConfig {
+            width: 5,
+            height: 4,
+            target_density: 0.55,
+            connected: false,
+            symmetry: true,
+            mud_density: 0.65,
+            mud_range: 4,
+            seed: Some(0xA11C_E5E5),
+        };
+
+        let mut borrowed_generator = MazeGenerator::new(config);
+        let (borrowed_walls, borrowed_mud) = borrowed_generator.generate();
+        let (owned_walls, owned_mud) = MazeGenerator::new(config).generate_owned();
+        let mut borrowed_mud: Vec<_> = borrowed_mud.iter().collect();
+        let mut owned_mud: Vec<_> = owned_mud.iter().collect();
+        borrowed_mud.sort_unstable();
+        owned_mud.sort_unstable();
+
+        assert_eq!(owned_walls, borrowed_walls);
+        assert_eq!(owned_mud, borrowed_mud);
     }
 
     #[test]

--- a/engine/rust/src/game/semantic_compatibility.rs
+++ b/engine/rust/src/game/semantic_compatibility.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::{Coordinates, Direction, GameBuilder, GameState, MudMap};
+use crate::{Coordinates, Direction, GameBuilder, GameState, MazeParams, MudMap};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct Edge {
@@ -150,6 +150,40 @@ fn fixed_game(seed: Option<u64>) -> GameState {
         .build()
         .create(seed)
         .expect("fixed compatibility fixture should be valid")
+}
+
+fn seeded_disconnected_game(seed: u64) -> GameState {
+    GameBuilder::new(3, 3)
+        .with_random_maze(MazeParams {
+            wall_density: 0.55,
+            connected: false,
+            symmetric: true,
+            mud_density: 0.65,
+            mud_range: 4,
+        })
+        .with_corner_positions()
+        .with_custom_cheese(vec![coordinate(1, 1)])
+        .build()
+        .create(Some(seed))
+        .expect("seeded disconnected compatibility fixture should be valid")
+}
+
+#[test]
+fn seeded_disconnected_topology_and_state_hash_are_stable() {
+    let game = seeded_disconnected_game(0xA11C_E5E5);
+    let topology = TopologyFingerprint::from_game(&game);
+
+    assert_eq!(
+        topology.canonical_bytes(),
+        vec![
+            0x03, 0x03, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x01, 0x00, 0x02, 0x00, 0x01,
+            0x01, 0x01, 0x01, 0x00, 0x01, 0x01, 0x01, 0x01, 0x01, 0x02, 0x01, 0x01, 0x02, 0x01,
+            0x01, 0x02, 0x02, 0x02, 0x02, 0x00, 0x02, 0x01, 0x04, 0x00, 0x00, 0x00, 0x00, 0x01,
+            0x02, 0x00, 0x02, 0x01, 0x02, 0x02, 0x01, 0x00, 0x02, 0x00, 0x02, 0x02, 0x01, 0x02,
+            0x02, 0x02,
+        ]
+    );
+    assert_eq!(game.state_hash(), 0x8177_5E20_C1DE_7EE2);
 }
 
 #[test]

--- a/engine/rust/src/game/types.rs
+++ b/engine/rust/src/game/types.rs
@@ -247,10 +247,7 @@ impl MudMap {
 
     /// Get mud value between two positions (order doesn't matter)
     pub fn get(&self, pos1: Coordinates, pos2: Coordinates) -> Option<u8> {
-        self.inner
-            .get(&(pos1, pos2))
-            .or_else(|| self.inner.get(&(pos2, pos1)))
-            .copied()
+        self.inner.get(&(pos1, pos2)).copied()
     }
 
     /// Returns an iterator over all unique mud positions and their values
@@ -277,7 +274,7 @@ impl MudMap {
 
     /// Check if mud exists between two positions (order doesn't matter)
     pub fn contains(&self, pos1: Coordinates, pos2: Coordinates) -> bool {
-        self.inner.contains_key(&(pos1, pos2)) || self.inner.contains_key(&(pos2, pos1))
+        self.inner.contains_key(&(pos1, pos2))
     }
 }
 
@@ -486,12 +483,24 @@ mod tests {
 
         mud_map.insert(pos1, pos2, 2);
 
-        // Test bidirectional lookup
+        // Inserting once establishes the bidirectional invariant.
         assert_eq!(mud_map.get(pos1, pos2), Some(2));
         assert_eq!(mud_map.get(pos2, pos1), Some(2));
+        assert!(mud_map.contains(pos1, pos2));
+        assert!(mud_map.contains(pos2, pos1));
+        assert_eq!(mud_map.len(), 1);
+        assert_eq!(mud_map.iter().collect::<Vec<_>>(), vec![((pos1, pos2), 2)]);
+
+        // Reversed insertion updates the same logical edge in both directions.
+        mud_map.insert(pos2, pos1, 3);
+        assert_eq!(mud_map.get(pos1, pos2), Some(3));
+        assert_eq!(mud_map.get(pos2, pos1), Some(3));
+        assert_eq!(mud_map.len(), 1);
+        assert_eq!(mud_map.iter().collect::<Vec<_>>(), vec![((pos1, pos2), 3)]);
 
         // Test non-existent mud
         assert_eq!(mud_map.get(pos1, Coordinates::new(1, 0)), None);
+        assert!(!mud_map.contains(pos1, Coordinates::new(1, 0)));
     }
     mod coordinates {
         use super::*;


### PR DESCRIPTION
## Motivation

`MudMap::insert` already stores each muddy passage in both directions. Reads still treated the reverse key as a fallback. On an ordinary passage with no mud, that meant hashing and probing twice. Maze generation also called the bidirectional insert method once per orientation, so each logical edge was written four times.

## Solution

`MudMap::get` and `contains` now use the directed key established by `insert`. Maze generation removes only the immediately paired reverse calls. Symmetric passage calls and their RNG order stay intact.

Random game creation now uses a crate-private consuming generation path, which moves mud out of its one-shot generator. The public `MazeGenerator::generate(&mut self)` API and repeat-call behavior remain unchanged.

Compatibility tests cover both lookup directions, reverse-oriented overwrite, unique iteration, and borrowed-versus-owned generation. A seeded `connected = false` fixture pins the exact generated topology and initial state hash without claiming determinism for the current connectivity algorithm.

Same-host ARM64 macOS measurements:

| Benchmark | Before | After | Change |
|---|---:|---:|---:|
| Medium/classic turns | 47.750M/s | 61.274M/s | +27.852% |
| Medium/mud-only turns | 29.383M/s | 44.720M/s | +52.533% |
| Medium/open turns | 85.812M/s | 85.792M/s | no change detected |
| Medium/classic random creation | 597.33/s | 610.78/s | about +2.25% |

Direct medium/classic maze generation stayed within noise.

## Test Plan

- `cargo test -p pyrat-rust --lib --no-default-features` (111 passed)
- `uv run --directory engine pytest python/tests -q` (224 passed)
- `cargo fmt --all -- --check`
- Focused no-feature and full-workspace all-feature Clippy with warnings denied
- Complete no-feature Criterion smoke matrix
- Release Python extension build and seven-case benchmark smoke
- `git diff --check`