### PR TITLE
perf(engine): speed up open maze creation

### DIFF
--- a/engine/rust/src/game/board.rs
+++ b/engine/rust/src/game/board.rs
@@ -55,6 +55,41 @@ impl MoveTable {
         Self { valid_moves, width }
     }
 
+    /// Build the packed movement masks for a board with no internal walls.
+    #[must_use]
+    pub(crate) fn open(width: u8, height: u8) -> Self {
+        let size = (width as usize * height as usize).div_ceil(2);
+        let mut valid_moves = vec![0u8; size];
+
+        for y in 0..height {
+            for x in 0..width {
+                let mut moves = 0u8;
+                if y < height - 1 {
+                    moves |= 1;
+                }
+                if x < width - 1 {
+                    moves |= 2;
+                }
+                if y > 0 {
+                    moves |= 4;
+                }
+                if x > 0 {
+                    moves |= 8;
+                }
+
+                let idx = Coordinates::new(x, y).to_index(width);
+                let byte_idx = idx / 2;
+                if idx.is_multiple_of(2) {
+                    valid_moves[byte_idx] |= moves;
+                } else {
+                    valid_moves[byte_idx] |= moves << 4;
+                }
+            }
+        }
+
+        Self { valid_moves, width }
+    }
+
     /// Check if a move is valid for a given position
     #[inline(always)]
     #[must_use]
@@ -198,6 +233,18 @@ mod tests {
         assert!(!move_table.is_move_valid(Coordinates::new(1, 1), Direction::Right)); // Grid boundary
         assert!(move_table.is_move_valid(Coordinates::new(1, 1), Direction::Down));
         assert!(move_table.is_move_valid(Coordinates::new(1, 1), Direction::Left));
+    }
+
+    #[test]
+    fn open_constructor_matches_empty_wall_compilation() {
+        let walls = HashMap::new();
+
+        for (width, height) in [(2, 2), (3, 4), (21, 15), (41, 31)] {
+            let compiled = MoveTable::new(width, height, &walls);
+            let open = MoveTable::open(width, height);
+
+            assert_eq!(open.bytes(), compiled.bytes(), "{width}x{height}");
+        }
     }
 
     #[test]

--- a/engine/rust/src/game/builder.rs
+++ b/engine/rust/src/game/builder.rs
@@ -24,7 +24,7 @@
 
 use crate::game::maze_generation::{CheeseConfig, CheeseGenerator, MazeConfig, MazeGenerator};
 use crate::game::types::MudMap;
-use crate::{Coordinates, GameState};
+use crate::{Coordinates, GameState, MoveTable};
 use rand::{Rng, RngExt, SeedableRng};
 use std::collections::HashMap;
 use std::marker::PhantomData;
