### PR TITLE
perf(engine): make maze connectivity deterministic

### DIFF
--- a/engine/rust/src/game/builder.rs
+++ b/engine/rust/src/game/builder.rs
@@ -656,10 +656,36 @@ mod tests {
         let game1 = config.create(Some(42)).unwrap();
         let game2 = config.create(Some(42)).unwrap();
 
-        assert_eq!(
-            game1.cheese.get_all_cheese_positions(),
-            game2.cheese.get_all_cheese_positions()
-        );
+        let canonical_walls = |game: &GameState| {
+            let mut walls: Vec<_> = game
+                .wall_entries()
+                .into_iter()
+                .map(|wall| (wall.pos1, wall.pos2))
+                .collect();
+            walls.sort_unstable();
+            walls
+        };
+        let canonical_mud = |game: &GameState| {
+            let mut mud: Vec<_> = game
+                .mud_positions()
+                .iter()
+                .map(|((first, second), cost)| (first, second, cost))
+                .collect();
+            mud.sort_unstable();
+            mud
+        };
+        let canonical_cheese = |game: &GameState| {
+            let mut cheese = game.cheese_positions();
+            cheese.sort_unstable();
+            cheese
+        };
+
+        assert_eq!(canonical_walls(&game1), canonical_walls(&game2));
+        assert_eq!(canonical_mud(&game1), canonical_mud(&game2));
+        assert_eq!(game1.player1_position(), game2.player1_position());
+        assert_eq!(game1.player2_position(), game2.player2_position());
+        assert_eq!(canonical_cheese(&game1), canonical_cheese(&game2));
+        assert_eq!(game1.state_hash(), game2.state_hash());
     }
 
     #[test]

--- a/engine/rust/src/game/maze_generation.rs
+++ b/engine/rust/src/game/maze_generation.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::uninlined_format_args)]
 
 use crate::{Coordinates, Direction};
-use rand::prelude::IndexedRandom;
+use rand::prelude::{IndexedRandom, SliceRandom};
 use rand::RngExt;
 use std::collections::{HashMap, HashSet};
 
