### PR TITLE
perf(engine): compile generated topology directly

### DIFF
--- a/engine/rust/src/game/board.rs
+++ b/engine/rust/src/game/board.rs
@@ -55,6 +55,30 @@ impl MoveTable {
         Self { valid_moves, width }
     }
 
+    /// Pack one four-direction movement mask per cell into the runtime table.
+    #[must_use]
+    pub(crate) fn from_cell_masks(width: u8, height: u8, masks: &[u8]) -> Self {
+        let cell_count = usize::from(width) * usize::from(height);
+        assert_eq!(
+            masks.len(),
+            cell_count,
+            "movement mask count must match board dimensions"
+        );
+        debug_assert!(
+            masks.iter().all(|mask| mask & !0x0f == 0),
+            "cell movement masks must use only the low four bits"
+        );
+
+        let mut valid_moves = Vec::with_capacity(cell_count.div_ceil(2));
+        for pair in masks.chunks(2) {
+            let low = pair[0];
+            let high = pair.get(1).copied().unwrap_or(0);
+            valid_moves.push(low | (high << 4));
+        }
+
+        Self { valid_moves, width }
+    }
+
     /// Build the packed movement masks for a board with no internal walls.
     #[must_use]
     pub(crate) fn open(width: u8, height: u8) -> Self {

--- a/engine/rust/src/game/builder.rs
+++ b/engine/rust/src/game/builder.rs
@@ -24,6 +24,7 @@
 
 use crate::game::maze_generation::{CheeseConfig, CheeseGenerator, MazeConfig, MazeGenerator};
 use crate::game::types::MudMap;
+use crate::game::zobrist;
 use crate::{Coordinates, GameState, MoveTable};
 use rand::{Rng, RngExt, SeedableRng};
 use std::collections::HashMap;
@@ -428,19 +429,24 @@ impl GameConfig {
             seed.map_or_else(rand::make_rng, SeedableRng::seed_from_u64);
 
         // 1. Maze topology
-        let (move_table, mud) = match &self.maze {
+        let (move_table, mud, topology_hash) = match &self.maze {
             MazeStrategy::Fixed { walls, mud } => {
                 let walls = walls.clone();
-                (
-                    MoveTable::new(self.width(), self.height(), &walls),
-                    mud.clone(),
-                )
+                let move_table = MoveTable::new(self.width(), self.height(), &walls);
+                let mud = mud.clone();
+                let topology_hash =
+                    zobrist::maze_hash(&move_table, &mud, self.width(), self.height());
+                (move_table, mud, topology_hash)
             },
             MazeStrategy::Random(params) => {
                 // Preserve the parent RNG stream even when the topology is predetermined.
                 let maze_seed = rng.random();
                 if params.wall_density == 0.0 && params.mud_density == 0.0 {
-                    (MoveTable::open(self.width(), self.height()), MudMap::new())
+                    let move_table = MoveTable::open(self.width(), self.height());
+                    let mud = MudMap::new();
+                    let topology_hash =
+                        zobrist::maze_hash(&move_table, &mud, self.width(), self.height());
+                    (move_table, mud, topology_hash)
                 } else {
                     let maze_config = MazeConfig {
                         width: self.width(),
@@ -452,8 +458,7 @@ impl GameConfig {
                         mud_range: params.mud_range,
                         seed: Some(maze_seed),
                     };
-                    let (walls, mud) = MazeGenerator::new(maze_config).generate_owned();
-                    (MoveTable::new(self.width(), self.height(), &walls), mud)
+                    MazeGenerator::new(maze_config).generate_runtime_topology()
                 }
             },
         };
@@ -494,6 +499,7 @@ impl GameConfig {
             self.height(),
             move_table,
             mud,
+            topology_hash,
             &cheese_positions,
             p1,
             p2,

--- a/engine/rust/src/game/game_logic.rs
+++ b/engine/rust/src/game/game_logic.rs
@@ -101,6 +101,7 @@ impl GameState {
         height: u8,
         move_table: MoveTable,
         mud: MudMap,
+        topology_hash: u64,
         cheese_positions: &[Coordinates],
         player1_pos: Coordinates,
         player2_pos: Coordinates,
@@ -139,8 +140,7 @@ impl GameState {
         }
 
         // Compute initial Zobrist hash: maze topology (static) XOR dynamic state
-        game.state_hash = zobrist::maze_hash(&game.move_table, &game.mud, width, height)
-            ^ zobrist::compute_from_scratch(&game);
+        game.state_hash = topology_hash ^ zobrist::compute_from_scratch(&game);
 
         game
     }

--- a/engine/rust/src/game/maze_generation.rs
+++ b/engine/rust/src/game/maze_generation.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::uninlined_format_args)]
 
-use crate::{Coordinates, Direction};
+use crate::game::zobrist;
+use crate::{Coordinates, Direction, MoveTable};
 use rand::prelude::{IndexedRandom, SliceRandom};
 use rand::RngExt;
 use std::collections::{HashMap, HashSet};
@@ -83,6 +84,10 @@ impl ConnectionGrid {
     #[inline]
     const fn in_bounds(&self, pos: Coordinates) -> bool {
         pos.x < self.width && pos.y < self.height
+    }
+
+    fn compile_move_table(&self) -> MoveTable {
+        MoveTable::from_cell_masks(self.width, self.height, &self.masks)
     }
 }
 
@@ -251,17 +256,33 @@ impl MazeGenerator {
 
     /// Generates a complete maze with walls and mud
     pub fn generate(&mut self) -> (WallMap, MudMap) {
-        let walls = self.generate_in_place();
+        self.generate_in_place();
+        let walls = self.connections_to_walls();
         (walls, self.mud.clone())
     }
 
     /// Generates a complete maze when the caller owns this generator.
+    #[cfg(test)]
     pub(crate) fn generate_owned(mut self) -> (WallMap, MudMap) {
-        let walls = self.generate_in_place();
+        self.generate_in_place();
+        let walls = self.connections_to_walls();
         (walls, self.mud)
     }
 
-    fn generate_in_place(&mut self) -> WallMap {
+    /// Generates and compiles the runtime topology without projecting a wall map.
+    pub(crate) fn generate_runtime_topology(mut self) -> (MoveTable, MudMap, u64) {
+        self.generate_in_place();
+        let move_table = self.connections.compile_move_table();
+        let topology_hash = zobrist::maze_hash(
+            &move_table,
+            &self.mud,
+            self.config.width,
+            self.config.height,
+        );
+        (move_table, self.mud, topology_hash)
+    }
+
+    fn generate_in_place(&mut self) {
         self.generate_initial_layout();
 
         if self.config.connected {
@@ -274,9 +295,6 @@ impl MazeGenerator {
         if let Err(e) = self.validate_output() {
             panic!("Maze generation failed validation: {e}");
         }
-
-        // Convert connections to walls (blocked passages)
-        self.connections_to_walls()
     }
 
     /// Generates the initial random layout of the maze
@@ -753,6 +771,7 @@ impl CheeseGenerator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::GameState;
 
     fn legacy_generate_cheese(
         config: &CheeseConfig,
@@ -1063,6 +1082,134 @@ mod tests {
         assert!(!grid.contains(corner, Coordinates::new(1, 1)));
         assert!(!grid.contains(corner, Coordinates::new(3, 0)));
         assert!(!grid.has_any(Coordinates::new(3, 0)));
+    }
+
+    #[test]
+    fn direct_runtime_topology_matches_wall_projection_and_action_traces() {
+        let cases = [
+            (3, 3, 0.0, true, true, 0.0, 2),
+            (4, 3, 0.35, true, false, 0.65, 4),
+            (7, 5, 0.7, true, true, 0.1, 5),
+            (8, 6, 1.0, false, true, 1.0, 4),
+        ];
+        let actions = [
+            (Direction::Right, Direction::Left),
+            (Direction::Up, Direction::Down),
+            (Direction::Up, Direction::Left),
+            (Direction::Left, Direction::Up),
+            (Direction::Down, Direction::Right),
+            (Direction::Right, Direction::Down),
+            (Direction::Stay, Direction::Stay),
+            (Direction::Down, Direction::Left),
+        ];
+
+        for (width, height, target_density, connected, symmetry, mud_density, mud_range) in cases {
+            for seed in [0, 1, 0xD15C_01A7, u64::MAX] {
+                let config = MazeConfig {
+                    width,
+                    height,
+                    target_density,
+                    connected,
+                    symmetry,
+                    mud_density,
+                    mud_range,
+                    seed: Some(seed),
+                };
+
+                let (walls, projected_mud) = MazeGenerator::new(config).generate_owned();
+                let projected_moves = MoveTable::new(width, height, &walls);
+                let projected_hash =
+                    zobrist::maze_hash(&projected_moves, &projected_mud, width, height);
+
+                let (direct_moves, direct_mud, direct_hash) =
+                    MazeGenerator::new(config).generate_runtime_topology();
+
+                assert_eq!(
+                    direct_moves.bytes(),
+                    projected_moves.bytes(),
+                    "packed movement masks changed for {config:?}"
+                );
+                assert_eq!(
+                    sorted_mud_entries(&direct_mud),
+                    sorted_mud_entries(&projected_mud),
+                    "mud projection changed for {config:?}"
+                );
+                assert_eq!(
+                    direct_hash, projected_hash,
+                    "static topology hash changed for {config:?}"
+                );
+
+                let cheese = [Coordinates::new(width / 2, height / 2)];
+                let player1 = Coordinates::new(0, 0);
+                let player2 = Coordinates::new(width - 1, height - 1);
+                let mut projected_game = GameState::new_with_config(
+                    width,
+                    height,
+                    projected_moves,
+                    projected_mud,
+                    projected_hash,
+                    &cheese,
+                    player1,
+                    player2,
+                    64,
+                );
+                let mut direct_game = GameState::new_with_config(
+                    width,
+                    height,
+                    direct_moves,
+                    direct_mud,
+                    direct_hash,
+                    &cheese,
+                    player1,
+                    player2,
+                    64,
+                );
+
+                assert_eq!(
+                    direct_game.wall_entries(),
+                    projected_game.wall_entries(),
+                    "public wall projection changed for {config:?}"
+                );
+                assert_eq!(
+                    direct_game.state_hash(),
+                    projected_game.state_hash(),
+                    "initial dynamic hash changed for {config:?}"
+                );
+
+                for (turn, &(player1_action, player2_action)) in
+                    actions.iter().cycle().take(32).enumerate()
+                {
+                    let projected_result =
+                        projected_game.process_turn(player1_action, player2_action);
+                    let direct_result = direct_game.process_turn(player1_action, player2_action);
+
+                    assert_eq!(
+                        (
+                            direct_result.p1_moved,
+                            direct_result.p2_moved,
+                            direct_result.game_over,
+                            direct_result.p1_score,
+                            direct_result.p2_score,
+                            direct_result.collected_cheese,
+                        ),
+                        (
+                            projected_result.p1_moved,
+                            projected_result.p2_moved,
+                            projected_result.game_over,
+                            projected_result.p1_score,
+                            projected_result.p2_score,
+                            projected_result.collected_cheese,
+                        ),
+                        "action result changed on turn {turn} for {config:?}"
+                    );
+                    assert_eq!(
+                        direct_game.state_hash(),
+                        projected_game.state_hash(),
+                        "dynamic hash changed on turn {turn} for {config:?}"
+                    );
+                }
+            }
+        }
     }
 
     const DISCONNECTED_LEGACY_CASES: [(u8, u8, f32, bool, f32, u8); 6] = [


### PR DESCRIPTION
## Motivation

Random maze generation already finishes with a dense movement relation, but game creation was
converting that relation into a hash-backed wall map and immediately scanning the map back into the
packed runtime move table. After connectivity repair became fast, this round trip was a material
share of creation time.

## Solution

Generated mazes now compile straight into the existing runtime representation:

```text
Before: ConnectionGrid -> WallMap -> MoveTable -> topology hash
Now:    ConnectionGrid -----------> MoveTable -> topology hash
```

The move table keeps its established two-cells-per-byte format. Generated mud moves into the game
unchanged, and the static topology hash is computed once before game assembly. Fixed mazes still
compile their supplied wall maps, while the zero-wall/zero-mud fast path remains unchanged.

The direct path is compared with the retained wall-map projection across connected and disconnected
mazes, symmetry on and off, odd and even cell counts, and zero, fractional, and full wall and mud
densities. The comparison covers packed movement masks, public wall projections, mud entries,
static hashes, 32-turn action results, and every resulting state hash. The current deterministic
seed-to-topology mapping stays exact.

Same-host Criterion results for complete random creation:

| Scenario | Before | After | Time reduction |
|---|---:|---:|---:|
| Classic, medium 21x15 | 55.250 us | 33.273 us | 39.61% |
| Classic, huge 41x31 | 240.013 us | 135.950 us | 43.86% |
| Walls-only, medium 21x15 | 51.690 us | 29.753 us | 42.57% |
| Walls-only, huge 41x31 | 223.143 us | 120.968 us | 45.35% |

## Test Plan

- `cargo test -p pyrat-rust --lib --no-default-features` (131 passed, 2 existing diagnostics ignored)
- `cargo clippy -p pyrat-rust --all-targets --no-default-features -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings -A non-local-definitions`
- `cargo fmt --all -- --check`
- `uv run --directory engine pytest python/tests -q` (224 passed)
- `make bench-smoke`
- `git diff --check`