@@ -427,21 +427,34 @@ impl GameConfig {
         let mut rng: rand::rngs::StdRng =
             seed.map_or_else(rand::make_rng, SeedableRng::seed_from_u64);
 
-        // 1. Maze
-        let (walls, mud) = match &self.maze {
-            MazeStrategy::Fixed { walls, mud } => (walls.clone(), mud.clone()),
+        // 1. Maze topology
+        let (move_table, mud) = match &self.maze {
+            MazeStrategy::Fixed { walls, mud } => {
+                let walls = walls.clone();
+                (
+                    MoveTable::new(self.width(), self.height(), &walls),
+                    mud.clone(),
+                )
+            },
             MazeStrategy::Random(params) => {
-                let maze_config = MazeConfig {
-                    width: self.width(),
-                    height: self.height(),
-                    target_density: params.wall_density,
-                    connected: params.connected,
-                    symmetry: params.symmetric,
-                    mud_density: params.mud_density,
-                    mud_range: params.mud_range,
-                    seed: Some(rng.random()),
-                };
-                MazeGenerator::new(maze_config).generate_owned()
+                // Preserve the parent RNG stream even when the topology is predetermined.
+                let maze_seed = rng.random();
+                if params.wall_density == 0.0 && params.mud_density == 0.0 {
+                    (MoveTable::open(self.width(), self.height()), MudMap::new())
+                } else {
+                    let maze_config = MazeConfig {
+                        width: self.width(),
+                        height: self.height(),
+                        target_density: params.wall_density,
+                        connected: params.connected,
+                        symmetry: params.symmetric,
+                        mud_density: params.mud_density,
+                        mud_range: params.mud_range,
+                        seed: Some(maze_seed),
+                    };
+                    let (walls, mud) = MazeGenerator::new(maze_config).generate_owned();
+                    (MoveTable::new(self.width(), self.height(), &walls), mud)
+                }
             },
         };
 
@@ -479,7 +492,7 @@ impl GameConfig {
         Ok(GameState::new_with_config(
             self.width(),
             self.height(),
-            walls,
+            move_table,
             mud,
             &cheese_positions,
             p1,
@@ -703,6 +716,56 @@ mod tests {
 
         assert_eq!(game1.player1_position(), game2.player1_position());
         assert_eq!(game1.player2_position(), game2.player2_position());
+    }
+
+    #[test]
+    fn open_seed_fixture_is_stable() {
+        let config = GameBuilder::new(7, 5)
+            .with_open_maze()
+            .with_random_positions()
+            .with_random_cheese(6, false)
+            .build();
+
+        let fixtures = [
+            (
+                0,
+                Coordinates::new(3, 3),
+                Coordinates::new(5, 0),
+                vec![
+                    Coordinates::new(4, 0),
+                    Coordinates::new(6, 0),
+                    Coordinates::new(5, 1),
+                    Coordinates::new(5, 2),
+                    Coordinates::new(6, 3),
+                    Coordinates::new(1, 4),
+                ],
+                0xAFFC_C2CF_9E1D_D84E,
+            ),
+            (
+                0xA11C_E5E5,
+                Coordinates::new(3, 1),
+                Coordinates::new(6, 3),
+                vec![
+                    Coordinates::new(5, 2),
+                    Coordinates::new(1, 3),
+                    Coordinates::new(2, 3),
+                    Coordinates::new(0, 4),
+                    Coordinates::new(5, 4),
+                    Coordinates::new(6, 4),
+                ],
+                0xF27C_E9D7_0E7F_1C76,
+            ),
+        ];
+
+        for (seed, player1, player2, cheese, state_hash) in fixtures {
+            let game = config.create(Some(seed)).unwrap();
+            assert!(game.wall_entries().is_empty(), "seed={seed:#x}");
+            assert!(game.mud_positions().is_empty(), "seed={seed:#x}");
+            assert_eq!(game.player1_position(), player1, "seed={seed:#x}");
+            assert_eq!(game.player2_position(), player2, "seed={seed:#x}");
+            assert_eq!(game.cheese_positions(), cheese, "seed={seed:#x}");
+            assert_eq!(game.state_hash(), state_hash, "seed={seed:#x}");
+        }
     }
 
     #[test]

--- a/engine/rust/src/game/game_logic.rs
+++ b/engine/rust/src/game/game_logic.rs
@@ -14,12 +14,12 @@
 //! - `MudMap` — HashMap lookup per move into a muddy passage;
 //!   this is the most expensive per-turn operation
 
-use crate::{CheeseBoard, Coordinates, Direction, MoveTable, Wall};
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-
 use crate::game::types::MudMap;
 use crate::game::zobrist;
+use crate::{CheeseBoard, Coordinates, Direction, MoveTable, Wall};
+use serde::{Deserialize, Serialize};
+#[cfg(test)]
+use std::collections::HashMap;
 
 /// Stores the state of a player including their movement status
 #[derive(Clone)]
@@ -94,77 +94,44 @@ impl GameState {
     pub const DEFAULT_WIDTH: u8 = 21;
     pub const DEFAULT_HEIGHT: u8 = 15;
     pub const DEFAULT_CHEESE_COUNT: u16 = 41;
-    #[must_use]
-    #[allow(clippy::needless_pass_by_value)] // We need to own the walls for MoveTable
-    pub(crate) fn new(
-        width: u8,
-        height: u8,
-        walls: HashMap<Coordinates, Vec<Coordinates>>,
-        max_turns: u16,
-    ) -> Self {
-        // Create move table for efficient move validation
-        let move_table = MoveTable::new(width, height, &walls);
-
-        // Initialize players at opposite corners
-        let player1 = PlayerState {
-            current_pos: Coordinates::new(0, 0), // Bottom left
-            mud_timer: 0,
-            score: 0.0,
-            misses: 0,
-        };
-
-        let player2 = PlayerState {
-            current_pos: Coordinates::new(width - 1, height - 1), // Top right
-            mud_timer: 0,
-            score: 0.0,
-            misses: 0,
-        };
-
-        Self {
-            width,
-            height,
-            move_table,
-            player1,
-            player2,
-            mud: MudMap::new(),
-            cheese: CheeseBoard::new(width, height),
-            turn: 0,
-            max_turns,
-            state_hash: 0, // Computed after full init in new_with_config
-        }
-    }
-
-    #[must_use]
-    pub(crate) fn new_with_positions(
-        width: u8,
-        height: u8,
-        walls: HashMap<Coordinates, Vec<Coordinates>>,
-        max_turns: u16,
-        player1_pos: Coordinates,
-        player2_pos: Coordinates,
-    ) -> Self {
-        let mut game = Self::new(width, height, walls, max_turns);
-        game.player1.current_pos = player1_pos;
-        game.player2.current_pos = player2_pos;
-        game
-    }
-
     #[allow(clippy::too_many_arguments)]
     #[must_use]
     pub(crate) fn new_with_config(
         width: u8,
         height: u8,
-        walls: HashMap<Coordinates, Vec<Coordinates>>,
+        move_table: MoveTable,
         mud: MudMap,
         cheese_positions: &[Coordinates],
         player1_pos: Coordinates,
         player2_pos: Coordinates,
         max_turns: u16,
     ) -> Self {
-        let mut game =
-            Self::new_with_positions(width, height, walls, max_turns, player1_pos, player2_pos);
+        let player1 = PlayerState {
+            current_pos: player1_pos,
+            mud_timer: 0,
+            score: 0.0,
+            misses: 0,
+        };
 
-        game.mud = mud;
+        let player2 = PlayerState {
+            current_pos: player2_pos,
+            mud_timer: 0,
+            score: 0.0,
+            misses: 0,
+        };
+
+        let mut game = Self {
+            width,
+            height,
+            move_table,
+            player1,
+            player2,
+            mud,
+            cheese: CheeseBoard::new(width, height),
+            turn: 0,
+            max_turns,
+            state_hash: 0,
+        };
 
         // Add cheese
         for &pos in cheese_positions {


### PR DESCRIPTION
## Motivation

An open maze has no walls or mud, so its topology is known before generation starts. The engine
still ran the complete random maze path: allocate construction state, sample every possible
passage, validate connectivity, materialize an empty wall map, and then compile the movement table.
That work produced the same open board every time.

## Solution

Random maze configurations with exactly zero wall density and zero mud density now build the packed
open movement table and empty mud map directly. `GameConfig::create` still consumes the parent
maze-seed draw before taking the shortcut, so random player positions, cheese placement, and later
RNG behavior remain unchanged. Other random mazes keep the existing generator and derived seed;
fixed mazes keep their existing wall-clone boundary.

`GameState` now receives its already compiled movement table during construction. This lets the
open path skip transient connection and wall representations without exposing a new public API.
Compatibility tests compare the direct packed masks with ordinary empty-wall compilation and pin
two seeds' walls, mud, starts, cheese, and initial state hashes.

Criterion measured four complete open-game creations per sample on the same host, comparing
`84cde00` with this branch:

| Board | Before | After | Speedup |
|---|---:|---:|---:|
| 11×9 | 60.187 µs | 2.153 µs | 28.0× |
| 15×13 | 118.020 µs | 2.928 µs | 40.3× |
| 21×15 | 199.430 µs | 3.957 µs | 50.4× |
| 31×21 | 411.360 µs | 6.347 µs | 64.8× |
| 41×31 | 809.500 µs | 11.325 µs | 71.5× |

All five reductions were statistically significant.

## Test Plan

- `cargo fmt --all -- --check`
- `cargo test -p pyrat-rust --lib --no-default-features` (118 passed)
- `cargo clippy -p pyrat-rust --all-targets --no-default-features -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings -A non-local-definitions`
- `uv run --directory engine pytest python/tests -q` (224 passed)
- `make bench-smoke`
- `git diff --check`