@@ -86,6 +86,132 @@ impl ConnectionGrid {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct Passage {
+    first: Coordinates,
+    second: Coordinates,
+}
+
+impl Passage {
+    fn new(first: Coordinates, second: Coordinates) -> Self {
+        debug_assert!(
+            Direction::between(first, second).is_some(),
+            "passage endpoints must be adjacent: {first:?} -> {second:?}"
+        );
+
+        if first <= second {
+            Self { first, second }
+        } else {
+            Self {
+                first: second,
+                second: first,
+            }
+        }
+    }
+
+    fn rotated(self, width: u8, height: u8) -> Self {
+        let rotate = |position: Coordinates| {
+            Coordinates::new(width - 1 - position.x, height - 1 - position.y)
+        };
+        Self::new(rotate(self.first), rotate(self.second))
+    }
+
+    fn indices(self, width: u8) -> (usize, usize) {
+        (self.first.to_index(width), self.second.to_index(width))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct PassageOrbit {
+    representative: Passage,
+    mate: Option<Passage>,
+}
+
+impl PassageOrbit {
+    const fn singleton(passage: Passage) -> Self {
+        Self {
+            representative: passage,
+            mate: None,
+        }
+    }
+
+    fn rotational(passage: Passage, width: u8, height: u8) -> Self {
+        let rotated = passage.rotated(width, height);
+        if passage == rotated {
+            Self::singleton(passage)
+        } else if passage < rotated {
+            Self {
+                representative: passage,
+                mate: Some(rotated),
+            }
+        } else {
+            Self {
+                representative: rotated,
+                mate: Some(passage),
+            }
+        }
+    }
+
+    fn passages(self) -> impl Iterator<Item = Passage> {
+        std::iter::once(self.representative).chain(self.mate)
+    }
+}
+
+/// Disjoint-set forest with path compression and union by rank.
+struct DisjointSet {
+    parent: Vec<usize>,
+    rank: Vec<u8>,
+    component_count: usize,
+}
+
+impl DisjointSet {
+    fn new(element_count: usize) -> Self {
+        Self {
+            parent: (0..element_count).collect(),
+            rank: vec![0; element_count],
+            component_count: element_count,
+        }
+    }
+
+    fn find(&mut self, element: usize) -> usize {
+        let mut root = element;
+        while self.parent[root] != root {
+            root = self.parent[root];
+        }
+
+        let mut current = element;
+        while current != root {
+            let parent = self.parent[current];
+            self.parent[current] = root;
+            current = parent;
+        }
+        root
+    }
+
+    fn same_component(&mut self, first: usize, second: usize) -> bool {
+        self.find(first) == self.find(second)
+    }
+
+    fn union(&mut self, first: usize, second: usize) -> bool {
+        let first_root = self.find(first);
+        let second_root = self.find(second);
+        if first_root == second_root {
+            return false;
+        }
+
+        match self.rank[first_root].cmp(&self.rank[second_root]) {
+            std::cmp::Ordering::Less => self.parent[first_root] = second_root,
+            std::cmp::Ordering::Greater => self.parent[second_root] = first_root,
+            std::cmp::Ordering::Equal => {
+                self.parent[second_root] = first_root;
+                self.rank[first_root] += 1;
+            },
+        }
+        self.component_count -= 1;
+        true
+    }
+}
+
 /// Configuration for maze generation
 #[derive(Debug, Clone, Copy)]
 pub struct MazeConfig {
@@ -139,7 +265,7 @@ impl MazeGenerator {
         self.generate_initial_layout();
 
         if self.config.connected {
-            self.ensure_full_connectivity();
+            self.repair_connectivity();
         }
 
         self.add_border_connections();
@@ -239,200 +365,98 @@ impl MazeGenerator {
         }
     }
 
-    /// Ensures the maze is fully connected by connecting all isolated regions
-    fn ensure_full_connectivity(&mut self) {
-        loop {
-            // Find all connected components
-            let mut visited = HashSet::new();
-            let mut components = Vec::new();
+    /// Connects all initial components with one seeded Kruskal-style orbit scan.
+    fn repair_connectivity(&mut self) {
+        let mut components = self.component_forest();
+        if components.component_count <= 1 {
+            return;
+        }
 
-            for x in 0..self.config.width {
-                for y in 0..self.config.height {
-                    let pos = Coordinates::new(x, y);
-                    if !visited.contains(&pos) {
-                        // Found a new component, explore it
-                        let mut component = HashSet::new();
-                        let mut stack = vec![pos];
+        let mut candidates = self.closed_repair_orbits();
+        candidates.shuffle(&mut self.rng);
 
-                        while let Some(current) = stack.pop() {
-                            if component.insert(current) {
-                                visited.insert(current);
-
-                                // Add all connected neighbors to stack
-                                for next in self.connections.neighbors(current) {
-                                    if !component.contains(&next) {
-                                        stack.push(next);
-                                    }
-                                }
-                            }
-                        }
-
-                        components.push(component);
-                    }
-                }
+        for orbit in candidates {
+            let crosses_components = orbit.passages().any(|passage| {
+                let (first, second) = passage.indices(self.config.width);
+                !components.same_component(first, second)
+            });
+            if !crosses_components {
+                continue;
             }
 
-            // If there's only one component, we're done
-            if components.len() <= 1 {
-                break;
+            self.open_passage_orbit(orbit);
+            for passage in orbit.passages() {
+                let (first, second) = passage.indices(self.config.width);
+                components.union(first, second);
             }
 
-            // Connect the first component to another component
-            let component1 = &components[0];
-            let component2 = &components[1];
-
-            // Find the closest pair of cells between the two components
-            let mut best_pair = None;
-            let mut min_distance = u32::MAX;
-
-            for &pos1 in component1 {
-                for &pos2 in component2 {
-                    // Check if they're adjacent
-                    let dx = (pos1.x as i32 - pos2.x as i32).unsigned_abs();
-                    let dy = (pos1.y as i32 - pos2.y as i32).unsigned_abs();
-
-                    if (dx == 1 && dy == 0) || (dx == 0 && dy == 1) {
-                        // They're adjacent, we can connect them directly
-                        best_pair = Some((pos1, pos2));
-                        min_distance = 1;
-                        break;
-                    }
-
-                    let distance = dx + dy;
-                    if distance < min_distance {
-                        min_distance = distance;
-                        best_pair = Some((pos1, pos2));
-                    }
-                }
-
-                if min_distance == 1 {
-                    break;
-                }
+            if components.component_count == 1 {
+                return;
             }
+        }
 
-            // Connect the two components
-            if let Some((from, to)) = best_pair {
-                if min_distance == 1 {
-                    // They're adjacent, connect directly
-                    self.add_passage(from, to);
+        debug_assert_eq!(
+            components.component_count, 1,
+            "all grid-edge orbits were exhausted before the maze became connected"
+        );
+    }
 
-                    if self.config.symmetry {
-                        let sym_from = self.get_symmetric(from);
-                        let sym_to = self.get_symmetric(to);
-                        self.add_passage(sym_from, sym_to);
+    fn component_forest(&self) -> DisjointSet {
+        let mut components =
+            DisjointSet::new(usize::from(self.config.width) * usize::from(self.config.height));
+
+        for x in 0..self.config.width {
+            for y in 0..self.config.height {
+                let current = Coordinates::new(x, y);
+                for adjacent in [
+                    (x + 1 < self.config.width).then(|| Coordinates::new(x + 1, y)),
+                    (y + 1 < self.config.height).then(|| Coordinates::new(x, y + 1)),
+                ]
+                .into_iter()
+                .flatten()
+                {
+                    if self.has_connection(current, adjacent) {
+                        components.union(
+                            current.to_index(self.config.width),
+                            adjacent.to_index(self.config.width),
+                        );
                     }
-                } else {
-                    // They're not adjacent, we need to find a path
-                    // For simplicity, just ensure the old algorithm runs
-                    self.ensure_connectivity();
                 }
             }
         }
+
+        components
     }
 
-    /// Ensures the maze is fully connected using a modified DFS algorithm
-    fn ensure_connectivity(&mut self) {
-        let mut connected =
-            vec![vec![false; self.config.height as usize]; self.config.width as usize];
-        let mut possible_border = Vec::new();
-
-        // Start from top-left corner (0,0)
-        let start = Coordinates::new(0, 0);
-        connected[0][0] = true;
-        possible_border.push(start);
-
-        self.connect_region(&mut connected, &mut possible_border);
-    }
-
-    /// Recursively connects regions of the maze using DFS
-    fn connect_region(
-        &mut self,
-        connected: &mut [Vec<bool>],
-        possible_border: &mut Vec<Coordinates>,
-    ) {
-        while !possible_border.is_empty() {
-            let mut border = Vec::new();
-            let mut new_possible_border = Vec::new();
-
-            // Match Python's border creation exactly
-            for &current in possible_border.iter() {
-                let mut is_candidate = false;
-                let x = current.x as usize;
-                let y = current.y as usize;
-
-                // Check each direction exactly as Python does
-                if current.x + 1 < self.config.width
-                    && !self.has_connection(current, Coordinates::new(current.x + 1, current.y))
-                    && !connected[(current.x + 1) as usize][y]
+    fn closed_repair_orbits(&self) -> Vec<PassageOrbit> {
+        let mut candidates = Vec::new();
+        for x in 0..self.config.width {
+            for y in 0..self.config.height {
+                let current = Coordinates::new(x, y);
+                for adjacent in [
+                    (x + 1 < self.config.width).then(|| Coordinates::new(x + 1, y)),
+                    (y + 1 < self.config.height).then(|| Coordinates::new(x, y + 1)),
+                ]
+                .into_iter()
+                .flatten()
                 {
-                    border.push((current, Coordinates::new(current.x + 1, current.y)));
-                    is_candidate = true;
-                }
-                if current.x > 0
-                    && !self.has_connection(current, Coordinates::new(current.x - 1, current.y))
-                    && !connected[(current.x - 1) as usize][y]
-                {
-                    border.push((current, Coordinates::new(current.x - 1, current.y)));
-                    is_candidate = true;
-                }
-                if current.y + 1 < self.config.height
-                    && !self.has_connection(current, Coordinates::new(current.x, current.y + 1))
-                    && !connected[x][(current.y + 1) as usize]
-                {
-                    border.push((current, Coordinates::new(current.x, current.y + 1)));
-                    is_candidate = true;
-                }
-                if current.y > 0
-                    && !self.has_connection(current, Coordinates::new(current.x, current.y - 1))
-                    && !connected[x][(current.y - 1) as usize]
-                {
-                    border.push((current, Coordinates::new(current.x, current.y - 1)));
-                    is_candidate = true;
-                }
+                    if self.has_connection(current, adjacent) {
+                        continue;
+                    }
 
-                if is_candidate {
-                    new_possible_border.push(current);
+                    let passage = Passage::new(current, adjacent);
+                    let orbit = if self.config.symmetry {
+                        PassageOrbit::rotational(passage, self.config.width, self.config.height)
+                    } else {
+                        PassageOrbit::singleton(passage)
+                    };
+                    if !self.config.symmetry || orbit.representative == passage {
+                        candidates.push(orbit);
+                    }
                 }
             }
-
-            if border.is_empty() {
-                break;
-            }
-
-            // Select random border exactly as Python
-            let idx = self.rng.random_range(0..border.len());
-            let (from, to) = border[idx];
-
-            // Generate mud exactly as Python
-            let mud_value = if self.rng.random::<f32>() < self.config.mud_density {
-                self.rng.random_range(2..=self.config.mud_range)
-            } else {
-                1
-            };
-
-            // Add connections
-            self.connections.connect(from, to);
-
-            if mud_value > 1 {
-                self.mud.insert(from, to, mud_value);
-            }
-
-            // Handle symmetry exactly as Python
-            if self.config.symmetry {
-                let sym_from = self.get_symmetric(from);
-                let sym_to = self.get_symmetric(to);
-
-                self.connections.connect(sym_from, sym_to);
-
-                if mud_value > 1 {
-                    self.mud.insert(sym_from, sym_to, mud_value);
-                }
-            }
-
-            connected[to.x as usize][to.y as usize] = true;
-            possible_border.push(to);
-            *possible_border = new_possible_border;
         }
+        candidates
     }
     #[inline]
     fn has_connection(&self, from: Coordinates, to: Coordinates) -> bool {
@@ -447,37 +471,30 @@ impl MazeGenerator {
                 if self.is_border_cell(current) && !self.has_any_connection(current) {
                     let neighbors = self.get_valid_neighbors(current);
                     if let Some(&neighbor) = neighbors.choose(&mut self.rng) {
-                        self.add_passage(current, neighbor);
-
-                        if self.config.symmetry {
-                            let sym_current = self.get_symmetric(current);
-                            let sym_neighbor = self.get_symmetric(neighbor);
-                            self.add_passage(sym_current, sym_neighbor);
-                        }
+                        let passage = Passage::new(current, neighbor);
+                        let orbit = if self.config.symmetry {
+                            PassageOrbit::rotational(passage, self.config.width, self.config.height)
+                        } else {
+                            PassageOrbit::singleton(passage)
+                        };
+                        self.open_passage_orbit(orbit);
                     }
                 }
             }
         }
     }
 
-    /// Adds a passage between two cells with optional mud
+    /// Opens one logical repair orbit and performs one shared mud trial.
     #[inline(always)]
-    fn add_passage(&mut self, from: Coordinates, to: Coordinates) {
-        // First add the walls bidirectionally
-        self.connections.connect(from, to);
+    fn open_passage_orbit(&mut self, orbit: PassageOrbit) {
+        for passage in orbit.passages() {
+            self.connections.connect(passage.first, passage.second);
+        }
 
-        // Then handle mud if needed
         if self.rng.random::<f32>() < self.config.mud_density {
             let mud_value = self.rng.random_range(2..=self.config.mud_range);
-
-            // MudMap stores both orientations for the passage.
-            self.mud.insert(from, to, mud_value);
-
-            // If symmetric, add mud for the symmetric passage
-            if self.config.symmetry {
-                let sym_from = self.get_symmetric(from);
-                let sym_to = self.get_symmetric(to);
-                self.mud.insert(sym_from, sym_to, mud_value);
+            for passage in orbit.passages() {
+                self.mud.insert(passage.first, passage.second, mud_value);
             }
         }
     }
@@ -1048,29 +1065,92 @@ mod tests {
         assert!(!grid.has_any(Coordinates::new(3, 0)));
     }
 
+    const DISCONNECTED_LEGACY_CASES: [(u8, u8, f32, bool, f32, u8); 6] = [
+        (1, 1, 1.0, false, 0.0, 2),
+        (2, 1, 1.0, true, 1.0, 4),
+        (4, 3, 0.35, false, 0.65, 4),
+        (5, 4, 0.55, true, 0.35, 5),
+        (4, 5, 0.0, true, 0.0, 2),
+        (6, 4, 1.0, true, 0.5, 3),
+    ];
+
+    fn disconnected_config(
+        width: u8,
+        height: u8,
+        target_density: f32,
+        symmetry: bool,
+        mud_density: f32,
+        mud_range: u8,
+        seed: u64,
+    ) -> MazeConfig {
+        MazeConfig {
+            width,
+            height,
+            target_density,
+            connected: false,
+            symmetry,
+            mud_density,
+            mud_range,
+            seed: Some(seed),
+        }
+    }
+
     #[test]
-    fn disconnected_generation_matches_legacy_hash_backed_path() {
+    fn disconnected_initial_layout_matches_legacy_hash_backed_path() {
+        for (width, height, target_density, symmetry, mud_density, mud_range) in
+            DISCONNECTED_LEGACY_CASES
+        {
+            for seed in [0, 1, 42, u64::MAX] {
+                let config = disconnected_config(
+                    width,
+                    height,
+                    target_density,
+                    symmetry,
+                    mud_density,
+                    mud_range,
+                    seed,
+                );
+                let mut dense = MazeGenerator::new(config);
+                let mut legacy = LegacyDisconnectedMazeGenerator::new(config);
+
+                for generation in 1..=2 {
+                    dense.generate_initial_layout();
+                    legacy.generate_initial_layout();
+                    assert_eq!(
+                        dense.connections_to_walls(),
+                        legacy.connections_to_walls(),
+                        "initial wall mismatch for {width}x{height}, symmetry={symmetry}, seed={seed}, generation={generation}"
+                    );
+                    assert_eq!(
+                        sorted_mud_entries(&dense.mud),
+                        sorted_mud_entries(&legacy.mud),
+                        "initial mud mismatch for {width}x{height}, symmetry={symmetry}, seed={seed}, generation={generation}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn unaffected_disconnected_generation_matches_legacy_hash_backed_path() {
         let cases = [
             (1, 1, 1.0, false, 0.0, 2),
-            (2, 1, 1.0, true, 1.0, 4),
             (4, 3, 0.35, false, 0.65, 4),
-            (5, 4, 0.55, true, 0.35, 5),
+            (6, 4, 1.0, false, 0.5, 3),
             (4, 5, 0.0, true, 0.0, 2),
-            (6, 4, 1.0, true, 0.5, 3),
         ];
 
         for (width, height, target_density, symmetry, mud_density, mud_range) in cases {
             for seed in [0, 1, 42, u64::MAX] {
-                let config = MazeConfig {
+                let config = disconnected_config(
                     width,
                     height,
                     target_density,
-                    connected: false,
                     symmetry,
                     mud_density,
                     mud_range,
-                    seed: Some(seed),
-                };
+                    seed,
+                );
                 let mut dense = MazeGenerator::new(config);
                 let mut legacy = LegacyDisconnectedMazeGenerator::new(config);
 
@@ -1088,6 +1168,116 @@ mod tests {
                     );
                 }
             }
+        }
+    }
+
+    #[test]
+    fn passage_orbits_respect_symmetry_mode_and_board_parity() {
+        let ordinary = Passage::new(Coordinates::new(0, 0), Coordinates::new(1, 0));
+        assert_eq!(
+            PassageOrbit::singleton(ordinary),
+            PassageOrbit {
+                representative: ordinary,
+                mate: None,
+            }
+        );
+
+        let paired = PassageOrbit::rotational(ordinary, 4, 3);
+        assert_eq!(paired.representative, ordinary);
+        assert_eq!(
+            paired.mate,
+            Some(Passage::new(Coordinates::new(2, 2), Coordinates::new(3, 2)))
+        );
+
+        let horizontal_center = Passage::new(Coordinates::new(1, 1), Coordinates::new(2, 1));
+        assert_eq!(
+            PassageOrbit::rotational(horizontal_center, 4, 3),
+            PassageOrbit::singleton(horizontal_center)
+        );
+
+        let vertical_center = Passage::new(Coordinates::new(1, 1), Coordinates::new(1, 2));
+        assert_eq!(
+            PassageOrbit::rotational(vertical_center, 3, 4),
+            PassageOrbit::singleton(vertical_center)
+        );
+    }
+
+    #[test]
+    fn closed_repair_orbits_are_stable_and_unique() {
+        let symmetric_config = MazeConfig {
+            width: 4,
+            height: 3,
+            target_density: 1.0,
+            connected: true,
+            symmetry: true,
+            mud_density: 0.0,
+            mud_range: 2,
+            seed: Some(0),
+        };
+        let symmetric = MazeGenerator::new(symmetric_config).closed_repair_orbits();
+        assert_eq!(symmetric.len(), 9);
+        assert_eq!(
+            symmetric
+                .iter()
+                .map(|orbit| orbit.representative)
+                .collect::<HashSet<_>>()
+                .len(),
+            symmetric.len()
+        );
+        assert_eq!(
+            symmetric
+                .iter()
+                .filter(|orbit| orbit.mate.is_none())
+                .count(),
+            1
+        );
+
+        let asymmetric = MazeGenerator::new(MazeConfig {
+            symmetry: false,
+            ..symmetric_config
+        })
+        .closed_repair_orbits();
+        assert_eq!(asymmetric.len(), 17);
+        assert!(asymmetric.iter().all(|orbit| orbit.mate.is_none()));
+    }
+
+    #[test]
+    fn mirrored_orbit_opens_atomically_when_its_mate_becomes_redundant() {
+        let config = MazeConfig {
+            width: 4,
+            height: 3,
+            target_density: 1.0,
+            connected: true,
+            symmetry: true,
+            mud_density: 1.0,
+            mud_range: 4,
+            seed: Some(7),
+        };
+        let passage = Passage::new(Coordinates::new(0, 0), Coordinates::new(1, 0));
+        let orbit = PassageOrbit::rotational(passage, config.width, config.height);
+        let mate = orbit.mate.expect("ordinary passage has a distinct mirror");
+        let mut components = DisjointSet::new(usize::from(config.width * config.height));
+        components.union(
+            passage.first.to_index(config.width),
+            mate.first.to_index(config.width),
+        );
+        components.union(
+            passage.second.to_index(config.width),
+            mate.second.to_index(config.width),
+        );
+        let (first, second) = passage.indices(config.width);
+        assert!(components.union(first, second));
+        let (first, second) = mate.indices(config.width);
+        assert!(!components.union(first, second));
+
+        let mut generator = MazeGenerator::new(config);
+        generator.open_passage_orbit(orbit);
+        for edge in orbit.passages() {
+            assert!(generator.connections.contains(edge.first, edge.second));
+            assert_eq!(
+                generator.mud.get(edge.first, edge.second),
+                generator.mud.get(passage.first, passage.second)
+            );
         }
     }
 
@@ -1182,25 +1372,37 @@ mod tests {
 
     #[test]
     fn connected_generation_preserves_grid_and_mud_invariants() {
-        for (width, height, symmetry) in [(3, 3, false), (4, 3, false), (5, 4, true), (4, 5, true)]
-        {
+        let mut generated = 0;
+        for (width, height, symmetry) in [
+            (3, 3, false),
+            (4, 3, false),
+            (5, 4, true),
+            (4, 5, true),
+            (4, 3, true),
+            (3, 4, true),
+            (4, 4, true),
+        ] {
             for target_density in [0.0, 0.7, 1.0] {
-                for seed in 0..4 {
-                    let config = MazeConfig {
-                        width,
-                        height,
-                        target_density,
-                        connected: true,
-                        symmetry,
-                        mud_density: 0.55,
-                        mud_range: 4,
-                        seed: Some(seed),
-                    };
-                    let (walls, mud) = MazeGenerator::new(config).generate_owned();
-                    assert_connected_generation_invariants(config, &walls, &mud);
+                for mud_density in [0.0, 0.55, 1.0] {
+                    for seed in 0..32 {
+                        let config = MazeConfig {
+                            width,
+                            height,
+                            target_density,
+                            connected: true,
+                            symmetry,
+                            mud_density,
+                            mud_range: 4,
+                            seed: Some(seed),
+                        };
+                        let (walls, mud) = MazeGenerator::new(config).generate_owned();
+                        assert_connected_generation_invariants(config, &walls, &mud);
+                        generated += 1;
+                    }
                 }
             }
         }
+        assert_eq!(generated, 2_016);
     }
 
     #[test]
@@ -1664,3 +1866,7 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "maze_generation_distribution_tests.rs"]
+mod distribution_tests;

--- a/engine/rust/src/game/maze_generation_distribution_tests.rs
+++ b/engine/rust/src/game/maze_generation_distribution_tests.rs
@@ -1,0 +1,688 @@
+use super::*;
+use crate::{GameBuilder, GameState, MazeParams};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::fmt::Write as _;
+use std::process::Command;
+
+const REPORT_PREFIX: &str = "PYRAT_PR9_REPORT";
+const TOPOLOGY_PREFIX: &str = "PYRAT_PR9_TOPOLOGY";
+const REPORT_PROCESSES: usize = 8;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Edge {
+    first: Coordinates,
+    second: Coordinates,
+}
+
+impl Edge {
+    fn new(first: Coordinates, second: Coordinates) -> Self {
+        if first <= second {
+            Self { first, second }
+        } else {
+            Self {
+                first: second,
+                second: first,
+            }
+        }
+    }
+
+    fn is_horizontal(self) -> bool {
+        self.first.y == self.second.y
+    }
+}
+
+struct GeneratedSample {
+    config: MazeConfig,
+    initial_passages: BTreeSet<Edge>,
+    final_passages: BTreeSet<Edge>,
+    mud: BTreeMap<Edge, u8>,
+}
+
+impl GeneratedSample {
+    fn repair_edges(&self) -> impl Iterator<Item = Edge> + '_ {
+        self.final_passages
+            .difference(&self.initial_passages)
+            .copied()
+    }
+
+    fn repair_orbit_key(&self, edge: Edge) -> Edge {
+        if !self.config.symmetry {
+            return edge;
+        }
+
+        let mirror = Edge::new(
+            symmetric(self.config, edge.first),
+            symmetric(self.config, edge.second),
+        );
+        edge.min(mirror)
+    }
+
+    fn topology_bytes(&self) -> Vec<u8> {
+        let passage_count =
+            u32::try_from(self.final_passages.len()).expect("diagnostic passage count fits in u32");
+        let mut bytes = Vec::with_capacity(6 + self.final_passages.len() * 4);
+
+        bytes.extend([self.config.width, self.config.height]);
+        bytes.extend(passage_count.to_le_bytes());
+        for edge in &self.final_passages {
+            bytes.extend([edge.first.x, edge.first.y, edge.second.x, edge.second.y]);
+        }
+
+        bytes
+    }
+
+    fn canonical_bytes(&self) -> Vec<u8> {
+        let mud_count = u32::try_from(self.mud.len()).expect("diagnostic mud count fits in u32");
+        let mut bytes = self.topology_bytes();
+        bytes.reserve(4 + self.mud.len() * 5);
+        bytes.extend(mud_count.to_le_bytes());
+        for (edge, cost) in &self.mud {
+            bytes.extend([
+                edge.first.x,
+                edge.first.y,
+                edge.second.x,
+                edge.second.y,
+                *cost,
+            ]);
+        }
+
+        bytes
+    }
+}
+
+#[derive(Default)]
+struct CorpusSummary {
+    seeds: usize,
+    topology_bytes: BTreeSet<Vec<u8>>,
+    topology_digest: u64,
+    full_digest: u64,
+    passages: u64,
+    cycle_rank: u64,
+    repair_edges: u64,
+    repair_orbits: u64,
+    muddy_repair_orbits: u64,
+    horizontal_candidates: u64,
+    horizontal_repairs: u64,
+    vertical_candidates: u64,
+    vertical_repairs: u64,
+    dead_ends: u64,
+    junctions: u64,
+    corner_distance: u64,
+    spatial_candidates: [u64; 16],
+    spatial_repairs: [u64; 16],
+}
+
+impl CorpusSummary {
+    fn add(&mut self, sample: &GeneratedSample) {
+        let topology_bytes = sample.topology_bytes();
+        self.topology_digest = fnv1a(self.topology_digest, &topology_bytes);
+        self.topology_bytes.insert(topology_bytes);
+        self.full_digest = fnv1a(self.full_digest, &sample.canonical_bytes());
+        self.seeds += 1;
+
+        let cell_count = usize::from(sample.config.width) * usize::from(sample.config.height);
+        self.passages += sample.final_passages.len() as u64;
+        self.cycle_rank += (sample.final_passages.len() + 1 - cell_count) as u64;
+
+        let repair_edges: Vec<_> = sample.repair_edges().collect();
+        let repair_orbits: BTreeSet<_> = repair_edges
+            .iter()
+            .map(|&edge| sample.repair_orbit_key(edge))
+            .collect();
+        let muddy_repair_orbits: BTreeSet<_> = repair_edges
+            .iter()
+            .filter(|edge| sample.mud.contains_key(edge))
+            .map(|&edge| sample.repair_orbit_key(edge))
+            .collect();
+        let candidate_orbits: BTreeSet<_> = all_grid_edges(sample.config)
+            .filter(|edge| !sample.initial_passages.contains(edge))
+            .map(|edge| sample.repair_orbit_key(edge))
+            .collect();
+
+        self.repair_edges += repair_edges.len() as u64;
+        self.repair_orbits += repair_orbits.len() as u64;
+        self.muddy_repair_orbits += muddy_repair_orbits.len() as u64;
+
+        for edge in candidate_orbits {
+            if edge.is_horizontal() {
+                self.horizontal_candidates += 1;
+            } else {
+                self.vertical_candidates += 1;
+            }
+            self.spatial_candidates[folded_spatial_bucket(sample.config, edge)] += 1;
+        }
+        for edge in repair_orbits.iter().copied() {
+            if edge.is_horizontal() {
+                self.horizontal_repairs += 1;
+            } else {
+                self.vertical_repairs += 1;
+            }
+            self.spatial_repairs[folded_spatial_bucket(sample.config, edge)] += 1;
+        }
+
+        let (dead_ends, junctions) = degree_counts(sample);
+        self.dead_ends += dead_ends as u64;
+        self.junctions += junctions as u64;
+        self.corner_distance += corner_distance(sample) as u64;
+    }
+
+    fn report(&self, name: &str) -> String {
+        let seeds = self.seeds as f64;
+        let horizontal_rate = ratio(self.horizontal_repairs, self.horizontal_candidates);
+        let vertical_rate = ratio(self.vertical_repairs, self.vertical_candidates);
+        let spatial_rates = self
+            .spatial_repairs
+            .iter()
+            .zip(self.spatial_candidates.iter())
+            .map(|(&repairs, &candidates)| {
+                if candidates == 0 {
+                    "-".to_owned()
+                } else {
+                    format!("{:.5}", ratio(repairs, candidates))
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+
+        format!(
+            "{REPORT_PREFIX}\t{name}\tseeds={}\tunique_topologies={}\ttopology_digest={:016x}\tfull_digest={:016x}\tpassages_mean={:.5}\tcycle_mean={:.5}\trepair_edges_mean={:.5}\trepair_orbits_mean={:.5}\tmud_orbit_rate={:.6}\thorizontal_rate={horizontal_rate:.6}\tvertical_rate={vertical_rate:.6}\tdead_ends_mean={:.5}\tjunctions_mean={:.5}\tcorner_distance_mean={:.5}\tspatial_rates={spatial_rates}",
+            self.seeds,
+            self.topology_bytes.len(),
+            self.topology_digest,
+            self.full_digest,
+            self.passages as f64 / seeds,
+            self.cycle_rank as f64 / seeds,
+            self.repair_edges as f64 / seeds,
+            self.repair_orbits as f64 / seeds,
+            ratio(self.muddy_repair_orbits, self.repair_orbits),
+            self.dead_ends as f64 / seeds,
+            self.junctions as f64 / seeds,
+            self.corner_distance as f64 / seeds,
+        )
+    }
+}
+
+fn classic_config(width: u8, height: u8, seed: u64) -> MazeConfig {
+    MazeConfig {
+        width,
+        height,
+        target_density: 0.7,
+        connected: true,
+        symmetry: true,
+        mud_density: 0.1,
+        mud_range: 3,
+        seed: Some(seed),
+    }
+}
+
+fn generate_sample(config: MazeConfig) -> GeneratedSample {
+    let mut generator = MazeGenerator::new(config);
+    generator.generate_initial_layout();
+    let initial_passages = connection_edges(&generator.connections);
+
+    if config.connected {
+        generator.repair_connectivity();
+    }
+    generator.add_border_connections();
+    generator
+        .validate_output()
+        .expect("diagnostic generation must satisfy maze invariants");
+
+    GeneratedSample {
+        config,
+        initial_passages,
+        final_passages: connection_edges(&generator.connections),
+        mud: generator
+            .mud
+            .iter()
+            .map(|((first, second), cost)| (Edge::new(first, second), cost))
+            .collect(),
+    }
+}
+
+fn connection_edges(connections: &ConnectionGrid) -> BTreeSet<Edge> {
+    let config = MazeConfig {
+        width: connections.width,
+        height: connections.height,
+        target_density: 0.0,
+        connected: false,
+        symmetry: false,
+        mud_density: 0.0,
+        mud_range: 2,
+        seed: None,
+    };
+    all_grid_edges(config)
+        .filter(|edge| connections.contains(edge.first, edge.second))
+        .collect()
+}
+
+fn all_grid_edges(config: MazeConfig) -> impl Iterator<Item = Edge> {
+    (0..config.width).flat_map(move |x| {
+        (0..config.height).flat_map(move |y| {
+            let current = Coordinates::new(x, y);
+            let right =
+                (x + 1 < config.width).then(|| Edge::new(current, Coordinates::new(x + 1, y)));
+            let up =
+                (y + 1 < config.height).then(|| Edge::new(current, Coordinates::new(x, y + 1)));
+            right.into_iter().chain(up)
+        })
+    })
+}
+
+fn symmetric(config: MazeConfig, position: Coordinates) -> Coordinates {
+    Coordinates::new(
+        config.width - 1 - position.x,
+        config.height - 1 - position.y,
+    )
+}
+
+fn folded_spatial_bucket(config: MazeConfig, edge: Edge) -> usize {
+    debug_assert_eq!(edge, generate_orbit_key(config, edge));
+    let x_sum = usize::from(edge.first.x) + usize::from(edge.second.x);
+    let y_sum = usize::from(edge.first.y) + usize::from(edge.second.y);
+    let x_bucket = (x_sum * 4 / (usize::from(config.width) * 2)).min(3);
+    let y_bucket = (y_sum * 4 / (usize::from(config.height) * 2)).min(3);
+    y_bucket * 4 + x_bucket
+}
+
+fn generate_orbit_key(config: MazeConfig, edge: Edge) -> Edge {
+    if !config.symmetry {
+        return edge;
+    }
+    let mirror = Edge::new(
+        symmetric(config, edge.first),
+        symmetric(config, edge.second),
+    );
+    edge.min(mirror)
+}
+
+fn degree_counts(sample: &GeneratedSample) -> (usize, usize) {
+    let mut dead_ends = 0;
+    let mut junctions = 0;
+    for x in 0..sample.config.width {
+        for y in 0..sample.config.height {
+            let position = Coordinates::new(x, y);
+            let degree = Direction::CARDINALS
+                .into_iter()
+                .map(|direction| direction.apply_to(position))
+                .filter(|&neighbor| {
+                    neighbor != position
+                        && neighbor.x < sample.config.width
+                        && neighbor.y < sample.config.height
+                        && sample
+                            .final_passages
+                            .contains(&Edge::new(position, neighbor))
+                })
+                .count();
+            dead_ends += usize::from(degree == 1);
+            junctions += usize::from(degree >= 3);
+        }
+    }
+    (dead_ends, junctions)
+}
+
+fn corner_distance(sample: &GeneratedSample) -> usize {
+    let width = sample.config.width;
+    let height = sample.config.height;
+    let start = Coordinates::new(0, 0);
+    let target = Coordinates::new(width - 1, height - 1);
+    let mut distances = vec![usize::MAX; usize::from(width) * usize::from(height)];
+    let mut queue = VecDeque::from([start]);
+    distances[start.to_index(width)] = 0;
+
+    while let Some(position) = queue.pop_front() {
+        if position == target {
+            return distances[position.to_index(width)];
+        }
+        let distance = distances[position.to_index(width)] + 1;
+        for direction in Direction::CARDINALS {
+            let neighbor = direction.apply_to(position);
+            if neighbor == position
+                || neighbor.x >= width
+                || neighbor.y >= height
+                || !sample
+                    .final_passages
+                    .contains(&Edge::new(position, neighbor))
+            {
+                continue;
+            }
+            let index = neighbor.to_index(width);
+            if distances[index] == usize::MAX {
+                distances[index] = distance;
+                queue.push_back(neighbor);
+            }
+        }
+    }
+
+    panic!("connected diagnostic maze has no corner-to-corner path")
+}
+
+fn fnv1a(previous: u64, bytes: &[u8]) -> u64 {
+    let mut hash = if previous == 0 {
+        0xcbf2_9ce4_8422_2325
+    } else {
+        previous
+    };
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+fn ratio(numerator: u64, denominator: u64) -> f64 {
+    numerator as f64 / denominator as f64
+}
+
+fn hex_bytes(bytes: &[u8]) -> String {
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(output, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    output
+}
+
+fn full_game_bytes(game: &GameState) -> Vec<u8> {
+    let mut walls: Vec<_> = game
+        .wall_entries()
+        .into_iter()
+        .map(|wall| Edge::new(wall.pos1, wall.pos2))
+        .collect();
+    walls.sort_unstable();
+    walls.dedup();
+    let mud: BTreeMap<_, _> = game
+        .mud_positions()
+        .iter()
+        .map(|((first, second), cost)| (Edge::new(first, second), cost))
+        .collect();
+    let mut cheese = game.cheese_positions();
+    cheese.sort_unstable();
+
+    let mut bytes = Vec::new();
+    bytes.extend([game.width(), game.height()]);
+    bytes.extend(
+        u32::try_from(walls.len())
+            .expect("diagnostic wall count fits u32")
+            .to_le_bytes(),
+    );
+    for wall in walls {
+        bytes.extend([wall.first.x, wall.first.y, wall.second.x, wall.second.y]);
+    }
+    bytes.extend(
+        u32::try_from(mud.len())
+            .expect("diagnostic mud count fits u32")
+            .to_le_bytes(),
+    );
+    for (edge, cost) in mud {
+        bytes.extend([
+            edge.first.x,
+            edge.first.y,
+            edge.second.x,
+            edge.second.y,
+            cost,
+        ]);
+    }
+    let player1 = game.player1_position();
+    let player2 = game.player2_position();
+    bytes.extend([player1.x, player1.y, player2.x, player2.y]);
+    bytes.extend(
+        u32::try_from(cheese.len())
+            .expect("diagnostic cheese count fits u32")
+            .to_le_bytes(),
+    );
+    for position in cheese {
+        bytes.extend([position.x, position.y]);
+    }
+    bytes.extend(game.state_hash().to_le_bytes());
+    bytes
+}
+
+fn topology_probe_games() -> Vec<(&'static str, GameState)> {
+    let symmetric = GameBuilder::new(11, 9)
+        .with_random_maze(MazeParams::classic())
+        .with_random_positions()
+        .with_random_cheese(12, true)
+        .build()
+        .create(Some(0xA11C_E5E5))
+        .expect("symmetric probe game must build");
+    let asymmetric = GameBuilder::new(10, 8)
+        .with_random_maze(MazeParams {
+            symmetric: false,
+            ..MazeParams::classic()
+        })
+        .with_random_positions()
+        .with_random_cheese(10, false)
+        .build()
+        .create(Some(0xA5A5_5A5A))
+        .expect("asymmetric probe game must build");
+    let singleton_orbit = GameBuilder::new(4, 3)
+        .with_random_maze(MazeParams {
+            wall_density: 1.0,
+            mud_density: 1.0,
+            mud_range: 4,
+            ..MazeParams::classic()
+        })
+        .with_random_positions()
+        .with_random_cheese(4, true)
+        .build()
+        .create(Some(0x51A6_1E70))
+        .expect("singleton-orbit probe game must build");
+
+    vec![
+        ("symmetric", symmetric),
+        ("asymmetric", asymmetric),
+        ("singleton", singleton_orbit),
+    ]
+}
+
+fn summarize_classic(width: u8, height: u8, seed_count: u64) -> CorpusSummary {
+    let mut summary = CorpusSummary::default();
+    for seed in 0..seed_count {
+        summary.add(&generate_sample(classic_config(width, height, seed)));
+    }
+    summary
+}
+
+fn report_corpus() -> Vec<String> {
+    [("medium", 21, 15, 256), ("huge", 41, 31, 64)]
+        .into_iter()
+        .map(|(name, width, height, seed_count)| {
+            summarize_classic(width, height, seed_count).report(name)
+        })
+        .collect()
+}
+
+fn run_probe_process(profile: &str) -> Vec<String> {
+    let output = Command::new(std::env::current_exe().expect("test binary path must be available"))
+        .args([
+            "--exact",
+            "game::maze_generation::distribution_tests::pr9_probe_child",
+            "--ignored",
+            "--nocapture",
+            "--test-threads=1",
+        ])
+        .env("PYRAT_PR9_PROFILE", profile)
+        .output()
+        .expect("maze probe child process must launch");
+    assert!(
+        output.status.success(),
+        "maze probe child failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    String::from_utf8(output.stdout)
+        .expect("probe output must be UTF-8")
+        .lines()
+        .filter_map(|line| {
+            line.find(REPORT_PREFIX)
+                .or_else(|| line.find(TOPOLOGY_PREFIX))
+                .map(|start| line[start..].to_owned())
+        })
+        .collect()
+}
+
+#[test]
+#[ignore = "manual multi-process distribution evidence"]
+fn pr9_distribution_report() {
+    for process in 0..REPORT_PROCESSES {
+        let rows = run_probe_process("report");
+        assert_eq!(rows.len(), 2, "each report process emits medium and huge");
+        for row in rows {
+            println!("{row}\tprocess={process}");
+        }
+    }
+}
+
+#[test]
+fn connected_generation_is_cross_process_deterministic() {
+    let first = run_probe_process("topology");
+    assert_eq!(first.len(), 3, "the child emits all topology scenarios");
+    for _ in 0..2 {
+        assert_eq!(run_probe_process("topology"), first);
+    }
+}
+
+#[test]
+fn connected_generation_is_same_process_deterministic() {
+    let expected: Vec<_> = topology_probe_games()
+        .into_iter()
+        .map(|(name, game)| (name, full_game_bytes(&game)))
+        .collect();
+    for _ in 0..8 {
+        let actual: Vec<_> = topology_probe_games()
+            .into_iter()
+            .map(|(name, game)| (name, full_game_bytes(&game)))
+            .collect();
+        assert_eq!(actual, expected);
+    }
+}
+
+#[test]
+fn repair_distribution_guardrails() {
+    let summary = summarize_classic(21, 15, 128);
+    assert!(summary.topology_bytes.len() >= 126);
+
+    let seed_count = summary.seeds as f64;
+    let passage_mean = summary.passages as f64 / seed_count;
+    let cycle_mean = summary.cycle_rank as f64 / seed_count;
+    let repair_edge_mean = summary.repair_edges as f64 / seed_count;
+    let repair_orbit_mean = summary.repair_orbits as f64 / seed_count;
+    let dead_end_mean = summary.dead_ends as f64 / seed_count;
+    let junction_mean = summary.junctions as f64 / seed_count;
+    let corner_distance_mean = summary.corner_distance as f64 / seed_count;
+    assert!((315.0..=322.0).contains(&passage_mean));
+    assert!((1.0..=7.0).contains(&cycle_mean));
+    assert!((125.0..=145.0).contains(&repair_edge_mean));
+    assert!((60.0..=75.0).contains(&repair_orbit_mean));
+    assert!((80.0..=105.0).contains(&dead_end_mean));
+    assert!((75.0..=95.0).contains(&junction_mean));
+    assert!((40.0..=65.0).contains(&corner_distance_mean));
+
+    let horizontal_rate = ratio(summary.horizontal_repairs, summary.horizontal_candidates);
+    let vertical_rate = ratio(summary.vertical_repairs, summary.vertical_candidates);
+    assert!((horizontal_rate - vertical_rate).abs() < 0.03);
+
+    let spatial_rates: Vec<_> = summary
+        .spatial_repairs
+        .iter()
+        .zip(summary.spatial_candidates.iter())
+        .filter(|(_, candidates)| **candidates > 0)
+        .map(|(&repairs, &candidates)| ratio(repairs, candidates))
+        .collect();
+    let minimum = spatial_rates.iter().copied().fold(f64::INFINITY, f64::min);
+    let maximum = spatial_rates
+        .iter()
+        .copied()
+        .fold(f64::NEG_INFINITY, f64::max);
+    assert!(maximum - minimum < 0.14);
+
+    let mud_rate = ratio(summary.muddy_repair_orbits, summary.repair_orbits);
+    assert!((0.08..=0.12).contains(&mud_rate));
+}
+
+#[test]
+fn repair_mud_uses_one_configured_probability_trial_per_orbit() {
+    let mut summary = CorpusSummary::default();
+    for seed in 0..256 {
+        summary.add(&generate_sample(MazeConfig {
+            target_density: 1.0,
+            ..classic_config(21, 15, seed)
+        }));
+    }
+    let mud_rate = ratio(summary.muddy_repair_orbits, summary.repair_orbits);
+    assert!(
+        (0.085..=0.115).contains(&mud_rate),
+        "repair-orbit mud rate {mud_rate:.6} should follow p=0.1, not the old p=0.19"
+    );
+}
+
+#[test]
+fn symmetric_border_repair_uses_one_configured_probability_trial_per_orbit() {
+    let mut repair_orbits = 0_u64;
+    let mut muddy_repair_orbits = 0_u64;
+    for seed in 0..256 {
+        let sample = generate_sample(MazeConfig {
+            connected: false,
+            target_density: 1.0,
+            ..classic_config(21, 15, seed)
+        });
+        let repaired: BTreeSet<_> = sample
+            .repair_edges()
+            .map(|edge| sample.repair_orbit_key(edge))
+            .collect();
+        let muddy: BTreeSet<_> = sample
+            .repair_edges()
+            .filter(|edge| sample.mud.contains_key(edge))
+            .map(|edge| sample.repair_orbit_key(edge))
+            .collect();
+        repair_orbits += repaired.len() as u64;
+        muddy_repair_orbits += muddy.len() as u64;
+    }
+
+    let mud_rate = ratio(muddy_repair_orbits, repair_orbits);
+    assert!(
+        (0.085..=0.115).contains(&mud_rate),
+        "border-repair orbit mud rate {mud_rate:.6} should follow p=0.1, not the old p=0.19"
+    );
+}
+
+#[test]
+fn symmetric_even_even_all_walls_has_one_redundant_mirrored_edge() {
+    for seed in 0..32 {
+        let sample = generate_sample(MazeConfig {
+            width: 4,
+            height: 4,
+            target_density: 1.0,
+            connected: true,
+            symmetry: true,
+            mud_density: 0.0,
+            mud_range: 2,
+            seed: Some(seed),
+        });
+        assert_eq!(sample.final_passages.len(), 16, "seed={seed}");
+        assert_eq!(sample.final_passages.len() + 1 - 16, 1, "seed={seed}");
+        assert_eq!(sample.repair_edges().count(), 16, "seed={seed}");
+    }
+}
+
+#[test]
+#[ignore = "child process for PR 9 diagnostics"]
+fn pr9_probe_child() {
+    match std::env::var("PYRAT_PR9_PROFILE").as_deref() {
+        Ok("report") => {
+            for row in report_corpus() {
+                println!("{row}");
+            }
+        },
+        Ok("topology") => {
+            for (name, game) in topology_probe_games() {
+                println!(
+                    "{TOPOLOGY_PREFIX}\t{name}\t{}",
+                    hex_bytes(&full_game_bytes(&game))
+                );
+            }
+        },
+        profile => panic!("unknown PR 9 diagnostic profile: {profile:?}"),
+    }
+}

--- a/engine/rust/src/game/semantic_compatibility.rs
+++ b/engine/rust/src/game/semantic_compatibility.rs
@@ -168,6 +168,32 @@ fn seeded_disconnected_game(seed: u64) -> GameState {
         .expect("seeded disconnected compatibility fixture should be valid")
 }
 
+fn seeded_connected_classic_game(seed: u64) -> GameState {
+    GameBuilder::new(7, 5)
+        .with_random_maze(MazeParams::classic())
+        .with_corner_positions()
+        .with_custom_cheese(vec![coordinate(3, 2)])
+        .build()
+        .create(Some(seed))
+        .expect("seeded connected compatibility fixture should be valid")
+}
+
+fn seeded_symmetric_border_repair_game(seed: u64) -> GameState {
+    GameBuilder::new(3, 3)
+        .with_random_maze(MazeParams {
+            wall_density: 1.0,
+            connected: false,
+            symmetric: true,
+            mud_density: 1.0,
+            mud_range: 4,
+        })
+        .with_corner_positions()
+        .with_custom_cheese(vec![coordinate(1, 1)])
+        .build()
+        .create(Some(seed))
+        .expect("seeded border-repair compatibility fixture should be valid")
+}
+
 #[test]
 fn seeded_disconnected_topology_and_state_hash_are_stable() {
     let game = seeded_disconnected_game(0xA11C_E5E5);
@@ -184,6 +210,39 @@ fn seeded_disconnected_topology_and_state_hash_are_stable() {
         ]
     );
     assert_eq!(game.state_hash(), 0x8177_5E20_C1DE_7EE2);
+}
+
+#[test]
+fn seeded_connected_classic_topology_and_state_hash_are_stable() {
+    let game = seeded_connected_classic_game(0xD15C_01A7);
+    let topology = TopologyFingerprint::from_game(&game);
+
+    assert_eq!(
+        topology.canonical_bytes(),
+        vec![
+            7, 5, 24, 0, 0, 2, 0, 3, 0, 3, 0, 4, 1, 0, 1, 1, 1, 0, 2, 0, 1, 1, 1, 2, 1, 1, 2, 1, 1,
+            3, 2, 3, 1, 4, 2, 4, 2, 2, 2, 3, 2, 2, 3, 2, 2, 3, 2, 4, 3, 0, 3, 1, 3, 2, 4, 2, 3, 3,
+            3, 4, 4, 0, 4, 1, 4, 0, 5, 0, 4, 1, 4, 2, 4, 1, 5, 1, 4, 3, 5, 3, 4, 4, 5, 4, 5, 2, 5,
+            3, 5, 3, 5, 4, 6, 0, 6, 1, 6, 1, 6, 2, 2, 0, 2, 4, 3, 4, 3, 3, 0, 4, 0, 3,
+        ]
+    );
+    assert_eq!(game.state_hash(), 0x4766_48D1_8D5C_2B13);
+}
+
+#[test]
+fn seeded_symmetric_border_repair_topology_and_state_hash_are_stable() {
+    let game = seeded_symmetric_border_repair_game(0xB04D_EA5E);
+    let topology = TopologyFingerprint::from_game(&game);
+
+    assert_eq!(
+        topology.canonical_bytes(),
+        vec![
+            3, 3, 6, 0, 0, 0, 0, 1, 0, 2, 1, 2, 1, 0, 1, 1, 1, 0, 2, 0, 1, 1, 1, 2, 2, 1, 2, 2, 6,
+            0, 0, 0, 1, 0, 2, 0, 1, 0, 2, 2, 0, 1, 1, 1, 3, 1, 1, 2, 1, 3, 1, 2, 2, 2, 2, 2, 0, 2,
+            1, 2,
+        ]
+    );
+    assert_eq!(game.state_hash(), 0xE511_3619_2A54_EA01);
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

Connected maze generation currently spends most of its time repairing the sampled layout. After each repair passage, it rebuilds every connected component and searches again. That cost grows quickly with board size.

The repair choice also depends on `HashSet` iteration order, so the same game seed can produce a different connected maze in another process. Symmetric repair has a second issue: it calls the passage helper once for each mirrored edge, giving one logical repair pair two mud trials. With the classic 10% mud setting, that creates mud on about 19% of repaired pairs.

## Solution

Initial wall and mud sampling stays unchanged. Connectivity repair now builds one private disjoint-set forest, enumerates every closed passage in a stable Right/Up order, folds mirrored passages into canonical rotational orbits, and shuffles that owned orbit list once with the seeded maze RNG.

Each orbit is considered once. If any member crosses two components, the whole orbit opens atomically, every member is unioned, and the orbit receives one shared mud trial. Already-connected layouts return before constructing or shuffling repair candidates. Isolated-border repair uses the same atomic helper, and the repeated component reconstruction and DFS fallback are gone.

### Compatibility

This is an intentional seed-to-topology mapping reset for connected layouts and symmetric disconnected layouts that require isolated-border repair. The old connected mapping was not stable across processes, so it is treated as a population baseline rather than a per-seed oracle.

The initial sampled layout, parent maze-seed draw, player starts, cheese, fixed mazes, open-maze fast path, public APIs, and unaffected disconnected paths remain exact. New connected-classic and symmetric border-repair topology and state-hash fixtures establish the deterministic mapping that later topology work must preserve.

### Distribution

The old medium and huge corpora produced different full-output digests in all eight operating-system processes. The new topology and full-output digests are identical across all eight processes. The fixed corpora retain 256 distinct topologies for 256 medium seeds and 64 for 64 huge seeds.

Mean passage and cycle counts stay nearly flat. Repair mud moves from about 19% to 9.98% on medium and 10.06% on huge, matching the configured probability. Orientation balance improves. The new orbit order modestly increases dead ends and materially lengthens corner-to-corner paths: roughly 14–17% on medium and 21–29% on huge. Permanent broad guardrails pin topology diversity, counts, degrees, paths, orientation, folded spatial balance, and mud incidence without claiming uniform maze sampling.

### Performance

Criterion uses prepared four-operation seed tapes. Times below are the batch point estimates divided by four.

| Path | Before | After | Speedup |
|---|---:|---:|---:|
| Complete classic creation, 21×15 | 1.4292 ms | 53.812 µs | 26.56× |
| Complete classic creation, 41×31 | 20.3233 ms | 227.877 µs | 89.18× |
| Direct classic generation, 21×15 | 1.3455 ms | 41.965 µs | 32.06× |
| Direct classic generation, 41×31 | 22.1408 ms | 177.097 µs | 125.02× |

Disconnected constructor-plus-generation controls improve only 3.3–5.3%, localizing the large change to connected repair.

## Test Plan

- `cargo test -p pyrat-rust --lib --no-default-features` (130 passed, 2 manual diagnostic entrypoints ignored)
- `uv run --directory engine pytest python/tests -q` (224 passed)
- `cargo fmt --all -- --check`
- `cargo clippy -p pyrat-rust --all-targets --no-default-features -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings -A non-local-definitions`
- `make bench-smoke`
- Eight-process release distribution report for medium and huge corpora
- Same-host Criterion comparison for connected classic/walls-only paths and disconnected/mud-only controls
- Three independent correctness, compatibility, and distribution reviews; all findings addressed and re-reviewed
